### PR TITLE
Add swipe-to-delete for individual visits in Logbook

### DIFF
--- a/PlaceNotes/Views/LogbookView.swift
+++ b/PlaceNotes/Views/LogbookView.swift
@@ -90,9 +90,12 @@ struct LogbookView: View {
             .alert("Delete Visit?", isPresented: $showDeleteConfirmation) {
                 Button("Delete", role: .destructive) {
                     if let visit = visitToDelete {
+                        if let place = visit.place,
+                           let index = place.visits.firstIndex(where: { $0.id == visit.id }) {
+                            place.visits.remove(at: index)
+                        }
                         modelContext.delete(visit)
                         try? modelContext.save()
-                        refreshID = UUID()
                         visitToDelete = nil
                     }
                 }
@@ -315,12 +318,13 @@ private struct MonthSection: View {
                         }
                     }
                     .buttonStyle(.plain)
-                    .swipeActions(edge: .trailing) {
-                        Button(role: .destructive) {
+                    .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                        Button {
                             onDelete?(visit)
                         } label: {
                             Label("Delete", systemImage: "trash")
                         }
+                        .tint(.red)
                     }
                 }
             }

--- a/PlaceNotes/Views/LogbookView.swift
+++ b/PlaceNotes/Views/LogbookView.swift
@@ -7,6 +7,8 @@ struct LogbookView: View {
     @Query private var places: [Place]
     @EnvironmentObject var settings: AppSettings
     @State private var visitForAlternatives: Visit?
+    @State private var visitToDelete: Visit?
+    @State private var showDeleteConfirmation = false
     @State private var refreshID = UUID()
 
     private var groupedVisits: [(year: Int, months: [(month: Int, visits: [Visit])])] {
@@ -57,6 +59,10 @@ struct LogbookView: View {
                                         visits: monthGroup.visits,
                                         onPickAlternative: { visit in
                                             visitForAlternatives = visit
+                                        },
+                                        onDelete: { visit in
+                                            visitToDelete = visit
+                                            showDeleteConfirmation = true
                                         }
                                     )
                                 }
@@ -80,6 +86,21 @@ struct LogbookView: View {
                 AlternativePlacePicker(visit: visit) {
                     refreshID = UUID()
                 }
+            }
+            .alert("Delete Visit?", isPresented: $showDeleteConfirmation) {
+                Button("Delete", role: .destructive) {
+                    if let visit = visitToDelete {
+                        modelContext.delete(visit)
+                        try? modelContext.save()
+                        refreshID = UUID()
+                        visitToDelete = nil
+                    }
+                }
+                Button("Cancel", role: .cancel) {
+                    visitToDelete = nil
+                }
+            } message: {
+                Text("This visit will be permanently deleted.")
             }
         }
     }
@@ -263,6 +284,7 @@ private struct MonthSection: View {
     let month: Int
     let visits: [Visit]
     var onPickAlternative: ((Visit) -> Void)?
+    var onDelete: ((Visit) -> Void)?
 
     private var monthName: String {
         let formatter = DateFormatter()
@@ -293,6 +315,13 @@ private struct MonthSection: View {
                         }
                     }
                     .buttonStyle(.plain)
+                    .swipeActions(edge: .trailing) {
+                        Button(role: .destructive) {
+                            onDelete?(visit)
+                        } label: {
+                            Label("Delete", systemImage: "trash")
+                        }
+                    }
                 }
             }
         } label: {


### PR DESCRIPTION
## Summary
- Swipe left on any visit row in the Logbook to reveal a red Delete button
- Shows a confirmation alert before permanently deleting the visit
- List refreshes automatically after deletion

## Test plan
- [x] Swipe left on a visit row — Delete button appears
- [x] Tap Delete — confirmation alert shows
- [x] Confirm delete — visit is removed and list updates
- [x] Tap Cancel — visit remains unchanged
- [x] Verify navigation to place detail still works (tap the row)

🤖 Generated with [Claude Code](https://claude.com/claude-code)