### PR TITLE
Fix map tab freeze caused by infinite render loop

### DIFF
--- a/PlaceNotes/Services/LocationManager.swift
+++ b/PlaceNotes/Services/LocationManager.swift
@@ -429,12 +429,19 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
     private func findOrCreatePlace(latitude: Double, longitude: Double, in context: ModelContext, addressOnly: Bool = false) async -> (place: Place, alternatives: [PlaceCandidate]) {
         let threshold = 0.0005 // ~50 meters
 
-        let descriptor = FetchDescriptor<Place>()
-        let allPlaces = (try? context.fetch(descriptor)) ?? []
+        let minLat = latitude - threshold
+        let maxLat = latitude + threshold
+        let minLon = longitude - threshold
+        let maxLon = longitude + threshold
+        let descriptor = FetchDescriptor<Place>(
+            predicate: #Predicate<Place> {
+                $0.latitude >= minLat && $0.latitude <= maxLat &&
+                $0.longitude >= minLon && $0.longitude <= maxLon
+            }
+        )
+        let nearbyPlaces = (try? context.fetch(descriptor)) ?? []
 
-        if let existing = allPlaces.first(where: {
-            abs($0.latitude - latitude) < threshold && abs($0.longitude - longitude) < threshold
-        }) {
+        if let existing = nearbyPlaces.first {
             logger.debug("Found existing place: \(existing.name)")
             return (existing, [])
         }

--- a/PlaceNotes/Views/FrequentPlacesMapView.swift
+++ b/PlaceNotes/Views/FrequentPlacesMapView.swift
@@ -13,6 +13,7 @@ struct FrequentPlacesMapView: View {
     @State private var visibleRegion: MKCoordinateRegion?
     @State private var cachedAnnotations: [any MapAnnotationItem] = []
     @State private var showTrackingAlert = false
+    @State private var isRebuildingAnnotations = false
 
     var body: some View {
         NavigationStack {
@@ -39,7 +40,21 @@ struct FrequentPlacesMapView: View {
                     MapScaleView()
                 }
                 .onMapCameraChange(frequency: .onEnd) { context in
-                    visibleRegion = context.region
+                    let newRegion = context.region
+                    // Skip rebuild if the region hasn't changed meaningfully — this
+                    // breaks the feedback loop where annotation updates nudge the
+                    // camera, which triggers another rebuild, and so on.
+                    if let old = visibleRegion {
+                        let spanTolerance = max(old.span.latitudeDelta * 0.02, 0.0001)
+                        let latSame = abs(old.span.latitudeDelta - newRegion.span.latitudeDelta) < spanTolerance
+                        let lonSame = abs(old.span.longitudeDelta - newRegion.span.longitudeDelta) < spanTolerance
+                        let centerLatSame = abs(old.center.latitude - newRegion.center.latitude) < spanTolerance
+                        let centerLonSame = abs(old.center.longitude - newRegion.center.longitude) < spanTolerance
+                        if latSame && lonSame && centerLatSame && centerLonSame {
+                            return
+                        }
+                    }
+                    visibleRegion = newRegion
                     rebuildAnnotations()
                 }
 
@@ -90,14 +105,26 @@ struct FrequentPlacesMapView: View {
 
     /// Rebuilds annotations only when region or data changes — not on every render.
     private func rebuildAnnotations() {
+        guard !isRebuildingAnnotations else { return }
+        isRebuildingAnnotations = true
+        defer { isRebuildingAnnotations = false }
+
         let rankings = Array(viewModel.monthlyPlaces.prefix(50))
-        guard let region = visibleRegion else {
-            cachedAnnotations = rankings.map { SingleItem(ranking: $0) }
-            return
+        let newAnnotations: [any MapAnnotationItem]
+        if let region = visibleRegion {
+            let clusterRadius = region.span.latitudeDelta * 0.08
+            newAnnotations = clusterItems(from: rankings, radius: clusterRadius)
+        } else {
+            newAnnotations = rankings.map { SingleItem(ranking: $0) }
         }
 
-        let clusterRadius = region.span.latitudeDelta * 0.08
-        cachedAnnotations = clusterItems(from: rankings, radius: clusterRadius)
+        // Only update if annotation IDs actually changed — avoids triggering
+        // a Map re-layout that would fire onMapCameraChange again.
+        let oldIDs = cachedAnnotations.map(\.id)
+        let newIDs = newAnnotations.map(\.id)
+        if oldIDs != newIDs {
+            cachedAnnotations = newAnnotations
+        }
     }
 
     private func clusterItems(from rankings: [PlaceRanking], radius: Double) -> [any MapAnnotationItem] {


### PR DESCRIPTION
## Summary
- **Break infinite render loop** in `FrequentPlacesMapView`: `onMapCameraChange` → `rebuildAnnotations()` → annotation update → camera adjustment → `onMapCameraChange` was creating a feedback loop that locked up the main thread. Fixed by skipping rebuilds when the region change is negligible (<2% of span) and only updating `cachedAnnotations` when annotation IDs actually change.
- **Narrow `findOrCreatePlace` database query**: replaced `FetchDescriptor<Place>()` (fetches ALL places) with a spatial bounding-box predicate so only nearby places are loaded, reducing main-thread pressure during location updates.

## Test plan
- [x] Enable tracking in the Tracking tab, then switch to the Map tab — app should remain responsive
- [x] Kill and restart the app with tracking enabled — Map tab should load without freezing
- [x] Pan and zoom on the map — annotations should cluster/uncluster correctly
- [x] Verify new visits are still recorded and appear on the map

🤖 Generated with [Claude Code](https://claude.com/claude-code)