### PR TITLE
fix: accept composite emojis in custom category input

### DIFF
--- a/PlaceNotes/Views/FrequentPlacesMapView.swift
+++ b/PlaceNotes/Views/FrequentPlacesMapView.swift
@@ -608,7 +608,7 @@ struct EmojiTextField: UIViewRepresentable {
     }
 
     func updateUIView(_ uiView: UIEmojiTextField, context: Context) {
-        uiView.text = text
+        if uiView.text != text { uiView.text = text }
     }
 
     func makeCoordinator() -> Coordinator {
@@ -623,13 +623,8 @@ struct EmojiTextField: UIViewRepresentable {
         }
 
         func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
-            // Allow deletions
             if string.isEmpty { return true }
-            // Only allow emoji characters
-            return string.unicodeScalars.allSatisfy { scalar in
-                scalar.properties.isEmoji && scalar.properties.isEmojiPresentation
-                || scalar.properties.isEmoji && scalar.value > 0x238C
-            }
+            return string.allSatisfy { $0.isEmoji }
         }
 
         @objc func textChanged(_ sender: UITextField) {
@@ -645,6 +640,15 @@ struct EmojiTextField: UIViewRepresentable {
 
         func textFieldDidBeginEditing(_ textField: UITextField) {
             textField.text = text
+        }
+    }
+}
+
+private extension Character {
+    var isEmoji: Bool {
+        unicodeScalars.contains { scalar in
+            scalar.properties.isEmojiPresentation ||
+            (scalar.properties.isEmoji && scalar.value > 0x238C)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Custom category emoji input rejected most multi-scalar emojis (❤️, 👨‍💻, 🏳️‍🌈, etc.), so users had to retry several times until they happened to pick a single-scalar emoji like 👍.
- Root cause: `EmojiTextField.shouldChangeCharactersIn` required *every* unicode scalar to satisfy `isEmoji`, but ZWJ (U+200D) and variation selectors (U+FE0F) are not emoji scalars on their own.
- Fix: validate at the grapheme-cluster level via a private `Character.isEmoji` extension.
- Also guard `updateUIView` against unconditional text rewrites that could race the emoji keyboard's multi-stage composition.

## Test plan
- [x] Open a place → Change Category → Create New Category
- [x] Type ❤️ (VS16) — accepts on first tap
- [x] Type 👨‍💻 (ZWJ sequence) — accepts on first tap
- [x] Type 🏳️‍🌈 (VS16 + ZWJ) — accepts on first tap
- [x] Type 👍 (single scalar, regression check) — still accepts
- [x] Backspace clears the field
- [x] Saved category persists with the chosen emoji

🤖 Generated with [Claude Code](https://claude.com/claude-code)