### PR TITLE
refactor: consolidate analysis scripts into placenotes_analysis package

### DIFF
--- a/scripts/placenotes.py
+++ b/scripts/placenotes.py
@@ -1,0 +1,279 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "folium>=0.15",
+#     "matplotlib>=3.7",
+#     "numpy>=1.24",
+#     "scikit-learn>=1.3",
+# ]
+# ///
+"""PlaceNotes analysis — single entry point.
+
+Interactive:
+    uv run scripts/placenotes.py
+
+One-line:
+    uv run scripts/placenotes.py pipeline <csv> [--tau_gap 600] [--eps 50] ...
+    uv run scripts/placenotes.py trips    <csv> [--use_rejected_for_trips] ...
+    uv run scripts/placenotes.py places   <csv> [--eps 40] [--min_pts 10] ...
+    uv run scripts/placenotes.py all      <csv> [...]
+
+Subcommands
+-----------
+  pipeline  ST-DBSCAN stay-point + trip extraction → annotated CSV + trips JSON
+  trips     Pipeline + folium map + speed timelines + day Gantt
+  places    Global place discovery + filter audit + time-of-day + behavior PCA
+  all       Run both `trips` and `places`
+"""
+
+import argparse
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from placenotes_analysis import (  # noqa: E402
+    run_pipeline,
+    run_place_analysis,
+    run_trip_visualization,
+)
+
+
+# ---------------------------------------------------------------------------
+# Argparse plumbing
+# ---------------------------------------------------------------------------
+
+def _add_pipeline_args(p: argparse.ArgumentParser) -> None:
+    p.add_argument("csv", help="Path to PlaceNotes CSV export")
+    p.add_argument("--tau_gap", type=float, default=600,
+                   help="Time gap threshold in seconds (default: 600)")
+    p.add_argument("--eps", type=float, default=50,
+                   help="Spatial eps in meters (default: 50)")
+    p.add_argument("--min_pts", type=int, default=3,
+                   help="Minimum points for a cluster (default: 3)")
+    p.add_argument("--use_all", action="store_true",
+                   help="Use all points including rejected")
+    p.add_argument("--use_rejected_for_trips", action="store_true",
+                   help="Detect stay points on accepted only, but include "
+                        "rejected inside trip bodies for speed/course stats")
+    p.add_argument("--output_dir", default="",
+                   help="Output directory (default: same as input)")
+
+
+def _add_places_args(p: argparse.ArgumentParser) -> None:
+    p.add_argument("csv", help="Path to PlaceNotes CSV export")
+    p.add_argument("--eps", type=float, default=40,
+                   help="DBSCAN eps in meters (default: 40)")
+    p.add_argument("--min_pts", type=int, default=10,
+                   help="DBSCAN min_samples (default: 10)")
+    p.add_argument("--visit_gap", type=float, default=600,
+                   help="Gap in seconds that separates visits (default: 600)")
+    p.add_argument("--output_dir", default="",
+                   help="Output directory (default: same as input)")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="placenotes",
+        description="PlaceNotes analysis — pipeline, trip viz, place discovery")
+    sub = parser.add_subparsers(dest="cmd")
+
+    p_pipeline = sub.add_parser("pipeline",
+                                help="Run the ST-DBSCAN pipeline only")
+    _add_pipeline_args(p_pipeline)
+
+    p_trips = sub.add_parser("trips",
+                             help="Pipeline + trip visualizations")
+    _add_pipeline_args(p_trips)
+
+    p_places = sub.add_parser("places",
+                              help="Place discovery + filter audit + behavior PCA")
+    _add_places_args(p_places)
+
+    p_all = sub.add_parser("all", help="Run both `trips` and `places`")
+    _add_pipeline_args(p_all)
+    p_all.add_argument("--place_eps", type=float, default=40,
+                       help="Place-discovery eps in meters (default: 40)")
+    p_all.add_argument("--place_min_pts", type=int, default=10,
+                       help="Place-discovery min_samples (default: 10)")
+    p_all.add_argument("--visit_gap", type=float, default=600,
+                       help="Gap in seconds that separates visits (default: 600)")
+
+    sub.add_parser("interactive", help="Interactive prompt-driven mode")
+
+    return parser
+
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+
+def _dispatch_pipeline(args) -> None:
+    run_pipeline(
+        csv_path=args.csv,
+        tau_gap=args.tau_gap,
+        eps=args.eps,
+        min_pts=args.min_pts,
+        use_all=args.use_all,
+        use_rejected_for_trips=args.use_rejected_for_trips,
+        output_dir=args.output_dir,
+    )
+
+
+def _dispatch_trips(args) -> None:
+    run_trip_visualization(
+        csv_path=args.csv,
+        tau_gap=args.tau_gap,
+        eps=args.eps,
+        min_pts=args.min_pts,
+        use_all=args.use_all,
+        use_rejected_for_trips=args.use_rejected_for_trips,
+        output_dir=args.output_dir,
+    )
+
+
+def _dispatch_places(args) -> None:
+    run_place_analysis(
+        csv_path=args.csv,
+        eps=args.eps,
+        min_pts=args.min_pts,
+        visit_gap=args.visit_gap,
+        output_dir=args.output_dir,
+    )
+
+
+def _dispatch_all(args) -> None:
+    run_trip_visualization(
+        csv_path=args.csv,
+        tau_gap=args.tau_gap,
+        eps=args.eps,
+        min_pts=args.min_pts,
+        use_all=args.use_all,
+        use_rejected_for_trips=args.use_rejected_for_trips,
+        output_dir=args.output_dir,
+    )
+    run_place_analysis(
+        csv_path=args.csv,
+        eps=args.place_eps,
+        min_pts=args.place_min_pts,
+        visit_gap=args.visit_gap,
+        output_dir=args.output_dir,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Interactive mode
+# ---------------------------------------------------------------------------
+
+def _prompt(label: str, default, cast=str):
+    raw = input(f"{label} [{default}]: ").strip()
+    if not raw:
+        return default
+    try:
+        return cast(raw)
+    except ValueError:
+        print(f"  ! invalid value, using default {default}")
+        return default
+
+
+def _prompt_bool(label: str, default: bool) -> bool:
+    suffix = "Y/n" if default else "y/N"
+    raw = input(f"{label} [{suffix}]: ").strip().lower()
+    if not raw:
+        return default
+    return raw in ("y", "yes", "true", "1")
+
+
+def _run_interactive() -> None:
+    print("PlaceNotes — interactive mode")
+    print("-" * 40)
+
+    csv_path = input("Path to CSV: ").strip().strip('"').strip("'")
+    if not csv_path:
+        print("No path given — aborting.")
+        return
+    if not os.path.isfile(csv_path):
+        print(f"Not a file: {csv_path}")
+        return
+
+    print("\nChoose an action:")
+    print("  1) pipeline — stay-point + trip extraction only")
+    print("  2) trips    — pipeline + map + speed + gantt")
+    print("  3) places   — place discovery + filter audit + behavior PCA")
+    print("  4) all      — trips + places")
+    choice = input("Choice [2]: ").strip() or "2"
+
+    output_dir = _prompt("Output directory (blank = alongside CSV)", "")
+
+    if choice in ("1", "2"):
+        print("\nPipeline parameters:")
+        tau_gap = _prompt("  tau_gap (s)", 600.0, float)
+        eps = _prompt("  eps (m)", 50.0, float)
+        min_pts = _prompt("  min_pts", 3, int)
+        use_all = _prompt_bool("  use ALL samples (incl. rejected)?", False)
+        use_rej = False
+        if not use_all:
+            use_rej = _prompt_bool(
+                "  fold rejected into trip bodies for speed/course?", True)
+
+        if choice == "1":
+            run_pipeline(csv_path, tau_gap, eps, min_pts,
+                         use_all, use_rej, output_dir)
+        else:
+            run_trip_visualization(csv_path, tau_gap, eps, min_pts,
+                                   use_all, use_rej, output_dir)
+
+    elif choice == "3":
+        print("\nPlace-discovery parameters:")
+        eps = _prompt("  eps (m)", 40.0, float)
+        min_pts = _prompt("  min_pts", 10, int)
+        visit_gap = _prompt("  visit_gap (s)", 600.0, float)
+        run_place_analysis(csv_path, eps, min_pts, visit_gap, output_dir)
+
+    elif choice == "4":
+        print("\nPipeline parameters (for trips):")
+        tau_gap = _prompt("  tau_gap (s)", 600.0, float)
+        eps_trip = _prompt("  eps (m)", 50.0, float)
+        min_pts_trip = _prompt("  min_pts", 3, int)
+        use_all = _prompt_bool("  use ALL samples (incl. rejected)?", False)
+        use_rej = False
+        if not use_all:
+            use_rej = _prompt_bool(
+                "  fold rejected into trip bodies?", True)
+
+        print("\nPlace-discovery parameters:")
+        eps_place = _prompt("  eps (m)", 40.0, float)
+        min_pts_place = _prompt("  min_pts", 10, int)
+        visit_gap = _prompt("  visit_gap (s)", 600.0, float)
+
+        run_trip_visualization(csv_path, tau_gap, eps_trip, min_pts_trip,
+                               use_all, use_rej, output_dir)
+        run_place_analysis(csv_path, eps_place, min_pts_place,
+                           visit_gap, output_dir)
+    else:
+        print(f"Unknown choice: {choice}")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    if args.cmd is None or args.cmd == "interactive":
+        _run_interactive()
+        return
+
+    dispatch = {
+        "pipeline": _dispatch_pipeline,
+        "trips": _dispatch_trips,
+        "places": _dispatch_places,
+        "all": _dispatch_all,
+    }
+    dispatch[args.cmd](args)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/placenotes_analysis/__init__.py
+++ b/scripts/placenotes_analysis/__init__.py
@@ -1,0 +1,77 @@
+"""PlaceNotes analysis utilities.
+
+Three pure-Python modules, no CLI:
+  - pipeline: ST-DBSCAN stay-point + trip extraction
+  - trips:    folium/matplotlib renderers for stays and trips
+  - places:   global place discovery, filter audit, behavior PCA
+"""
+
+from .pipeline import (
+    EARTH_RADIUS_M,
+    LocationSample,
+    StayPoint,
+    Trip,
+    dbscan_spatial,
+    extract_stay_points,
+    extract_trips,
+    haversine,
+    infer_transport_mode,
+    load_csv,
+    print_summary,
+    run_pipeline,
+    segment_by_time_gap,
+    write_annotated_csv,
+    write_trips_json,
+)
+from .places import (
+    Place,
+    assign_rejected_to_places,
+    cluster_places,
+    compute_visits,
+    render_behavior_pca,
+    render_filter_audit,
+    render_places_map,
+    render_tod,
+    run_place_analysis,
+    write_places_csv,
+)
+from .trips import (
+    MODE_COLORS,
+    render_day_gantt,
+    render_map,
+    render_speed_timelines,
+    run_trip_visualization,
+)
+
+__all__ = [
+    "EARTH_RADIUS_M",
+    "LocationSample",
+    "MODE_COLORS",
+    "Place",
+    "StayPoint",
+    "Trip",
+    "assign_rejected_to_places",
+    "cluster_places",
+    "compute_visits",
+    "dbscan_spatial",
+    "extract_stay_points",
+    "extract_trips",
+    "haversine",
+    "infer_transport_mode",
+    "load_csv",
+    "print_summary",
+    "render_behavior_pca",
+    "render_day_gantt",
+    "render_filter_audit",
+    "render_map",
+    "render_places_map",
+    "render_speed_timelines",
+    "render_tod",
+    "run_pipeline",
+    "run_place_analysis",
+    "run_trip_visualization",
+    "segment_by_time_gap",
+    "write_annotated_csv",
+    "write_places_csv",
+    "write_trips_json",
+]

--- a/scripts/placenotes_analysis/pipeline.py
+++ b/scripts/placenotes_analysis/pipeline.py
@@ -1,35 +1,20 @@
-"""
-Two-Stage ST-DBSCAN Pipeline for Trip Detection
-================================================
-PlaceNotes project — scripts/st_dbscan_pipeline.py
+"""Two-stage ST-DBSCAN pipeline for stay-point and trip detection.
 
-Usage:
-    python scripts/st_dbscan_pipeline.py <path_to_csv> [--tau_gap 600] [--eps 50] [--min_pts 3]
-
-This script implements the two-stage approach:
-  Stage 1: Temporal gap segmentation (split trajectory by time gaps > tau_gap)
-  Stage 2: Spatial DBSCAN within each segment to find stay points
-
-Output:
-  - Console summary of detected stay points and trips
-  - Annotated CSV with cluster labels
-  - (Optional) HTML map visualization
+Stage 1: Temporal gap segmentation (split trajectory by time gaps > tau_gap).
+Stage 2: Spatial DBSCAN within each segment to find stay points.
 """
 
-import argparse
 import csv
 import json
 import math
 import os
-import sys
-from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from dataclasses import dataclass
+from datetime import datetime
 from typing import Optional
 
 
-# ---------------------------------------------------------------------------
-# Data structures
-# ---------------------------------------------------------------------------
+EARTH_RADIUS_M = 6_371_000
+
 
 @dataclass
 class LocationSample:
@@ -45,7 +30,6 @@ class LocationSample:
     course: Optional[float]
     filter_status: str
     motion_activity: str
-    # Computed during pipeline
     segment_id: int = -1
     cluster_id: int = -1  # -1 = noise (in motion)
     label: str = ""       # "stay" or "moving"
@@ -61,7 +45,7 @@ class StayPoint:
     arrival: datetime
     departure: datetime
     sample_count: int
-    radius_m: float  # max distance from center to any point in cluster
+    radius_m: float
 
 
 @dataclass
@@ -74,51 +58,39 @@ class Trip:
     end_time: datetime
     duration_seconds: float
     distance_m: float
-    samples: list  # LocationSamples during this trip
+    samples: list
     avg_speed_ms: float
     max_speed_ms: float
-    transport_mode: str  # inferred: walk / bike / drive / unknown
+    transport_mode: str
 
-
-# ---------------------------------------------------------------------------
-# Utilities
-# ---------------------------------------------------------------------------
 
 def haversine(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
     """Distance in meters between two (lat, lon) pairs."""
-    R = 6_371_000  # Earth radius in meters
     dlat = math.radians(lat2 - lat1)
     dlon = math.radians(lon2 - lon1)
     a = (math.sin(dlat / 2) ** 2 +
          math.cos(math.radians(lat1)) * math.cos(math.radians(lat2)) *
          math.sin(dlon / 2) ** 2)
-    return R * 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
+    return EARTH_RADIUS_M * 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
 
 
 def parse_timestamp(ts_str: str) -> datetime:
-    """Parse ISO 8601 timestamp string to datetime."""
-    # Handle both "2026-04-18T05:22:49.074Z" and without fractional seconds
     ts_str = ts_str.replace("Z", "+00:00")
     return datetime.fromisoformat(ts_str)
 
 
 def infer_transport_mode(avg_speed_ms: float, max_speed_ms: float) -> str:
-    """Simple rule-based transport mode inference from speed."""
     if avg_speed_ms < 0:
         return "unknown"
-    elif avg_speed_ms < 2.0:       # < 7.2 km/h
+    elif avg_speed_ms < 2.0:
         return "walk"
-    elif avg_speed_ms < 6.0:       # < 21.6 km/h
+    elif avg_speed_ms < 6.0:
         return "bike"
-    elif avg_speed_ms < 50.0:      # < 180 km/h
+    elif avg_speed_ms < 50.0:
         return "drive"
     else:
         return "unknown"
 
-
-# ---------------------------------------------------------------------------
-# CSV Loading
-# ---------------------------------------------------------------------------
 
 def load_csv(path: str) -> list[LocationSample]:
     """Load GPS samples from PlaceNotes CSV export."""
@@ -152,18 +124,9 @@ def load_csv(path: str) -> list[LocationSample]:
     return samples
 
 
-# ---------------------------------------------------------------------------
-# Stage 1: Temporal Gap Segmentation
-# ---------------------------------------------------------------------------
-
 def segment_by_time_gap(samples: list[LocationSample],
                         tau_gap_seconds: float = 600) -> list[list[LocationSample]]:
-    """
-    Split the trajectory into segments wherever the time gap between
-    consecutive points exceeds tau_gap_seconds.
-
-    Default tau_gap = 600s (10 minutes).
-    """
+    """Split the trajectory into segments by time gaps > tau_gap_seconds."""
     if not samples:
         return []
 
@@ -187,28 +150,19 @@ def segment_by_time_gap(samples: list[LocationSample],
     return segments
 
 
-# ---------------------------------------------------------------------------
-# Stage 2: Spatial DBSCAN within segments
-# ---------------------------------------------------------------------------
-
 def dbscan_spatial(samples: list[LocationSample],
                    eps_meters: float = 50,
                    min_pts: int = 3,
                    cluster_id_offset: int = 0) -> int:
-    """
-    Run DBSCAN on spatial coordinates within a single segment.
-    Assigns cluster_id to each sample in-place.
+    """Run DBSCAN on spatial coordinates within a single segment.
 
-    Returns the next available cluster_id (for offset tracking across segments).
-
-    This is a from-scratch implementation so the script has zero dependencies
-    beyond the Python standard library.
+    Assigns cluster_id to each sample in-place. Returns the next available
+    cluster_id (for offset tracking across segments). Zero external deps.
     """
     n = len(samples)
     if n == 0:
         return cluster_id_offset
 
-    # Pre-compute pairwise distances (fine for small n per segment)
     dist = [[0.0] * n for _ in range(n)]
     for i in range(n):
         for j in range(i + 1, n):
@@ -217,11 +171,10 @@ def dbscan_spatial(samples: list[LocationSample],
             dist[i][j] = d
             dist[j][i] = d
 
-    # Find neighbors
     def region_query(idx):
         return [j for j in range(n) if dist[idx][j] <= eps_meters]
 
-    labels = [-1] * n  # -1 = unvisited
+    labels = [-1] * n
     visited = [False] * n
     cluster = cluster_id_offset
 
@@ -232,9 +185,8 @@ def dbscan_spatial(samples: list[LocationSample],
         neighbors = region_query(i)
 
         if len(neighbors) < min_pts:
-            labels[i] = -1  # noise
+            labels[i] = -1
         else:
-            # Expand cluster
             labels[i] = cluster
             seed_set = list(neighbors)
             k = 0
@@ -257,12 +209,7 @@ def dbscan_spatial(samples: list[LocationSample],
     return cluster
 
 
-# ---------------------------------------------------------------------------
-# Stay Point and Trip extraction
-# ---------------------------------------------------------------------------
-
 def extract_stay_points(samples: list[LocationSample]) -> list[StayPoint]:
-    """Extract stay points from clustered samples."""
     clusters: dict[int, list[LocationSample]] = {}
     for s in samples:
         if s.cluster_id >= 0:
@@ -293,16 +240,20 @@ def extract_stay_points(samples: list[LocationSample]) -> list[StayPoint]:
 
 def extract_trips(samples: list[LocationSample],
                   stay_points: list[StayPoint]) -> list[Trip]:
-    """Extract trips between consecutive stay points."""
+    """Extract trips between consecutive stay points.
+
+    `samples` may contain rejected points (cluster_id == -1 by default); they
+    will be included in trip bodies alongside accepted-but-moving points.
+    """
     if len(stay_points) < 2:
         return []
 
+    samples = sorted(samples, key=lambda s: s.timestamp)
     trips = []
     for i in range(len(stay_points) - 1):
         origin = stay_points[i]
         dest = stay_points[i + 1]
 
-        # Find samples between departure of origin and arrival of destination
         trip_samples = [
             s for s in samples
             if origin.departure <= s.timestamp <= dest.arrival
@@ -313,7 +264,6 @@ def extract_trips(samples: list[LocationSample],
         distance = haversine(origin.center_lat, origin.center_lon,
                              dest.center_lat, dest.center_lon)
 
-        # Speed stats from trip samples
         valid_speeds = [s.speed for s in trip_samples if s.speed >= 0]
         avg_speed = sum(valid_speeds) / len(valid_speeds) if valid_speeds else -1
         max_speed = max(valid_speeds) if valid_speeds else -1
@@ -336,12 +286,7 @@ def extract_trips(samples: list[LocationSample],
     return trips
 
 
-# ---------------------------------------------------------------------------
-# Output
-# ---------------------------------------------------------------------------
-
-def print_summary(samples, segments, stay_points, trips):
-    """Print a human-readable summary of the pipeline results."""
+def print_summary(samples, segments, stay_points, trips) -> None:
     print("\n" + "=" * 60)
     print("ST-DBSCAN Pipeline Results")
     print("=" * 60)
@@ -371,8 +316,7 @@ def print_summary(samples, segments, stay_points, trips):
                   f"mode={t.transport_mode}")
 
 
-def write_annotated_csv(samples: list[LocationSample], output_path: str):
-    """Write the original CSV with added segment_id, cluster_id, and label columns."""
+def write_annotated_csv(samples: list[LocationSample], output_path: str) -> None:
     fieldnames = [
         "id", "latitude", "longitude", "timestamp",
         "horizontalAccuracy", "speed", "altitude", "verticalAccuracy",
@@ -399,11 +343,10 @@ def write_annotated_csv(samples: list[LocationSample], output_path: str):
                 "cluster_id": s.cluster_id,
                 "label": s.label,
             })
-    print(f"\nAnnotated CSV written to: {output_path}")
+    print(f"Annotated CSV: {output_path}")
 
 
-def write_trips_json(trips: list[Trip], output_path: str):
-    """Write trip summaries as JSON (useful for LLM annotation later)."""
+def write_trips_json(trips: list[Trip], output_path: str) -> None:
     data = []
     for t in trips:
         data.append({
@@ -422,57 +365,49 @@ def write_trips_json(trips: list[Trip], output_path: str):
 
     with open(output_path, "w") as f:
         json.dump(data, f, indent=2)
-    print(f"Trips JSON written to: {output_path}")
+    print(f"Trips JSON: {output_path}")
 
-
-# ---------------------------------------------------------------------------
-# Main pipeline
-# ---------------------------------------------------------------------------
 
 def run_pipeline(csv_path: str,
                  tau_gap: float = 600,
                  eps: float = 50,
                  min_pts: int = 3,
                  use_all: bool = False,
+                 use_rejected_for_trips: bool = False,
                  output_dir: str = ""):
-    """
-    Run the full two-stage ST-DBSCAN pipeline.
+    """Run the full two-stage ST-DBSCAN pipeline.
 
-    Args:
-        csv_path:   Path to PlaceNotes CSV export
-        tau_gap:    Stage 1 — time gap threshold in seconds (default 600 = 10 min)
-        eps:        Stage 2 — spatial distance threshold in meters (default 50)
-        min_pts:    Stage 2 — minimum points to form a cluster (default 3)
-        use_all:    If True, use all points; if False, only use accepted points
-        output_dir: Directory for output files (default: same as input)
+    Returns (samples, segments, stay_points, trips).
     """
-    # Load
     all_samples = load_csv(csv_path)
     print(f"Loaded {len(all_samples)} samples from {csv_path}")
 
-    # Filter
+    rejected_samples: list[LocationSample] = []
     if use_all:
         samples = all_samples
     else:
         samples = [s for s in all_samples if s.filter_status == "accepted"]
+        rejected_samples = [s for s in all_samples if s.filter_status != "accepted"]
         print(f"Using {len(samples)} accepted samples (filtered out "
-              f"{len(all_samples) - len(samples)} rejected)")
+              f"{len(rejected_samples)} rejected)")
 
-    # Stage 1: temporal segmentation
     segments = segment_by_time_gap(samples, tau_gap)
     print(f"Stage 1: {len(segments)} segments (tau_gap={tau_gap}s)")
 
-    # Stage 2: spatial DBSCAN per segment
     cluster_offset = 0
     for seg in segments:
         cluster_offset = dbscan_spatial(seg, eps, min_pts, cluster_offset)
     print(f"Stage 2: {cluster_offset} clusters found (eps={eps}m, min_pts={min_pts})")
 
-    # Extract stay points and trips
     stay_points = extract_stay_points(samples)
-    trips = extract_trips(samples, stay_points)
+    if use_rejected_for_trips and not use_all and rejected_samples:
+        trip_pool = samples + rejected_samples
+        print(f"Trip inference: folding in {len(rejected_samples)} rejected "
+              f"samples for speed/course stats")
+    else:
+        trip_pool = samples
+    trips = extract_trips(trip_pool, stay_points)
 
-    # Output
     print_summary(samples, segments, stay_points, trips)
 
     if not output_dir:
@@ -483,31 +418,3 @@ def run_pipeline(csv_path: str,
     write_trips_json(trips, os.path.join(output_dir, f"{base}_trips.json"))
 
     return samples, segments, stay_points, trips
-
-
-# ---------------------------------------------------------------------------
-# CLI
-# ---------------------------------------------------------------------------
-
-def main():
-    parser = argparse.ArgumentParser(
-        description="Two-Stage ST-DBSCAN pipeline for trip detection")
-    parser.add_argument("csv", help="Path to PlaceNotes CSV export")
-    parser.add_argument("--tau_gap", type=float, default=600,
-                        help="Time gap threshold in seconds (default: 600)")
-    parser.add_argument("--eps", type=float, default=50,
-                        help="Spatial eps in meters (default: 50)")
-    parser.add_argument("--min_pts", type=int, default=3,
-                        help="Minimum points for a cluster (default: 3)")
-    parser.add_argument("--use_all", action="store_true",
-                        help="Use all points including rejected")
-    parser.add_argument("--output_dir", default="",
-                        help="Output directory (default: same as input)")
-    args = parser.parse_args()
-
-    run_pipeline(args.csv, args.tau_gap, args.eps, args.min_pts,
-                 args.use_all, args.output_dir)
-
-
-if __name__ == "__main__":
-    main()

--- a/scripts/placenotes_analysis/places.py
+++ b/scripts/placenotes_analysis/places.py
@@ -1,0 +1,410 @@
+"""Place discovery, filter audit, and behavior PCA on raw location samples.
+
+Two analyses in one pass:
+  1. Place discovery — global spatial DBSCAN over accepted samples to surface
+     recurring places (home, office, gym, ...).
+  2. Filter audit — per-place counts of nearby rejected samples, to see where
+     the in-app filter is systematically dropping points.
+
+Plus a behavior-feature PCA over *all* samples (accepted + rejected) to
+visualize movement patterns independent of position.
+"""
+
+import csv
+import os
+from dataclasses import dataclass, field
+
+import folium
+import matplotlib.pyplot as plt
+import numpy as np
+from sklearn.cluster import DBSCAN
+from sklearn.decomposition import PCA
+from sklearn.neighbors import BallTree
+from sklearn.preprocessing import StandardScaler
+
+from .pipeline import EARTH_RADIUS_M, haversine, load_csv
+
+
+@dataclass
+class Place:
+    place_id: int
+    center_lat: float
+    center_lon: float
+    radius_m: float
+    accepted_samples: list
+    rejected_samples: list = field(default_factory=list)
+    visits: list = field(default_factory=list)  # list[(start, end, n_samples)]
+
+    @property
+    def accepted_count(self) -> int:
+        return len(self.accepted_samples)
+
+    @property
+    def rejected_count(self) -> int:
+        return len(self.rejected_samples)
+
+    @property
+    def rejected_ratio(self) -> float:
+        total = self.accepted_count + self.rejected_count
+        return self.rejected_count / total if total else 0.0
+
+    @property
+    def total_dwell_seconds(self) -> float:
+        return sum((end - start).total_seconds() for start, end, _ in self.visits)
+
+    @property
+    def visit_count(self) -> int:
+        return len(self.visits)
+
+
+def cluster_places(accepted, eps_m: float, min_pts: int) -> list[Place]:
+    """Global DBSCAN on accepted samples using haversine metric."""
+    if not accepted:
+        return []
+
+    coords = np.radians([[s.latitude, s.longitude] for s in accepted])
+    eps_rad = eps_m / EARTH_RADIUS_M
+
+    db = DBSCAN(eps=eps_rad, min_samples=min_pts, metric="haversine").fit(coords)
+    labels = db.labels_
+
+    grouped: dict[int, list] = {}
+    for sample, label in zip(accepted, labels):
+        if label < 0:
+            continue
+        grouped.setdefault(int(label), []).append(sample)
+
+    places = []
+    for cid, pts in sorted(grouped.items()):
+        lat = sum(p.latitude for p in pts) / len(pts)
+        lon = sum(p.longitude for p in pts) / len(pts)
+        radius = max(haversine(lat, lon, p.latitude, p.longitude) for p in pts)
+        places.append(Place(
+            place_id=cid,
+            center_lat=lat,
+            center_lon=lon,
+            radius_m=radius,
+            accepted_samples=pts,
+        ))
+    return places
+
+
+def assign_rejected_to_places(places: list[Place],
+                              rejected: list,
+                              eps_m: float) -> int:
+    """Attach each rejected sample to its nearest place (if within radius+eps).
+
+    Returns the number of rejected samples attached.
+    """
+    if not places or not rejected:
+        return 0
+
+    centers = np.radians([[p.center_lat, p.center_lon] for p in places])
+    tree = BallTree(centers, metric="haversine")
+
+    coords = np.radians([[s.latitude, s.longitude] for s in rejected])
+    dists, idxs = tree.query(coords, k=1)
+    dists_m = dists.flatten() * EARTH_RADIUS_M
+    idxs = idxs.flatten()
+
+    attached = 0
+    for sample, d_m, i in zip(rejected, dists_m, idxs):
+        place = places[i]
+        if d_m <= place.radius_m + eps_m:
+            place.rejected_samples.append(sample)
+            attached += 1
+    return attached
+
+
+def compute_visits(place: Place, visit_gap_s: float) -> None:
+    """Split a place's accepted samples into visits separated by time gaps."""
+    pts = sorted(place.accepted_samples, key=lambda s: s.timestamp)
+    if not pts:
+        return
+
+    start = pts[0].timestamp
+    prev = pts[0].timestamp
+    count = 1
+    for s in pts[1:]:
+        gap = (s.timestamp - prev).total_seconds()
+        if gap > visit_gap_s:
+            place.visits.append((start, prev, count))
+            start = s.timestamp
+            count = 1
+        else:
+            count += 1
+        prev = s.timestamp
+    place.visits.append((start, prev, count))
+
+
+def _ratio_color(ratio: float) -> str:
+    """Green (low rejected ratio) → red (high). Clamped at 0.5 for saturation."""
+    t = min(ratio * 2.0, 1.0)
+    r = int(255 * t)
+    g = int(255 * (1.0 - t))
+    return f"#{r:02x}{g:02x}00"
+
+
+def render_places_map(places: list[Place], output_path: str) -> None:
+    if not places:
+        print("No places to map")
+        return
+
+    center_lat = sum(p.center_lat for p in places) / len(places)
+    center_lon = sum(p.center_lon for p in places) / len(places)
+    m = folium.Map(location=[center_lat, center_lon],
+                   zoom_start=13, tiles="CartoDB positron")
+
+    for p in places:
+        dwell_min = p.total_dwell_seconds / 60
+        folium.CircleMarker(
+            location=[p.center_lat, p.center_lon],
+            radius=6 + min(dwell_min / 30, 30),
+            color="#222", weight=1,
+            fill=True,
+            fill_color=_ratio_color(p.rejected_ratio),
+            fill_opacity=0.75,
+            popup=folium.Popup(
+                f"<b>Place {p.place_id}</b><br>"
+                f"({p.center_lat:.5f}, {p.center_lon:.5f})<br>"
+                f"r={p.radius_m:.0f} m · {p.visit_count} visits<br>"
+                f"dwell: {dwell_min:.0f} min<br>"
+                f"accepted: {p.accepted_count} · "
+                f"rejected: {p.rejected_count}<br>"
+                f"rejected ratio: {p.rejected_ratio:.1%}",
+                max_width=260,
+            ),
+        ).add_to(m)
+
+    m.save(output_path)
+    print(f"Places map: {output_path}")
+
+
+def render_filter_audit(places: list[Place],
+                        total_accepted: int,
+                        total_rejected: int,
+                        output_path: str) -> None:
+    fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(12, 4.2))
+
+    ax1.bar(["accepted", "rejected"],
+            [total_accepted, total_rejected],
+            color=["#4f81bd", "#c0392b"])
+    ax1.set_title("Total sample counts")
+    ax1.set_ylabel("count")
+    for i, v in enumerate([total_accepted, total_rejected]):
+        ax1.text(i, v, f"{v}", ha="center", va="bottom")
+
+    top = sorted(places,
+                 key=lambda p: p.accepted_count + p.rejected_count,
+                 reverse=True)[:15]
+    if top:
+        x = np.arange(len(top))
+        acc = [p.accepted_count for p in top]
+        rej = [p.rejected_count for p in top]
+        ax2.bar(x, acc, label="accepted", color="#4f81bd")
+        ax2.bar(x, rej, bottom=acc, label="rejected", color="#c0392b")
+        ax2.set_xticks(x)
+        ax2.set_xticklabels([f"#{p.place_id}" for p in top],
+                            rotation=45, ha="right")
+        ax2.set_title("Accepted vs. rejected per place (top 15 by volume)")
+        ax2.set_ylabel("count")
+        ax2.legend()
+
+    plt.tight_layout()
+    plt.savefig(output_path, dpi=130)
+    plt.close(fig)
+    print(f"Filter audit: {output_path}")
+
+
+def render_tod(places: list[Place], output_path: str, top_n: int = 9) -> None:
+    top = sorted(places, key=lambda p: p.total_dwell_seconds,
+                 reverse=True)[:top_n]
+    if not top:
+        print("No places for time-of-day plot")
+        return
+
+    cols = 3
+    rows = (len(top) + cols - 1) // cols
+    fig, axes = plt.subplots(rows, cols, figsize=(12, 3 * rows), squeeze=False)
+    flat = axes.flatten()
+
+    for ax, p in zip(flat, top):
+        hours = [s.timestamp.hour for s in p.accepted_samples]
+        ax.hist(hours, bins=range(25), color="#4f81bd", edgecolor="white")
+        ax.set_title(
+            f"Place {p.place_id} · "
+            f"{p.total_dwell_seconds / 3600:.1f}h dwell · "
+            f"{p.visit_count} visits",
+            fontsize=10,
+        )
+        ax.set_xlim(0, 24)
+        ax.set_xticks(range(0, 25, 6))
+        ax.set_xlabel("hour of day")
+        ax.set_ylabel("samples")
+
+    for ax in flat[len(top):]:
+        ax.axis("off")
+
+    plt.tight_layout()
+    plt.savefig(output_path, dpi=130)
+    plt.close(fig)
+    print(f"Time-of-day: {output_path}")
+
+
+def _behavior_features(samples: list) -> tuple[np.ndarray, list[str]]:
+    """Build a per-sample behavior feature matrix (no position)."""
+    rows = []
+    for s in samples:
+        speed = max(s.speed, 0.0)
+        h_acc = max(s.horizontal_accuracy, 0.0)
+        v_acc = max(s.vertical_accuracy, 0.0)
+        hour = s.timestamp.hour + s.timestamp.minute / 60.0
+        hour_sin = np.sin(2 * np.pi * hour / 24.0)
+        hour_cos = np.cos(2 * np.pi * hour / 24.0)
+        if s.course is not None and s.course >= 0:
+            course_rad = np.radians(s.course)
+            course_sin = np.sin(course_rad)
+            course_cos = np.cos(course_rad)
+        else:
+            course_sin = 0.0
+            course_cos = 0.0
+        rows.append([
+            speed,
+            np.log1p(h_acc),
+            np.log1p(v_acc),
+            hour_sin,
+            hour_cos,
+            course_sin,
+            course_cos,
+        ])
+    names = ["speed", "log_h_acc", "log_v_acc",
+             "hour_sin", "hour_cos", "course_sin", "course_cos"]
+    return np.array(rows, dtype=float), names
+
+
+def render_behavior_pca(samples: list, output_path: str) -> None:
+    """PCA of per-sample behavior features, colored by motion & filter."""
+    if len(samples) < 3:
+        print("Too few samples for behavior PCA")
+        return
+
+    X, feat_names = _behavior_features(samples)
+    X_scaled = StandardScaler().fit_transform(X)
+    pca = PCA(n_components=2)
+    Z = pca.fit_transform(X_scaled)
+    var = pca.explained_variance_ratio_
+
+    fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(13, 5.2))
+
+    activity_colors = {
+        "stationary": "#4f81bd",
+        "walking": "#2ca02c",
+        "running": "#8e44ad",
+        "cycling": "#ff7f0e",
+        "automotive": "#d62728",
+        "unknown": "#7f7f7f",
+        "": "#bdc3c7",
+    }
+    activities = [s.motion_activity or "" for s in samples]
+    for act in sorted(set(activities)):
+        mask = np.array([a == act for a in activities])
+        if not mask.any():
+            continue
+        ax1.scatter(Z[mask, 0], Z[mask, 1],
+                    s=8, alpha=0.55,
+                    color=activity_colors.get(act, "#95a5a6"),
+                    label=f"{act or 'n/a'} ({int(mask.sum())})")
+    ax1.set_title("Behavior PCA — colored by motion activity")
+    ax1.set_xlabel(f"PC1 ({var[0]:.1%})")
+    ax1.set_ylabel(f"PC2 ({var[1]:.1%})")
+    ax1.legend(fontsize=8, loc="best")
+    ax1.grid(True, alpha=0.2)
+
+    accepted = np.array([s.filter_status == "accepted" for s in samples])
+    ax2.scatter(Z[~accepted, 0], Z[~accepted, 1],
+                s=8, alpha=0.5, color="#c0392b",
+                label=f"rejected ({int((~accepted).sum())})")
+    ax2.scatter(Z[accepted, 0], Z[accepted, 1],
+                s=8, alpha=0.5, color="#1f77b4",
+                label=f"accepted ({int(accepted.sum())})")
+    ax2.set_title("Behavior PCA — colored by filter status")
+    ax2.set_xlabel(f"PC1 ({var[0]:.1%})")
+    ax2.set_ylabel(f"PC2 ({var[1]:.1%})")
+    ax2.legend(fontsize=8, loc="best")
+    ax2.grid(True, alpha=0.2)
+
+    loadings = pca.components_
+    footer = "PC1: " + ", ".join(
+        f"{n}{l:+.2f}" for n, l in zip(feat_names, loadings[0])
+    ) + "\nPC2: " + ", ".join(
+        f"{n}{l:+.2f}" for n, l in zip(feat_names, loadings[1])
+    )
+    fig.text(0.5, -0.02, footer, ha="center", va="top", fontsize=8,
+             family="monospace")
+
+    plt.tight_layout()
+    plt.savefig(output_path, dpi=130, bbox_inches="tight")
+    plt.close(fig)
+    print(f"Behavior PCA: {output_path}")
+
+
+def write_places_csv(places: list[Place], output_path: str) -> None:
+    with open(output_path, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow([
+            "place_id", "center_lat", "center_lon", "radius_m",
+            "accepted_count", "rejected_count", "rejected_ratio",
+            "visit_count", "total_dwell_minutes",
+            "first_seen", "last_seen",
+        ])
+        for p in places:
+            all_ts = [s.timestamp for s in p.accepted_samples]
+            writer.writerow([
+                p.place_id,
+                f"{p.center_lat:.6f}",
+                f"{p.center_lon:.6f}",
+                f"{p.radius_m:.1f}",
+                p.accepted_count,
+                p.rejected_count,
+                f"{p.rejected_ratio:.3f}",
+                p.visit_count,
+                f"{p.total_dwell_seconds / 60:.1f}",
+                min(all_ts).isoformat() if all_ts else "",
+                max(all_ts).isoformat() if all_ts else "",
+            ])
+    print(f"Places CSV: {output_path}")
+
+
+def run_place_analysis(csv_path: str,
+                       eps: float = 40,
+                       min_pts: int = 10,
+                       visit_gap: float = 600,
+                       output_dir: str = "") -> None:
+    """Run place discovery, filter audit, time-of-day, and behavior PCA."""
+    all_samples = load_csv(csv_path)
+    accepted = [s for s in all_samples if s.filter_status == "accepted"]
+    rejected = [s for s in all_samples if s.filter_status != "accepted"]
+    print(f"Loaded {len(all_samples)} samples "
+          f"({len(accepted)} accepted, {len(rejected)} rejected)")
+
+    places = cluster_places(accepted, eps, min_pts)
+    print(f"Discovered {len(places)} places "
+          f"(eps={eps}m, min_pts={min_pts})")
+
+    attached = assign_rejected_to_places(places, rejected, eps)
+    print(f"Attached {attached}/{len(rejected)} rejected samples to places "
+          f"(remaining {len(rejected) - attached} are off-place noise)")
+
+    for p in places:
+        compute_visits(p, visit_gap)
+
+    out = output_dir or (os.path.dirname(csv_path) or ".")
+    base = os.path.splitext(os.path.basename(csv_path))[0]
+
+    write_places_csv(places, os.path.join(out, f"{base}_places.csv"))
+    render_places_map(places, os.path.join(out, f"{base}_places.html"))
+    render_filter_audit(places, len(accepted), len(rejected),
+                        os.path.join(out, f"{base}_filter_audit.png"))
+    render_tod(places, os.path.join(out, f"{base}_tod.png"))
+    render_behavior_pca(all_samples,
+                        os.path.join(out, f"{base}_behavior.png"))

--- a/scripts/placenotes_analysis/trips.py
+++ b/scripts/placenotes_analysis/trips.py
@@ -1,0 +1,203 @@
+"""Visualization of stay points and trips from the ST-DBSCAN pipeline.
+
+Produces three artifacts:
+  - <base>_map.html     Folium map with stay points + trip polylines
+  - <base>_speed.png    Per-trip speed timelines (accepted vs. rejected)
+  - <base>_gantt.png    Day-level timeline of stays and trips
+"""
+
+import os
+
+import folium
+import matplotlib.dates as mdates
+import matplotlib.pyplot as plt
+
+from .pipeline import run_pipeline
+
+
+MODE_COLORS = {
+    "walk": "#2ca02c",
+    "bike": "#ff7f0e",
+    "drive": "#d62728",
+    "unknown": "#7f7f7f",
+}
+
+
+def render_map(samples, stay_points, trips, output_path: str) -> None:
+    if not samples:
+        print("No samples to render — skipping map")
+        return
+
+    center_lat = sum(s.latitude for s in samples) / len(samples)
+    center_lon = sum(s.longitude for s in samples) / len(samples)
+    m = folium.Map(location=[center_lat, center_lon], zoom_start=14,
+                   tiles="CartoDB positron")
+
+    stays_layer = folium.FeatureGroup(name="Stay points")
+    for sp in stay_points:
+        duration_min = (sp.departure - sp.arrival).total_seconds() / 60
+        folium.CircleMarker(
+            location=[sp.center_lat, sp.center_lon],
+            radius=6 + min(duration_min / 5, 24),
+            color="#1f4e79", weight=2,
+            fill=True, fill_color="#4f81bd", fill_opacity=0.5,
+            popup=folium.Popup(
+                f"<b>Stay {sp.cluster_id}</b><br>"
+                f"{sp.arrival:%H:%M}–{sp.departure:%H:%M}<br>"
+                f"{duration_min:.0f} min · {sp.sample_count} pts · "
+                f"r={sp.radius_m:.0f} m",
+                max_width=250),
+        ).add_to(stays_layer)
+    stays_layer.add_to(m)
+
+    trips_layer = folium.FeatureGroup(name="Trips")
+    samples_layer = folium.FeatureGroup(name="Trip samples")
+    for t in trips:
+        color = MODE_COLORS.get(t.transport_mode, "#7f7f7f")
+        coords = [(s.latitude, s.longitude) for s in t.samples]
+        if len(coords) >= 2:
+            avg_kmh = t.avg_speed_ms * 3.6 if t.avg_speed_ms >= 0 else float("nan")
+            folium.PolyLine(
+                coords, color=color, weight=5, opacity=0.85,
+                popup=folium.Popup(
+                    f"<b>Trip {t.trip_id}</b><br>"
+                    f"mode: {t.transport_mode}<br>"
+                    f"{t.start_time:%H:%M}–{t.end_time:%H:%M}<br>"
+                    f"{t.distance_m:.0f} m · avg {avg_kmh:.1f} km/h",
+                    max_width=260),
+            ).add_to(trips_layer)
+
+        for s in t.samples:
+            spd = f"{s.speed * 3.6:.1f} km/h" if s.speed >= 0 else "n/a"
+            is_accepted = s.filter_status == "accepted"
+            folium.CircleMarker(
+                location=[s.latitude, s.longitude],
+                radius=2.5,
+                color="#333" if is_accepted else "#c0392b",
+                weight=1,
+                fill=True,
+                fill_color="#333" if is_accepted else "#c0392b",
+                fill_opacity=0.8,
+                popup=folium.Popup(
+                    f"{s.timestamp:%H:%M:%S}<br>"
+                    f"speed: {spd}<br>"
+                    f"course: {s.course if s.course is not None else 'n/a'}<br>"
+                    f"status: {s.filter_status}",
+                    max_width=220),
+            ).add_to(samples_layer)
+    trips_layer.add_to(m)
+    samples_layer.add_to(m)
+
+    folium.LayerControl(collapsed=False).add_to(m)
+    m.save(output_path)
+    print(f"Map: {output_path}")
+
+
+def render_speed_timelines(trips, output_path: str) -> None:
+    trips_with_samples = [t for t in trips if t.samples]
+    n = len(trips_with_samples)
+    if n == 0:
+        print("No trips with samples — skipping speed timelines")
+        return
+
+    fig, axes = plt.subplots(n, 1, figsize=(11, 2.6 * n), squeeze=False)
+    axes = axes.flatten()
+
+    for ax, t in zip(axes, trips_with_samples):
+        acc = [(s.timestamp, s.speed * 3.6)
+               for s in t.samples
+               if s.filter_status == "accepted" and s.speed >= 0]
+        rej = [(s.timestamp, s.speed * 3.6)
+               for s in t.samples
+               if s.filter_status != "accepted" and s.speed >= 0]
+
+        if acc:
+            ax.scatter([p[0] for p in acc], [p[1] for p in acc],
+                       s=22, color="#1f77b4", label=f"accepted ({len(acc)})",
+                       zorder=3)
+        if rej:
+            ax.scatter([p[0] for p in rej], [p[1] for p in rej],
+                       s=22, color="#d62728", marker="x",
+                       label=f"rejected ({len(rej)})", zorder=3)
+
+        avg_kmh = t.avg_speed_ms * 3.6 if t.avg_speed_ms >= 0 else float("nan")
+        max_kmh = t.max_speed_ms * 3.6 if t.max_speed_ms >= 0 else float("nan")
+        ax.set_title(
+            f"Trip {t.trip_id} · {t.start_time:%H:%M}–{t.end_time:%H:%M} · "
+            f"mode={t.transport_mode} · avg {avg_kmh:.1f} km/h · "
+            f"max {max_kmh:.1f} km/h",
+            fontsize=10,
+        )
+        ax.set_ylabel("speed (km/h)")
+        ax.xaxis.set_major_formatter(mdates.DateFormatter("%H:%M"))
+        ax.grid(True, alpha=0.3)
+        if acc or rej:
+            ax.legend(loc="upper right", fontsize=8)
+
+    axes[-1].set_xlabel("time")
+    plt.tight_layout()
+    plt.savefig(output_path, dpi=130)
+    plt.close(fig)
+    print(f"Speed timelines: {output_path}")
+
+
+def render_day_gantt(stay_points, trips, output_path: str) -> None:
+    if not stay_points and not trips:
+        print("Nothing to plot — skipping gantt")
+        return
+
+    fig, ax = plt.subplots(figsize=(14, 2.6))
+    legend_seen = set()
+
+    def _bar(start, end, color, label):
+        width = mdates.date2num(end) - mdates.date2num(start)
+        show_label = label not in legend_seen
+        legend_seen.add(label)
+        ax.barh(0, width, left=mdates.date2num(start),
+                color=color, edgecolor="black", height=0.55,
+                label=label if show_label else None)
+
+    for sp in stay_points:
+        _bar(sp.arrival, sp.departure, "#4f81bd", "stay")
+
+    for t in trips:
+        color = MODE_COLORS.get(t.transport_mode, "#7f7f7f")
+        _bar(t.start_time, t.end_time, color, t.transport_mode)
+
+    ax.xaxis_date()
+    ax.xaxis.set_major_formatter(mdates.DateFormatter("%m-%d %H:%M"))
+    fig.autofmt_xdate()
+    ax.set_yticks([])
+    ax.set_title("Day timeline · stays and trips")
+    ax.legend(loc="upper right", fontsize=9, ncol=4)
+    plt.tight_layout()
+    plt.savefig(output_path, dpi=130)
+    plt.close(fig)
+    print(f"Gantt: {output_path}")
+
+
+def run_trip_visualization(csv_path: str,
+                           tau_gap: float = 600,
+                           eps: float = 50,
+                           min_pts: int = 3,
+                           use_all: bool = False,
+                           use_rejected_for_trips: bool = False,
+                           output_dir: str = "") -> None:
+    """Run the pipeline and render all three trip visualizations."""
+    samples, _, stay_points, trips = run_pipeline(
+        csv_path=csv_path,
+        tau_gap=tau_gap,
+        eps=eps,
+        min_pts=min_pts,
+        use_all=use_all,
+        use_rejected_for_trips=use_rejected_for_trips,
+        output_dir=output_dir,
+    )
+
+    out = output_dir or (os.path.dirname(csv_path) or ".")
+    base = os.path.splitext(os.path.basename(csv_path))[0]
+
+    render_map(samples, stay_points, trips,
+               os.path.join(out, f"{base}_map.html"))
+    render_speed_timelines(trips, os.path.join(out, f"{base}_speed.png"))
+    render_day_gantt(stay_points, trips, os.path.join(out, f"{base}_gantt.png"))


### PR DESCRIPTION
## Summary

- Split the three standalone scripts (`st_dbscan_pipeline.py`, `visualize_trips.py`, `cluster_analysis.py`) into a reusable `scripts/placenotes_analysis/` package — pure utility modules with no CLI.
- Introduce a single entry point `scripts/placenotes.py` supporting both one-line subcommands and an interactive prompt-driven mode.
- Keep the `--use_rejected_for_trips` flag so the app's speed-rejected samples still feed transport-mode inference inside trip bodies while stay-point detection stays on accepted-only.

## New layout

```
scripts/
  placenotes.py                    # single entry point (PEP 723 deps via uv)
  placenotes_analysis/
    __init__.py                    # re-exports public API
    pipeline.py                    # ST-DBSCAN: load_csv, run_pipeline, stay-points, trips
    trips.py                       # folium map + speed timelines + day gantt
    places.py                      # place discovery, filter audit, time-of-day, behavior PCA
```

## Usage

```bash
# interactive (prompts for CSV, action, params with defaults)
uv run scripts/placenotes.py

# one-line subcommands
uv run scripts/placenotes.py pipeline <csv>
uv run scripts/placenotes.py trips    <csv> [--use_rejected_for_trips]
uv run scripts/placenotes.py places   <csv> [--eps 40] [--min_pts 10]
uv run scripts/placenotes.py all      <csv>
```

Library modules stay CLI-free, so a notebook or REPL can `from placenotes_analysis import run_place_analysis`.

## Test plan

- [x] `uv run scripts/placenotes.py --help` resolves all imports and lists subcommands
- [x] `uv run scripts/placenotes.py trips --help` shows flags including `--use_rejected_for_trips`
- [x] Run `uv run scripts/placenotes.py all <your-csv>` against a real export and eyeball the outputs (`*_map.html`, `*_places.html`, `*_behavior.png`, etc.)
- [x] Run interactive mode end-to-end with defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)