### PR TITLE
Redesign map with emoji annotations and clustering

### DIFF
--- a/PlaceNotes/Services/PlaceCategorizer.swift
+++ b/PlaceNotes/Services/PlaceCategorizer.swift
@@ -92,4 +92,39 @@ final class PlaceCategorizer {
         guard let label = categoryLabel else { return "mappin.circle.fill" }
         return categoryMap.first(where: { $0.label == label })?.icon ?? "mappin.circle.fill"
     }
+
+    /// Emoji mapping for categories — used for map annotations.
+    private static let emojiMap: [String: String] = [
+        "Restaurant": "\u{1F374}",    // fork and knife
+        "Cafe": "\u{2615}",           // hot beverage
+        "Bakery": "\u{1F370}",        // shortcake
+        "Brewery": "\u{1F37A}",       // beer mug
+        "Grocery": "\u{1F6D2}",       // shopping cart
+        "Gym": "\u{1F4AA}",           // flexed biceps
+        "Hospital": "\u{1F3E5}",      // hospital
+        "Pharmacy": "\u{1F48A}",      // pill
+        "School": "\u{1F393}",        // graduation cap
+        "University": "\u{1F3DB}",    // classical building
+        "Library": "\u{1F4DA}",       // books
+        "Store": "\u{1F6CD}",         // shopping bags
+        "Gas Station": "\u{26FD}",    // fuel pump
+        "Parking": "\u{1F17F}",       // P button
+        "Park": "\u{1F333}",          // deciduous tree
+        "Beach": "\u{1F3D6}",         // beach with umbrella
+        "Theater": "\u{1F3AD}",       // performing arts
+        "Museum": "\u{1F3DB}",        // classical building
+        "Nightlife": "\u{1F3B6}",     // musical notes
+        "Hotel": "\u{1F3E8}",         // hotel
+        "Airport": "\u{2708}",        // airplane
+        "Transit": "\u{1F68C}",       // bus
+        "Bank": "\u{1F3E6}",          // bank
+        "Post Office": "\u{1F4EE}",   // postbox
+        "Laundry": "\u{1F9FA}",       // basket
+    ]
+
+    /// Returns an emoji for a category label.
+    static func emoji(for categoryLabel: String?) -> String {
+        guard let label = categoryLabel else { return "\u{1F4CD}" } // round pushpin
+        return emojiMap[label] ?? "\u{1F4CD}"
+    }
 }

