### PR TITLE
Fix map tab lag on first open

### DIFF
--- a/PlaceNotes/Services/ReportGenerator.swift
+++ b/PlaceNotes/Services/ReportGenerator.swift
@@ -1,11 +1,15 @@
 import Foundation
 import SwiftData
 
-struct PlaceRanking: Identifiable {
+struct PlaceRanking: Identifiable, Equatable {
     let id = UUID()
     let place: Place
     let qualifiedStays: Int
     let totalMinutes: Int
+
+    static func == (lhs: PlaceRanking, rhs: PlaceRanking) -> Bool {
+        lhs.place.id == rhs.place.id && lhs.qualifiedStays == rhs.qualifiedStays && lhs.totalMinutes == rhs.totalMinutes
+    }
 }
 
 struct MonthlyReport: Identifiable {

--- a/PlaceNotes/ViewModels/PlacesViewModel.swift
+++ b/PlaceNotes/ViewModels/PlacesViewModel.swift
@@ -16,17 +16,36 @@ final class PlacesViewModel: ObservableObject {
         let now = Date()
         let sevenDaysAgo = Calendar.current.date(byAdding: .day, value: -7, to: now)!
         let thirtyDaysAgo = Calendar.current.date(byAdding: .day, value: -30, to: now)!
+        let minStay = settings.minStayMinutes
 
-        weeklyPlaces = ReportGenerator.frequentPlaces(
-            from: places,
-            since: sevenDaysAgo,
-            minStayMinutes: settings.minStayMinutes
-        )
+        // Snapshot the data needed for ranking so we can compute off the main thread
+        let snapshots = places.map { place -> (Place, [(Date, Int)]) in
+            let visitData = place.visits.map { ($0.arrivalDate, $0.durationMinutes) }
+            return (place, visitData)
+        }
 
-        monthlyPlaces = ReportGenerator.frequentPlaces(
-            from: places,
-            since: thirtyDaysAgo,
-            minStayMinutes: settings.minStayMinutes
-        )
+        Task.detached {
+            let weekly = Self.computeRankings(from: snapshots, since: sevenDaysAgo, minStayMinutes: minStay)
+            let monthly = Self.computeRankings(from: snapshots, since: thirtyDaysAgo, minStayMinutes: minStay)
+
+            await MainActor.run {
+                self.weeklyPlaces = weekly
+                self.monthlyPlaces = monthly
+            }
+        }
+    }
+
+    private nonisolated static func computeRankings(
+        from snapshots: [(Place, [(Date, Int)])],
+        since startDate: Date,
+        minStayMinutes: Int
+    ) -> [PlaceRanking] {
+        snapshots.compactMap { place, visits in
+            let qualified = visits.filter { $0.0 >= startDate && $0.1 >= minStayMinutes }
+            guard !qualified.isEmpty else { return nil }
+            let totalMin = qualified.reduce(0) { $0 + $1.1 }
+            return PlaceRanking(place: place, qualifiedStays: qualified.count, totalMinutes: totalMin)
+        }
+        .sorted { ($0.qualifiedStays, $0.totalMinutes) > ($1.qualifiedStays, $1.totalMinutes) }
     }
 }

--- a/PlaceNotes/Views/FrequentPlacesMapView.swift
+++ b/PlaceNotes/Views/FrequentPlacesMapView.swift
@@ -67,10 +67,11 @@ struct FrequentPlacesMapView: View {
             .navigationBarTitleDisplayMode(.inline)
             .onAppear {
                 viewModel.refresh(places: places)
-                rebuildAnnotations()
             }
             .onChange(of: places) { _, newPlaces in
                 viewModel.refresh(places: newPlaces)
+            }
+            .onChange(of: viewModel.monthlyPlaces) { _, _ in
                 rebuildAnnotations()
             }
         }
@@ -82,7 +83,7 @@ struct FrequentPlacesMapView: View {
     private func rebuildAnnotations() {
         let rankings = Array(viewModel.monthlyPlaces.prefix(50))
         guard let region = visibleRegion else {
-            cachedAnnotations = rankings.map { SingleItem(ranking: $0) }
+            // Don't render all annotations unclustered before the map reports a region
             return
         }
 


### PR DESCRIPTION
## Summary
- Defer annotation rendering until the map reports a visible region — previously all 50 annotations were rendered unclustered with animated flame effects on the first frame
- Move `PlacesViewModel.refresh()` ranking computation to a background task so it doesn't block the main thread
- Annotations now rebuild reactively via `onChange(of: viewModel.monthlyPlaces)` instead of synchronously in `onAppear`

## Test plan
- [ ] Open the Map tab — verify it loads without a noticeable freeze
- [ ] Annotations should appear shortly after the map settles
- [ ] Pan/zoom the map and verify clustering still works correctly
- [ ] Switch tabs and return to Map — annotations should still display

🤖 Generated with [Claude Code](https://claude.com/claude-code)