### PR TITLE
Fix watchdog crash from MKMapView background update

### DIFF
--- a/PlaceNotes/Views/FrequentPlacesMapView.swift
+++ b/PlaceNotes/Views/FrequentPlacesMapView.swift
@@ -14,10 +14,12 @@ struct FrequentPlacesMapView: View {
     @State private var cachedAnnotations: [any MapAnnotationItem] = []
     @State private var showTrackingAlert = false
     @State private var isRebuildingAnnotations = false
+    @Environment(\.scenePhase) private var scenePhase
 
     var body: some View {
         NavigationStack {
             ZStack(alignment: .bottomTrailing) {
+                if scenePhase != .background {
                 Map(position: $cameraPosition, selection: $selectedPlace) {
                     UserAnnotation()
 
@@ -56,6 +58,7 @@ struct FrequentPlacesMapView: View {
                     }
                     visibleRegion = newRegion
                     rebuildAnnotations()
+                }
                 }
 
                 // Current location button


### PR DESCRIPTION
## Summary
- App was being killed by the system watchdog (`0x8BADF00D`) when backgrounded
- Root cause: `MKMapView`'s attribution layout (`_UIComplexBoundingPath`) was blocking the main thread for 10+ seconds during a SwiftUI scene update while the app was in the background
- Fix: conditionally remove the `Map` view when `scenePhase == .background` so MKMapView isn't updated off-screen

## Test plan
- [x] Open the Map tab, then background the app — verify no crash after 10+ seconds
- [x] Return to foreground — map should reappear normally
- [x] Verify map interactions (pan, zoom, tap annotations) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)