### PR TITLE
Add visible Edit/Delete button to places list

### DIFF
--- a/PlaceNotes/Views/FrequentPlacesView.swift
+++ b/PlaceNotes/Views/FrequentPlacesView.swift
@@ -8,6 +8,7 @@ struct FrequentPlacesView: View {
     @State private var selectedTab: PlacesPeriod = .weekly
     @State private var placeToDelete: Place?
     @State private var showDeleteConfirmation = false
+    @State private var isEditing = false
 
     var body: some View {
         NavigationStack {
@@ -33,21 +34,47 @@ struct FrequentPlacesView: View {
                 } else {
                     List {
                         ForEach(rankings) { ranking in
-                            PlaceRankingRow(ranking: ranking)
-                                .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-                                    Button(role: .destructive) {
+                            HStack(spacing: 12) {
+                                // Visible delete button in edit mode
+                                if isEditing {
+                                    Button {
                                         placeToDelete = ranking.place
                                         showDeleteConfirmation = true
                                     } label: {
-                                        Label("Delete", systemImage: "trash")
+                                        Image(systemName: "minus.circle.fill")
+                                            .font(.title3)
+                                            .foregroundStyle(.red)
                                     }
+                                    .buttonStyle(.plain)
                                 }
+
+                                PlaceRankingRow(ranking: ranking)
+                            }
+                            .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                                Button(role: .destructive) {
+                                    placeToDelete = ranking.place
+                                    showDeleteConfirmation = true
+                                } label: {
+                                    Label("Delete", systemImage: "trash")
+                                }
+                            }
                         }
                     }
                     .listStyle(.insetGrouped)
+                    .animation(.default, value: isEditing)
                 }
             }
             .navigationTitle("Frequent Places")
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    let rankings = selectedTab == .weekly ? viewModel.weeklyPlaces : viewModel.monthlyPlaces
+                    if !rankings.isEmpty {
+                        Button(isEditing ? "Done" : "Edit") {
+                            isEditing.toggle()
+                        }
+                    }
+                }
+            }
             .onAppear { viewModel.refresh(places: places) }
             .onChange(of: selectedTab) { _, _ in viewModel.refresh(places: places) }
             .alert("Delete Place?", isPresented: $showDeleteConfirmation) {


### PR DESCRIPTION
## Summary
- Adds an **Edit** button in the top-right toolbar of the Places tab that toggles edit mode
- In edit mode, red ⊖ delete buttons appear on each place row — tapping shows a confirmation dialog
- Swipe-to-delete is also preserved for quick access
- Three ways to delete: Edit mode button, swipe left, or map detail sheet

## Test plan
- [x] Open Places tab with recorded places
- [x] Tap "Edit" — verify red minus buttons appear on each row
- [x] Tap a minus button — verify confirmation dialog shows place name and visit count
- [x] Confirm delete — verify place is removed from the list
- [x] Tap "Done" — verify edit mode exits and minus buttons disappear
- [x] Swipe left on a row — verify "Delete" still works
- [x] Verify "Edit" button is hidden when the list is empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)