### PR TITLE
Lock app to portrait-only full screen

### DIFF
--- a/PlaceNotes/Info.plist
+++ b/PlaceNotes/Info.plist
@@ -25,11 +25,11 @@
         <key>UIApplicationSupportsMultipleScenes</key>
         <true/>
     </dict>
+    <key>UIRequiresFullScreen</key>
+    <true/>
     <key>UISupportedInterfaceOrientations</key>
     <array>
         <string>UIInterfaceOrientationPortrait</string>
-        <string>UIInterfaceOrientationLandscapeLeft</string>
-        <string>UIInterfaceOrientationLandscapeRight</string>
     </array>
     <key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
     <string>PlaceNotes tracks the places you visit to generate summaries and reports about your frequent locations.</string>


### PR DESCRIPTION
## Summary
- Sets `UIRequiresFullScreen = true` in Info.plist
- Limits `UISupportedInterfaceOrientations` to portrait only
- Fixes App Store validation warning: "All interface orientations must be supported unless the app requires full screen"

## Test plan
- [x] Run on iPhone — verify app stays in portrait
- [x] Run on iPad — verify no Split View / Slide Over
- [x] Archive and validate — verify no orientation warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)