### PR TITLE
Fix journal photo taking up excessive vertical space

### DIFF
--- a/PlaceNotes/Views/PhotoGridView.swift
+++ b/PlaceNotes/Views/PhotoGridView.swift
@@ -16,7 +16,7 @@ struct PhotoGridView: View {
             LazyVGrid(columns: columns, spacing: 4) {
                 ForEach(photoFilenames, id: \.self) { filename in
                     PhotoThumbnailView(filename: filename)
-                        .aspectRatio(1, contentMode: .fill)
+                        .aspectRatio(1, contentMode: .fit)
                         .clipped()
                         .clipShape(RoundedRectangle(cornerRadius: 8))
                         .overlay(alignment: .topTrailing) {


### PR DESCRIPTION
## Summary
- Journal entry photos were displayed excessively large, taking up most of the screen
- Changed `PhotoGridView` aspect ratio content mode from `.fill` to `.fit` so photo thumbnails are properly constrained within their grid cells instead of expanding to fill unbounded ScrollView space

## Test plan
- [x] Add a photo to a journal entry and verify it displays at a reasonable size
- [x] Verify multi-photo grid still displays correctly
- [x] Verify photo remove button still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)