### PR TITLE
Fix journal photo scroll bounce

### DIFF
--- a/PlaceNotes/Views/PhotoGridView.swift
+++ b/PlaceNotes/Views/PhotoGridView.swift
@@ -43,23 +43,25 @@ struct PhotoThumbnailView: View {
     @State private var image: UIImage?
 
     var body: some View {
-        Group {
-            if let image {
-                Image(uiImage: image)
-                    .resizable()
-                    .scaledToFill()
-            } else {
-                Rectangle()
-                    .fill(Color(.systemGray5))
-                    .overlay {
-                        Image(systemName: "photo")
-                            .foregroundStyle(.secondary)
-                    }
+        Color.clear
+            .overlay {
+                if let image {
+                    Image(uiImage: image)
+                        .resizable()
+                        .scaledToFill()
+                } else {
+                    Rectangle()
+                        .fill(Color(.systemGray5))
+                        .overlay {
+                            Image(systemName: "photo")
+                                .foregroundStyle(.secondary)
+                        }
+                }
             }
-        }
-        .onAppear {
-            image = PhotoStorage.loadImage(filename: filename)
-        }
+            .clipped()
+            .onAppear {
+                image = PhotoStorage.loadImage(filename: filename)
+            }
     }
 }
 


### PR DESCRIPTION
## Summary
- Fixes scroll bouncing when scrolling up in the place journal view
- Root cause: `PhotoThumbnailView` used `Group` as its container, which has no intrinsic size — with `.aspectRatio(1, contentMode: .fit)`, thumbnails collapsed to zero height, causing layout instability
- Fix: replaced `Group` with `Color.clear` + `.overlay` so thumbnails properly accept the grid cell's proposed size and produce stable squares

## Test plan
- [ ] Open a place with journal photos and scroll up/down — no bounce
- [ ] Verify photos still display correctly in the grid
- [ ] Verify photo remove button still works in the editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)