### PR TITLE
Add ability to delete recorded places with confirmation

### DIFF
--- a/PlaceNotes/Views/FrequentPlacesMapView.swift
+++ b/PlaceNotes/Views/FrequentPlacesMapView.swift
@@ -44,8 +44,11 @@ struct FrequentPlacesMapView: View {
                 .padding(.bottom, 24)
             }
             .sheet(item: $selectedPlace) { place in
-                PlaceDetailSheet(place: place)
-                    .presentationDetents([.medium])
+                PlaceDetailSheet(place: place) {
+                    selectedPlace = nil
+                    viewModel.refresh(places: places)
+                }
+                .presentationDetents([.medium])
             }
             .navigationTitle("Map")
             .navigationBarTitleDisplayMode(.inline)
@@ -86,7 +89,12 @@ struct PlaceAnnotationView: View {
 }
 
 struct PlaceDetailSheet: View {
+    @Environment(\.modelContext) private var modelContext
+    @Environment(\.dismiss) private var dismiss
     let place: Place
+    var onDelete: (() -> Void)?
+
+    @State private var showDeleteConfirmation = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -109,7 +117,30 @@ struct PlaceDetailSheet: View {
             }
 
             Spacer()
+
+            Button(role: .destructive) {
+                showDeleteConfirmation = true
+            } label: {
+                Label("Delete Place", systemImage: "trash")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.large)
         }
         .padding()
+        .alert("Delete Place?", isPresented: $showDeleteConfirmation) {
+            Button("Delete", role: .destructive) {
+                for visit in place.visits {
+                    modelContext.delete(visit)
+                }
+                modelContext.delete(place)
+                try? modelContext.save()
+                onDelete?()
+                dismiss()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Delete \"\(place.name)\" and all \(place.visits.count) recorded visits? This cannot be undone.")
+        }
     }
 }

--- a/PlaceNotes/Views/FrequentPlacesView.swift
+++ b/PlaceNotes/Views/FrequentPlacesView.swift
@@ -2,9 +2,12 @@ import SwiftUI
 import SwiftData
 
 struct FrequentPlacesView: View {
+    @Environment(\.modelContext) private var modelContext
     @Query private var places: [Place]
     @StateObject private var viewModel = PlacesViewModel()
     @State private var selectedTab: PlacesPeriod = .weekly
+    @State private var placeToDelete: Place?
+    @State private var showDeleteConfirmation = false
 
     var body: some View {
         NavigationStack {
@@ -28,8 +31,18 @@ struct FrequentPlacesView: View {
                     )
                     Spacer()
                 } else {
-                    List(rankings) { ranking in
-                        PlaceRankingRow(ranking: ranking)
+                    List {
+                        ForEach(rankings) { ranking in
+                            PlaceRankingRow(ranking: ranking)
+                                .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                                    Button(role: .destructive) {
+                                        placeToDelete = ranking.place
+                                        showDeleteConfirmation = true
+                                    } label: {
+                                        Label("Delete", systemImage: "trash")
+                                    }
+                                }
+                        }
                     }
                     .listStyle(.insetGrouped)
                 }
@@ -37,7 +50,31 @@ struct FrequentPlacesView: View {
             .navigationTitle("Frequent Places")
             .onAppear { viewModel.refresh(places: places) }
             .onChange(of: selectedTab) { _, _ in viewModel.refresh(places: places) }
+            .alert("Delete Place?", isPresented: $showDeleteConfirmation) {
+                Button("Delete", role: .destructive) {
+                    if let place = placeToDelete {
+                        deletePlace(place)
+                    }
+                }
+                Button("Cancel", role: .cancel) {
+                    placeToDelete = nil
+                }
+            } message: {
+                if let place = placeToDelete {
+                    Text("Delete \"\(place.name)\" and all \(place.visits.count) recorded visits? This cannot be undone.")
+                }
+            }
         }
+    }
+
+    private func deletePlace(_ place: Place) {
+        for visit in place.visits {
+            modelContext.delete(visit)
+        }
+        modelContext.delete(place)
+        try? modelContext.save()
+        placeToDelete = nil
+        viewModel.refresh(places: places)
     }
 }
 


### PR DESCRIPTION
- Places list: swipe left on any place to reveal a Delete button
- Map detail sheet: adds a "Delete Place" button at the bottom
- Both show a confirmation dialog with the place name and visit count before deleting
- Deleting a place removes it and all associated visits from the database permanently