### PR TITLE
Add place rename/nickname and disable CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,12 @@
 name: CI
 
-on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+# Disabled for now — re-enable by uncommenting the triggers below
+# on:
+#   push:
+#     branches: [main]
+#   pull_request:
+#     branches: [main]
+on: workflow_dispatch  # manual trigger only
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/PlaceNotes/Models/Place.swift
+++ b/PlaceNotes/Models/Place.swift
@@ -6,9 +6,18 @@ import CoreLocation
 final class Place {
     var id: UUID
     var name: String
+    var nickname: String?
     var latitude: Double
     var longitude: Double
     var category: String?
+
+    /// Returns nickname if set, otherwise the auto-detected name.
+    var displayName: String {
+        if let nickname, !nickname.isEmpty {
+            return nickname
+        }
+        return name
+    }
 
     @Relationship(deleteRule: .cascade, inverse: \Visit.place)
     var visits: [Visit]
@@ -33,9 +42,10 @@ final class Place {
         qualifiedStays(minMinutes: minMinutes).reduce(0) { $0 + $1.durationMinutes }
     }
 
-    init(name: String, latitude: Double, longitude: Double, category: String? = nil) {
+    init(name: String, latitude: Double, longitude: Double, category: String? = nil, nickname: String? = nil) {
         self.id = UUID()
         self.name = name
+        self.nickname = nickname
         self.latitude = latitude
         self.longitude = longitude
         self.category = category

--- a/PlaceNotes/Views/FrequentPlacesMapView.swift
+++ b/PlaceNotes/Views/FrequentPlacesMapView.swift
@@ -23,7 +23,7 @@ struct FrequentPlacesMapView: View {
                                 ClusterAnnotationView(cluster: cluster)
                             }
                         } else if let single = item as? SingleItem {
-                            Annotation(single.ranking.place.name, coordinate: single.coordinate) {
+                            Annotation(single.ranking.place.displayName, coordinate: single.coordinate) {
                                 PlaceAnnotationView(ranking: single.ranking)
                             }
                             .tag(single.ranking.place)
@@ -231,6 +231,8 @@ struct PlaceDetailSheet: View {
     var onDelete: (() -> Void)?
 
     @State private var showDeleteConfirmation = false
+    @State private var showRenameDialog = false
+    @State private var renameText = ""
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -239,8 +241,14 @@ struct PlaceDetailSheet: View {
                     .font(.largeTitle)
 
                 VStack(alignment: .leading, spacing: 4) {
-                    Text(place.name)
+                    Text(place.displayName)
                         .font(.title2.bold())
+
+                    if place.nickname != nil {
+                        Text(place.name)
+                            .font(.caption)
+                            .foregroundStyle(.tertiary)
+                    }
 
                     if let category = place.category {
                         Text(category)
@@ -261,16 +269,45 @@ struct PlaceDetailSheet: View {
 
             Spacer()
 
-            Button(role: .destructive) {
-                showDeleteConfirmation = true
-            } label: {
-                Label("Delete Place", systemImage: "trash")
-                    .frame(maxWidth: .infinity)
+            HStack(spacing: 12) {
+                Button {
+                    renameText = place.displayName
+                    showRenameDialog = true
+                } label: {
+                    Label("Rename", systemImage: "pencil")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.large)
+
+                Button(role: .destructive) {
+                    showDeleteConfirmation = true
+                } label: {
+                    Label("Delete", systemImage: "trash")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.large)
             }
-            .buttonStyle(.bordered)
-            .controlSize(.large)
         }
         .padding()
+        .alert("Rename Place", isPresented: $showRenameDialog) {
+            TextField("Name", text: $renameText)
+            Button("Save") {
+                let trimmed = renameText.trimmingCharacters(in: .whitespaces)
+                if !trimmed.isEmpty {
+                    place.nickname = trimmed
+                    try? modelContext.save()
+                }
+            }
+            Button("Reset to Original", role: .destructive) {
+                place.nickname = nil
+                try? modelContext.save()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Original name: \(place.name)")
+        }
         .alert("Delete Place?", isPresented: $showDeleteConfirmation) {
             Button("Delete", role: .destructive) {
                 for visit in place.visits {
@@ -283,7 +320,7 @@ struct PlaceDetailSheet: View {
             }
             Button("Cancel", role: .cancel) {}
         } message: {
-            Text("Delete \"\(place.name)\" and all \(place.visits.count) recorded visits? This cannot be undone.")
+            Text("Delete \"\(place.displayName)\" and all \(place.visits.count) recorded visits? This cannot be undone.")
         }
     }
 }

--- a/PlaceNotes/Views/FrequentPlacesView.swift
+++ b/PlaceNotes/Views/FrequentPlacesView.swift
@@ -9,6 +9,9 @@ struct FrequentPlacesView: View {
     @State private var placeToDelete: Place?
     @State private var showDeleteConfirmation = false
     @State private var isEditing = false
+    @State private var placeToRename: Place?
+    @State private var showRenameDialog = false
+    @State private var renameText = ""
 
     var body: some View {
         NavigationStack {
@@ -57,6 +60,15 @@ struct FrequentPlacesView: View {
                                 } label: {
                                     Label("Delete", systemImage: "trash")
                                 }
+
+                                Button {
+                                    placeToRename = ranking.place
+                                    renameText = ranking.place.displayName
+                                    showRenameDialog = true
+                                } label: {
+                                    Label("Rename", systemImage: "pencil")
+                                }
+                                .tint(.orange)
                             }
                         }
                     }
@@ -78,6 +90,32 @@ struct FrequentPlacesView: View {
             }
             .onAppear { viewModel.refresh(places: places) }
             .onChange(of: selectedTab) { _, _ in viewModel.refresh(places: places) }
+            .alert("Rename Place", isPresented: $showRenameDialog) {
+                TextField("Name", text: $renameText)
+                Button("Save") {
+                    if let place = placeToRename, !renameText.trimmingCharacters(in: .whitespaces).isEmpty {
+                        place.nickname = renameText.trimmingCharacters(in: .whitespaces)
+                        try? modelContext.save()
+                        viewModel.refresh(places: places)
+                    }
+                    placeToRename = nil
+                }
+                Button("Reset to Original", role: .destructive) {
+                    if let place = placeToRename {
+                        place.nickname = nil
+                        try? modelContext.save()
+                        viewModel.refresh(places: places)
+                    }
+                    placeToRename = nil
+                }
+                Button("Cancel", role: .cancel) {
+                    placeToRename = nil
+                }
+            } message: {
+                if let place = placeToRename {
+                    Text("Original name: \(place.name)")
+                }
+            }
             .alert("Delete Place?", isPresented: $showDeleteConfirmation) {
                 Button("Delete", role: .destructive) {
                     if let place = placeToDelete {
@@ -121,8 +159,14 @@ struct PlaceRankingRow: View {
                 .frame(width: 28)
 
             VStack(alignment: .leading, spacing: 4) {
-                Text(ranking.place.name)
+                Text(ranking.place.displayName)
                     .font(.body.weight(.medium))
+
+                if ranking.place.nickname != nil {
+                    Text(ranking.place.name)
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                }
 
                 if let category = ranking.place.category, !category.isEmpty {
                     Text(category)


### PR DESCRIPTION
## Summary
- **Rename places**: Users can set a custom nickname for any place, or correct an incorrect auto-detected name
  - **Places list**: swipe left reveals orange "Rename" button alongside Delete
  - **Map detail sheet**: "Rename" button next to "Delete"
  - Dialog shows original name and offers Save / Reset to Original / Cancel
  - Nicknamed places show the custom name prominently with the original name in faded text below
- **Disable CI**: Changed workflow trigger to `workflow_dispatch` (manual only) to speed up development

### How rename works
- `Place` model gets a new `nickname` field
- `displayName` computed property returns nickname if set, otherwise the auto-detected name
- All views (list rows, map annotations, detail sheet) use `displayName`
- "Reset to Original" clears the nickname and reverts to auto-detected name

## Test plan
- [x] Open Places tab → swipe left on a place → tap orange "Rename"
- [x] Enter a custom name → tap Save → verify name updates in list and map
- [x] Verify original name shown in faded text below nickname
- [x] Open map → tap a pin → tap "Rename" → set name → verify map label updates
- [x] Rename dialog → tap "Reset to Original" → verify nickname is cleared
- [x] Verify CI no longer runs automatically on push/PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)