--- a/PlaceNotes/Views/FrequentPlacesMapView.swift
+++ b/PlaceNotes/Views/FrequentPlacesMapView.swift
@@ -8,25 +8,34 @@ struct FrequentPlacesMapView: View {
     @EnvironmentObject private var locationManager: LocationManager
     @State private var selectedPlace: Place?
     @State private var cameraPosition: MapCameraPosition = .automatic
+    @State private var visibleRegion: MKCoordinateRegion?
 
     var body: some View {
         NavigationStack {
             ZStack(alignment: .bottomTrailing) {
                 Map(position: $cameraPosition, selection: $selectedPlace) {
-                    // User's current location
                     UserAnnotation()
 
-                    ForEach(viewModel.monthlyPlaces.prefix(20)) { ranking in
-                        Annotation(ranking.place.name, coordinate: ranking.place.coordinate) {
-                            PlaceAnnotationView(ranking: ranking)
+                    ForEach(clusteredAnnotations, id: \.id) { item in
+                        if let cluster = item as? ClusterItem {
+                            Annotation("", coordinate: cluster.coordinate) {
+                                ClusterAnnotationView(cluster: cluster)
+                            }
+                        } else if let single = item as? SingleItem {
+                            Annotation(single.ranking.place.name, coordinate: single.coordinate) {
+                                PlaceAnnotationView(ranking: single.ranking)
+                            }
+                            .tag(single.ranking.place)
                         }
-                        .tag(ranking.place)
                     }
                 }
                 .mapStyle(.standard(showsTraffic: false))
                 .mapControls {
                     MapCompass()
                     MapScaleView()
+                }
+                .onMapCameraChange(frequency: .onEnd) { context in
+                    visibleRegion = context.region
                 }
 
                 // Current location button
@@ -56,6 +65,55 @@ struct FrequentPlacesMapView: View {
         }
     }
 
+    // MARK: - Clustering
+
+    private var clusteredAnnotations: [any MapAnnotationItem] {
+        let rankings = Array(viewModel.monthlyPlaces.prefix(50))
+        guard let region = visibleRegion else {
+            // No region yet — show all as singles
+            return rankings.map { SingleItem(ranking: $0) }
+        }
+
+        let clusterRadius = region.span.latitudeDelta * 0.08
+        return clusterItems(from: rankings, radius: clusterRadius)
+    }
+
+    private func clusterItems(from rankings: [PlaceRanking], radius: Double) -> [any MapAnnotationItem] {
+        var used = Set<UUID>()
+        var result: [any MapAnnotationItem] = []
+
+        for ranking in rankings {
+            guard !used.contains(ranking.id) else { continue }
+
+            // Find nearby rankings within cluster radius
+            var group = [ranking]
+            used.insert(ranking.id)
+
+            for other in rankings {
+                guard !used.contains(other.id) else { continue }
+                let latDiff = abs(ranking.place.latitude - other.place.latitude)
+                let lonDiff = abs(ranking.place.longitude - other.place.longitude)
+                if latDiff < radius && lonDiff < radius {
+                    group.append(other)
+                    used.insert(other.id)
+                }
+            }
+
+            if group.count == 1 {
+                result.append(SingleItem(ranking: ranking))
+            } else {
+                let avgLat = group.reduce(0.0) { $0 + $1.place.latitude } / Double(group.count)
+                let avgLon = group.reduce(0.0) { $0 + $1.place.longitude } / Double(group.count)
+                result.append(ClusterItem(
+                    coordinate: CLLocationCoordinate2D(latitude: avgLat, longitude: avgLon),
+                    rankings: group
+                ))
+            }
+        }
+
+        return result
+    }
+
     private func goToCurrentLocation() {
         if let coordinate = locationManager.userLocation {
             withAnimation {
@@ -69,24 +127,89 @@ struct FrequentPlacesMapView: View {
     }
 }
 
+// MARK: - Annotation Data Models
+
+protocol MapAnnotationItem: Identifiable {
+    var id: UUID { get }
+    var coordinate: CLLocationCoordinate2D { get }
+}
+
+struct SingleItem: MapAnnotationItem {
+    let id = UUID()
+    let ranking: PlaceRanking
+    var coordinate: CLLocationCoordinate2D { ranking.place.coordinate }
+}
+
+struct ClusterItem: MapAnnotationItem {
+    let id = UUID()
+    let coordinate: CLLocationCoordinate2D
+    let rankings: [PlaceRanking]
+
+    var totalVisits: Int {
+        rankings.reduce(0) { $0 + $1.qualifiedStays }
+    }
+
+    var topEmojis: String {
+        let emojis = rankings
+            .prefix(3)
+            .map { PlaceCategorizer.emoji(for: $0.place.category) }
+        return emojis.joined()
+    }
+}
+
+// MARK: - Annotation Views
+
 struct PlaceAnnotationView: View {
     let ranking: PlaceRanking
 
     var body: some View {
         VStack(spacing: 2) {
-            Image(systemName: PlaceCategorizer.icon(for: ranking.place.category))
+            Text(PlaceCategorizer.emoji(for: ranking.place.category))
                 .font(.title)
-                .foregroundStyle(.red)
+                .frame(width: 44, height: 44)
+                .background(.white)
+                .clipShape(Circle())
+                .shadow(color: .black.opacity(0.15), radius: 3, y: 1)
 
             Text("\(ranking.qualifiedStays)")
                 .font(.caption2.bold())
+                .foregroundStyle(.white)
                 .padding(.horizontal, 6)
                 .padding(.vertical, 2)
-                .background(.ultraThinMaterial)
+                .background(Color.accentColor)
                 .clipShape(Capsule())
         }
     }
 }
+
+struct ClusterAnnotationView: View {
+    let cluster: ClusterItem
+
+    var body: some View {
+        VStack(spacing: 2) {
+            Text(cluster.topEmojis)
+                .font(.callout)
+                .frame(width: 52, height: 52)
+                .background(.white)
+                .clipShape(Circle())
+                .overlay(
+                    Circle()
+                        .strokeBorder(Color.accentColor.opacity(0.3), lineWidth: 2)
+                )
+                .shadow(color: .black.opacity(0.15), radius: 3, y: 1)
+
+            Text("\(cluster.rankings.count) places")
+                .font(.caption2.bold())
+                .foregroundStyle(.white)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(Color.accentColor)
+                .clipShape(Capsule())
+        }
+    }
+}
+
+// MARK: - Place Detail Sheet
 
 struct PlaceDetailSheet: View {
     @Environment(\.modelContext) private var modelContext
@@ -98,13 +221,20 @@ struct PlaceDetailSheet: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
-            Text(place.name)
-                .font(.title2.bold())
+            HStack(spacing: 12) {
+                Text(PlaceCategorizer.emoji(for: place.category))
+                    .font(.largeTitle)
 
-            if let category = place.category {
-                Label(category, systemImage: PlaceCategorizer.icon(for: category))
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(place.name)
+                        .font(.title2.bold())
+
+                    if let category = place.category {
+                        Text(category)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                }
             }
 
             Divider()


### PR DESCRIPTION
## Summary
- Replace red SF Symbol map pins with **category emoji in white circle bubbles** (e.g. 🍴 Restaurant, 💪 Gym, ☕ Cafe, 🌳 Park)
- Visit count badge uses accent color instead of gray
- **Auto-clustering**: nearby places group together when zoomed out, showing top 3 emojis and "N places" count. Clusters break apart as you zoom in.
- Cluster radius scales dynamically with the visible map span
- Detail sheet header now shows emoji + name

## Test plan
- [x] Open Map tab — verify emoji bubbles appear instead of red icons
- [x] Check various categories show correct emoji (restaurant = 🍴, gym = 💪, etc.)
- [x] Zoom out — verify nearby places cluster into a single bubble with multiple emojis
- [x] Zoom in — verify clusters break apart into individual places
- [x] Tap a place annotation — verify detail sheet shows emoji + name
- [x] Verify uncategorized places show 📍 pushpin emoji

🤖 Generated with [Claude Code](https://claude.com/claude-code)