### PR TITLE
Reset swiped-open rows when exiting edit mode

### DIFF
--- a/PlaceNotes/Views/FrequentPlacesView.swift
+++ b/PlaceNotes/Views/FrequentPlacesView.swift
@@ -61,6 +61,7 @@ struct FrequentPlacesView: View {
                         }
                     }
                     .listStyle(.insetGrouped)
+                    .id(isEditing)
                     .animation(.default, value: isEditing)
                 }
             }


### PR DESCRIPTION
## Summary
- Adds `.id(isEditing)` to the List in FrequentPlacesView so that toggling edit mode forces SwiftUI to recreate rows, dismissing any open swipe actions
- Previously, swiping left to reveal the Delete button would stay open even after tapping "Done"

## Test plan
- [x] Open Places tab with recorded places
- [x] Swipe left on one or more rows to reveal the Delete button
- [x] Tap "Edit" then "Done" — verify swiped rows are reset
- [x] Verify swipe-to-delete still works normally after toggling edit mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)