### PR TITLE
Day Trajectory on Map

### DIFF
--- a/PlaceNotes/Services/DebugSeed.swift
+++ b/PlaceNotes/Services/DebugSeed.swift
@@ -1,0 +1,205 @@
+#if DEBUG
+import Foundation
+import SwiftData
+
+/// Generates synthetic Places, Visits, and RawLocationSamples so the trajectory
+/// feature can be exercised on a fresh simulator without waiting hours for
+/// real CoreLocation fixes. DEBUG builds only.
+///
+/// All generated samples are marked `filterStatus = "accepted"` so the
+/// trajectory query (which filters to accepted samples) renders the full path.
+/// In real-world use the LocationManager classifies samples with speed > 2 m/s
+/// as "rejected-speed", so on-device data won't include the driving segments —
+/// the seed therefore shows the *intended* feature behavior, which is more
+/// useful for verification than real data would be.
+enum DebugSeed {
+
+    @MainActor
+    static func seedSampleTrajectories(in context: ModelContext) {
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: Date())
+
+        let home = Coord(lat: 37.7649, lon: -122.4194)
+        let coffee = Coord(lat: 37.7706, lon: -122.4128)
+        let work = Coord(lat: 37.7858, lon: -122.4065)
+        let restaurant = Coord(lat: 37.7795, lon: -122.4143)
+
+        let homePlace = Place(name: "Home", latitude: home.lat, longitude: home.lon, category: "Home", city: "San Francisco", state: "CA")
+        let coffeePlace = Place(name: "Blue Bottle Coffee", latitude: coffee.lat, longitude: coffee.lon, category: "Café", city: "San Francisco", state: "CA")
+        let workPlace = Place(name: "Office", latitude: work.lat, longitude: work.lon, category: "Work", city: "San Francisco", state: "CA")
+        let restaurantPlace = Place(name: "Tartine", latitude: restaurant.lat, longitude: restaurant.lon, category: "Restaurant", city: "San Francisco", state: "CA")
+
+        for place in [homePlace, coffeePlace, workPlace, restaurantPlace] {
+            context.insert(place)
+        }
+
+        var samples: [RawLocationSample] = []
+
+        // Day 0 (today) — golden path: Home → Coffee → Work → Restaurant → Home.
+        seedGoldenPath(
+            day: today,
+            home: home, coffee: coffee, work: work, restaurant: restaurant,
+            homePlace: homePlace, coffeePlace: coffeePlace,
+            workPlace: workPlace, restaurantPlace: restaurantPlace,
+            samples: &samples,
+            context: context
+        )
+
+        // Day -1 — samples but no qualifying visits (just transit through SF).
+        let dayMinus1 = calendar.date(byAdding: .day, value: -1, to: today) ?? today
+        let routeStart = Coord(lat: 37.7649, lon: -122.4194)
+        let routeMid1 = Coord(lat: 37.7700, lon: -122.4150)
+        let routeMid2 = Coord(lat: 37.7750, lon: -122.4100)
+        let routeEnd = Coord(lat: 37.7800, lon: -122.4050)
+        samples += transitSamples(from: routeStart, to: routeMid1, start: timeOf(day: dayMinus1, hour: 10, minute: 0), end: timeOf(day: dayMinus1, hour: 10, minute: 30))
+        samples += transitSamples(from: routeMid1, to: routeMid2, start: timeOf(day: dayMinus1, hour: 10, minute: 30), end: timeOf(day: dayMinus1, hour: 11, minute: 0))
+        samples += transitSamples(from: routeMid2, to: routeEnd, start: timeOf(day: dayMinus1, hour: 11, minute: 0), end: timeOf(day: dayMinus1, hour: 11, minute: 30))
+
+        // Day -2 — visits but no GPS samples (e.g., feature added after this history existed).
+        let dayMinus2 = calendar.date(byAdding: .day, value: -2, to: today) ?? today
+        let visitNoSamples1 = Visit(arrivalDate: timeOf(day: dayMinus2, hour: 9, minute: 0), departureDate: timeOf(day: dayMinus2, hour: 9, minute: 30), place: coffeePlace)
+        let visitNoSamples2 = Visit(arrivalDate: timeOf(day: dayMinus2, hour: 10, minute: 0), departureDate: timeOf(day: dayMinus2, hour: 17, minute: 0), place: workPlace)
+        for v in [visitNoSamples1, visitNoSamples2] {
+            v.confidence = .high
+            v.medianAccuracyMeters = 12
+            context.insert(v)
+        }
+
+        // Day -3 — phone-off gap > 10 min (polyline should visibly break).
+        let dayMinus3 = calendar.date(byAdding: .day, value: -3, to: today) ?? today
+        let gapVisit1 = Visit(arrivalDate: timeOf(day: dayMinus3, hour: 8, minute: 0), departureDate: timeOf(day: dayMinus3, hour: 8, minute: 30), place: homePlace)
+        let gapVisit2 = Visit(arrivalDate: timeOf(day: dayMinus3, hour: 11, minute: 0), departureDate: timeOf(day: dayMinus3, hour: 12, minute: 0), place: workPlace)
+        for v in [gapVisit1, gapVisit2] {
+            v.confidence = .high
+            v.medianAccuracyMeters = 12
+            context.insert(v)
+        }
+        samples += clusterSamples(at: home, start: timeOf(day: dayMinus3, hour: 8, minute: 0), end: timeOf(day: dayMinus3, hour: 8, minute: 30), interval: 60)
+        // 8:30 → 10:50 = 140-minute gap — phone off.
+        samples += transitSamples(from: home, to: work, start: timeOf(day: dayMinus3, hour: 10, minute: 50), end: timeOf(day: dayMinus3, hour: 11, minute: 0))
+        samples += clusterSamples(at: work, start: timeOf(day: dayMinus3, hour: 11, minute: 0), end: timeOf(day: dayMinus3, hour: 12, minute: 0), interval: 60)
+
+        for sample in samples {
+            context.insert(sample)
+        }
+
+        try? context.save()
+    }
+
+    @MainActor
+    static func clearAllData(in context: ModelContext) {
+        deleteAll(of: RawLocationSample.self, in: context)
+        deleteAll(of: JournalEntry.self, in: context)
+        deleteAll(of: Visit.self, in: context)
+        deleteAll(of: Place.self, in: context)
+        try? context.save()
+    }
+
+    // MARK: - Day 0 (golden path)
+
+    @MainActor
+    private static func seedGoldenPath(
+        day: Date,
+        home: Coord, coffee: Coord, work: Coord, restaurant: Coord,
+        homePlace: Place, coffeePlace: Place, workPlace: Place, restaurantPlace: Place,
+        samples: inout [RawLocationSample],
+        context: ModelContext
+    ) {
+        let visits = [
+            Visit(arrivalDate: timeOf(day: day, hour: 8, minute: 0),  departureDate: timeOf(day: day, hour: 8, minute: 30), place: homePlace),
+            Visit(arrivalDate: timeOf(day: day, hour: 8, minute: 40), departureDate: timeOf(day: day, hour: 9, minute: 5),  place: coffeePlace),
+            Visit(arrivalDate: timeOf(day: day, hour: 9, minute: 20), departureDate: timeOf(day: day, hour: 17, minute: 30), place: workPlace),
+            Visit(arrivalDate: timeOf(day: day, hour: 18, minute: 0), departureDate: timeOf(day: day, hour: 19, minute: 30), place: restaurantPlace),
+            Visit(arrivalDate: timeOf(day: day, hour: 19, minute: 50), departureDate: timeOf(day: day, hour: 22, minute: 0), place: homePlace)
+        ]
+        for v in visits {
+            v.confidence = .high
+            v.medianAccuracyMeters = 12
+            context.insert(v)
+        }
+
+        samples += clusterSamples(at: home,       start: timeOf(day: day, hour: 8,  minute: 0),  end: timeOf(day: day, hour: 8,  minute: 30), interval: 60)
+        samples += transitSamples(from: home,     to: coffee,     start: timeOf(day: day, hour: 8,  minute: 30), end: timeOf(day: day, hour: 8,  minute: 40))
+        samples += clusterSamples(at: coffee,     start: timeOf(day: day, hour: 8,  minute: 40), end: timeOf(day: day, hour: 9,  minute: 5),  interval: 60)
+        samples += transitSamples(from: coffee,   to: work,       start: timeOf(day: day, hour: 9,  minute: 5),  end: timeOf(day: day, hour: 9,  minute: 20))
+        // Sparse during the workday — OS slows updates when stationary.
+        samples += clusterSamples(at: work,       start: timeOf(day: day, hour: 9,  minute: 20), end: timeOf(day: day, hour: 17, minute: 30), interval: 300)
+        samples += transitSamples(from: work,     to: restaurant, start: timeOf(day: day, hour: 17, minute: 30), end: timeOf(day: day, hour: 18, minute: 0))
+        samples += clusterSamples(at: restaurant, start: timeOf(day: day, hour: 18, minute: 0),  end: timeOf(day: day, hour: 19, minute: 30), interval: 60)
+        samples += transitSamples(from: restaurant, to: home,     start: timeOf(day: day, hour: 19, minute: 30), end: timeOf(day: day, hour: 19, minute: 50))
+        samples += clusterSamples(at: home,       start: timeOf(day: day, hour: 19, minute: 50), end: timeOf(day: day, hour: 22, minute: 0),  interval: 300)
+    }
+
+    // MARK: - Sample generators
+
+    private struct Coord {
+        let lat: Double
+        let lon: Double
+    }
+
+    private static func clusterSamples(at point: Coord, start: Date, end: Date, interval: TimeInterval) -> [RawLocationSample] {
+        var result: [RawLocationSample] = []
+        var t = start
+        while t <= end {
+            let jitterLat = Double.random(in: -0.00005...0.00005)
+            let jitterLon = Double.random(in: -0.00005...0.00005)
+            result.append(RawLocationSample(
+                latitude: point.lat + jitterLat,
+                longitude: point.lon + jitterLon,
+                timestamp: t,
+                horizontalAccuracy: Double.random(in: 8...15),
+                speed: 0,
+                altitude: 50,
+                verticalAccuracy: 5,
+                course: nil,
+                filterStatus: "accepted"
+            ))
+            t = t.addingTimeInterval(interval)
+        }
+        return result
+    }
+
+    private static func transitSamples(from a: Coord, to b: Coord, start: Date, end: Date) -> [RawLocationSample] {
+        let duration = end.timeIntervalSince(start)
+        guard duration > 0 else { return [] }
+        let intervalSec: TimeInterval = 20
+        let count = max(2, Int(duration / intervalSec))
+        var result: [RawLocationSample] = []
+        for i in 0...count {
+            let progress = Double(i) / Double(count)
+            let lat = a.lat + (b.lat - a.lat) * progress + Double.random(in: -0.00003...0.00003)
+            let lon = a.lon + (b.lon - a.lon) * progress + Double.random(in: -0.00003...0.00003)
+            let timestamp = start.addingTimeInterval(duration * progress)
+            result.append(RawLocationSample(
+                latitude: lat,
+                longitude: lon,
+                timestamp: timestamp,
+                horizontalAccuracy: Double.random(in: 8...15),
+                speed: 1.5,
+                altitude: 50,
+                verticalAccuracy: 5,
+                course: nil,
+                filterStatus: "accepted"
+            ))
+        }
+        return result
+    }
+
+    // MARK: - Time helper
+
+    private static func timeOf(day: Date, hour: Int, minute: Int) -> Date {
+        Calendar.current.date(bySettingHour: hour, minute: minute, second: 0, of: day) ?? day
+    }
+
+    // MARK: - Bulk delete helper
+
+    @MainActor
+    private static func deleteAll<T: PersistentModel>(of type: T.Type, in context: ModelContext) {
+        let descriptor = FetchDescriptor<T>()
+        let items = (try? context.fetch(descriptor)) ?? []
+        for item in items {
+            context.delete(item)
+        }
+    }
+}
+#endif

--- a/PlaceNotes/Services/TrajectoryBuilder.swift
+++ b/PlaceNotes/Services/TrajectoryBuilder.swift
@@ -27,4 +27,67 @@ enum TrajectoryBuilder {
         result.append(current)
         return result
     }
+
+    /// Douglas–Peucker line simplification. Drops points whose perpendicular
+    /// distance from the local approximation line is < `epsilonMeters`.
+    /// Uses an equirectangular projection around the input's midpoint — good
+    /// enough at the few-km scale a single day's path occupies.
+    static func simplify(
+        _ points: [TrajectoryPoint],
+        epsilonMeters: Double
+    ) -> [TrajectoryPoint] {
+        guard points.count > 2 else { return points }
+
+        let midLat = (points.first!.coordinate.latitude + points.last!.coordinate.latitude) / 2
+        let metersPerDegLat = 111_320.0
+        let metersPerDegLon = 111_320.0 * cos(midLat * .pi / 180)
+
+        func project(_ c: CLLocationCoordinate2D) -> (x: Double, y: Double) {
+            (x: c.longitude * metersPerDegLon, y: c.latitude * metersPerDegLat)
+        }
+
+        func perpendicularDistance(
+            _ p: CLLocationCoordinate2D,
+            from a: CLLocationCoordinate2D,
+            to b: CLLocationCoordinate2D
+        ) -> Double {
+            let pp = project(p), pa = project(a), pb = project(b)
+            let dx = pb.x - pa.x
+            let dy = pb.y - pa.y
+            let lengthSq = dx * dx + dy * dy
+            if lengthSq == 0 {
+                let ex = pp.x - pa.x, ey = pp.y - pa.y
+                return (ex * ex + ey * ey).squareRoot()
+            }
+            let cross = abs((pp.x - pa.x) * dy - (pp.y - pa.y) * dx)
+            return cross / lengthSq.squareRoot()
+        }
+
+        func recurse(start: Int, end: Int, into keep: inout [Bool]) {
+            guard end > start + 1 else { return }
+            var maxDist = 0.0
+            var maxIdx = start
+            let a = points[start].coordinate
+            let b = points[end].coordinate
+            for i in (start + 1)..<end {
+                let d = perpendicularDistance(points[i].coordinate, from: a, to: b)
+                if d > maxDist {
+                    maxDist = d
+                    maxIdx = i
+                }
+            }
+            if maxDist > epsilonMeters {
+                keep[maxIdx] = true
+                recurse(start: start, end: maxIdx, into: &keep)
+                recurse(start: maxIdx, end: end, into: &keep)
+            }
+        }
+
+        var keep = [Bool](repeating: false, count: points.count)
+        keep[0] = true
+        keep[points.count - 1] = true
+        recurse(start: 0, end: points.count - 1, into: &keep)
+
+        return zip(points, keep).compactMap { $0.1 ? $0.0 : nil }
+    }
 }

--- a/PlaceNotes/Services/TrajectoryBuilder.swift
+++ b/PlaceNotes/Services/TrajectoryBuilder.swift
@@ -93,13 +93,12 @@ enum TrajectoryBuilder {
 
     static func computeStats(
         segments: [TrajectorySegment],
+        rawSampleCount: Int,
         placeCount: Int
     ) -> TrajectoryStats {
         var totalDistance: Double = 0
-        var totalSamples = 0
 
         for segment in segments {
-            totalSamples += segment.points.count
             guard segment.points.count > 1 else { continue }
             for i in 1..<segment.points.count {
                 let a = segment.points[i - 1].coordinate
@@ -112,7 +111,7 @@ enum TrajectoryBuilder {
 
         return TrajectoryStats(
             totalDistanceMeters: totalDistance,
-            sampleCount: totalSamples,
+            rawSampleCount: rawSampleCount,
             segmentCount: segments.count,
             placeCount: placeCount
         )

--- a/PlaceNotes/Services/TrajectoryBuilder.swift
+++ b/PlaceNotes/Services/TrajectoryBuilder.swift
@@ -1,0 +1,30 @@
+import Foundation
+import CoreLocation
+
+enum TrajectoryBuilder {
+    /// Split a chronologically sorted run of samples wherever the temporal gap
+    /// between consecutive samples is **strictly greater than** `maxGapSeconds`.
+    /// Without this we would draw a "teleport" line across the gap.
+    static func splitIntoSegments(
+        _ samples: [RawLocationSample],
+        maxGapSeconds: TimeInterval
+    ) -> [[RawLocationSample]] {
+        guard !samples.isEmpty else { return [] }
+
+        var result: [[RawLocationSample]] = []
+        var current: [RawLocationSample] = [samples[0]]
+
+        for i in 1..<samples.count {
+            let prev = samples[i - 1]
+            let next = samples[i]
+            if next.timestamp.timeIntervalSince(prev.timestamp) > maxGapSeconds {
+                result.append(current)
+                current = [next]
+            } else {
+                current.append(next)
+            }
+        }
+        result.append(current)
+        return result
+    }
+}

--- a/PlaceNotes/Services/TrajectoryBuilder.swift
+++ b/PlaceNotes/Services/TrajectoryBuilder.swift
@@ -38,7 +38,7 @@ enum TrajectoryBuilder {
     ) -> [TrajectoryPoint] {
         guard points.count > 2 else { return points }
 
-        let midLat = (points.first!.coordinate.latitude + points.last!.coordinate.latitude) / 2
+        let midLat = (points[0].coordinate.latitude + points[points.count - 1].coordinate.latitude) / 2
         let metersPerDegLat = 111_320.0
         let metersPerDegLon = 111_320.0 * cos(midLat * .pi / 180)
 

--- a/PlaceNotes/Services/TrajectoryBuilder.swift
+++ b/PlaceNotes/Services/TrajectoryBuilder.swift
@@ -135,19 +135,27 @@ enum TrajectoryBuilder {
         }
     }
 
-    static func convertToPoints(
+    private static func convertToPoints(
         _ samples: [RawLocationSample],
         dayStart: Date
     ) -> [TrajectoryPoint] {
-        let dayLength: TimeInterval = 86_400
+        // Use the calendar to compute day length so DST transitions (23h or 25h
+        // local days) produce a normalizedTimeOfDay that doesn't drift past 1.
+        let nextDay = Calendar.current.date(byAdding: .day, value: 1, to: dayStart) ?? dayStart.addingTimeInterval(86_400)
+        let dayLength = nextDay.timeIntervalSince(dayStart)
+
         return samples.map { s in
             let raw = s.timestamp.timeIntervalSince(dayStart) / dayLength
             let normalized = min(1.0, max(0.0, raw))
+            // CoreLocation reports speed = -1 when unknown. v1 doesn't render
+            // speed, so coerce to 0; if the v2 .speed color mode lands, this
+            // should be revisited (likely promote speedMetersPerSecond to optional).
+            let speed = max(0, s.speed)
             return TrajectoryPoint(
                 coordinate: CLLocationCoordinate2D(latitude: s.latitude, longitude: s.longitude),
                 timestamp: s.timestamp,
                 normalizedTimeOfDay: normalized,
-                speedMetersPerSecond: max(0, s.speed)
+                speedMetersPerSecond: speed
             )
         }
     }

--- a/PlaceNotes/Services/TrajectoryBuilder.swift
+++ b/PlaceNotes/Services/TrajectoryBuilder.swift
@@ -117,4 +117,38 @@ enum TrajectoryBuilder {
             placeCount: placeCount
         )
     }
+
+    static func build(
+        samples: [RawLocationSample],
+        day: Date,
+        epsilonMeters: Double = 5,
+        maxGapSeconds: TimeInterval = 600
+    ) -> [TrajectorySegment] {
+        let dayStart = Calendar.current.startOfDay(for: day)
+        let raw = splitIntoSegments(samples, maxGapSeconds: maxGapSeconds)
+
+        return raw.compactMap { rawSegment in
+            let points = convertToPoints(rawSegment, dayStart: dayStart)
+            let simplified = simplify(points, epsilonMeters: epsilonMeters)
+            guard simplified.count >= 2 else { return nil }
+            return TrajectorySegment(points: simplified)
+        }
+    }
+
+    static func convertToPoints(
+        _ samples: [RawLocationSample],
+        dayStart: Date
+    ) -> [TrajectoryPoint] {
+        let dayLength: TimeInterval = 86_400
+        return samples.map { s in
+            let raw = s.timestamp.timeIntervalSince(dayStart) / dayLength
+            let normalized = min(1.0, max(0.0, raw))
+            return TrajectoryPoint(
+                coordinate: CLLocationCoordinate2D(latitude: s.latitude, longitude: s.longitude),
+                timestamp: s.timestamp,
+                normalizedTimeOfDay: normalized,
+                speedMetersPerSecond: max(0, s.speed)
+            )
+        }
+    }
 }

--- a/PlaceNotes/Services/TrajectoryBuilder.swift
+++ b/PlaceNotes/Services/TrajectoryBuilder.swift
@@ -90,4 +90,31 @@ enum TrajectoryBuilder {
 
         return zip(points, keep).compactMap { $0.1 ? $0.0 : nil }
     }
+
+    static func computeStats(
+        segments: [TrajectorySegment],
+        placeCount: Int
+    ) -> TrajectoryStats {
+        var totalDistance: Double = 0
+        var totalSamples = 0
+
+        for segment in segments {
+            totalSamples += segment.points.count
+            guard segment.points.count > 1 else { continue }
+            for i in 1..<segment.points.count {
+                let a = segment.points[i - 1].coordinate
+                let b = segment.points[i].coordinate
+                let aLoc = CLLocation(latitude: a.latitude, longitude: a.longitude)
+                let bLoc = CLLocation(latitude: b.latitude, longitude: b.longitude)
+                totalDistance += aLoc.distance(from: bLoc)
+            }
+        }
+
+        return TrajectoryStats(
+            totalDistanceMeters: totalDistance,
+            sampleCount: totalSamples,
+            segmentCount: segments.count,
+            placeCount: placeCount
+        )
+    }
 }

--- a/PlaceNotes/Services/TrajectoryTypes.swift
+++ b/PlaceNotes/Services/TrajectoryTypes.swift
@@ -1,0 +1,27 @@
+import Foundation
+import CoreLocation
+
+struct TrajectoryPoint {
+    let coordinate: CLLocationCoordinate2D
+    let timestamp: Date
+    /// Position within the day's local 0:00–24:00 window, clamped to 0...1.
+    let normalizedTimeOfDay: Double
+    let speedMetersPerSecond: Double
+}
+
+struct TrajectorySegment {
+    let points: [TrajectoryPoint]
+}
+
+struct TrajectoryStats {
+    let totalDistanceMeters: Double
+    let sampleCount: Int
+    let segmentCount: Int
+    let placeCount: Int
+}
+
+enum TrajectoryColorMode {
+    case time
+    case speed
+    case plain
+}

--- a/PlaceNotes/Services/TrajectoryTypes.swift
+++ b/PlaceNotes/Services/TrajectoryTypes.swift
@@ -15,7 +15,7 @@ struct TrajectorySegment {
 
 struct TrajectoryStats {
     let totalDistanceMeters: Double
-    let sampleCount: Int
+    let rawSampleCount: Int
     let segmentCount: Int
     let placeCount: Int
 }

--- a/PlaceNotes/Views/DayTrajectoryView.swift
+++ b/PlaceNotes/Views/DayTrajectoryView.swift
@@ -1,0 +1,153 @@
+import SwiftUI
+import SwiftData
+import MapKit
+
+struct DayTrajectoryView: View {
+    @Environment(\.modelContext) private var modelContext
+    let day: Date
+
+    @State private var segments: [TrajectorySegment] = []
+    @State private var stats: TrajectoryStats?
+    @State private var dayPlaces: [Place] = []
+    @State private var selectedPlace: Place?
+    @State private var cameraPosition: MapCameraPosition = .automatic
+    @State private var hasLoaded = false
+
+    private var isPathAvailable: Bool { !segments.isEmpty }
+
+    var body: some View {
+        ZStack(alignment: .top) {
+            Map(position: $cameraPosition, selection: $selectedPlace) {
+                TrajectoryPolyline(segments: segments, colorMode: .time)
+
+                ForEach(rankings(), id: \.id) { ranking in
+                    Annotation(
+                        ranking.place.displayName,
+                        coordinate: ranking.place.coordinate
+                    ) {
+                        PlaceAnnotationView(ranking: ranking)
+                    }
+                    .tag(ranking.place)
+                }
+            }
+            .mapStyle(.standard(showsTraffic: false))
+            .mapControls {
+                MapCompass()
+                MapScaleView()
+            }
+
+            TrajectoryHeaderCard(day: day, stats: stats, isPathAvailable: isPathAvailable)
+                .padding(.horizontal, 16)
+                .padding(.top, 8)
+
+            if !isPathAvailable && dayPlaces.isEmpty {
+                emptyOverlay
+            }
+        }
+        .navigationTitle(navTitle)
+        .navigationBarTitleDisplayMode(.inline)
+        .sheet(item: $selectedPlace) { place in
+            PlaceDetailSheet(place: place)
+                .presentationDetents([.medium])
+        }
+        .task {
+            guard !hasLoaded else { return }
+            hasLoaded = true
+            await load()
+        }
+    }
+
+    private var navTitle: String {
+        let f = DateFormatter()
+        f.dateFormat = "MMM d"
+        return f.string(from: day)
+    }
+
+    private var emptyOverlay: some View {
+        VStack {
+            Spacer()
+            Text("No location data recorded for this day")
+                .font(.callout)
+                .padding(12)
+                .background(.regularMaterial)
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+                .padding(.bottom, 32)
+        }
+    }
+
+    /// Build a synthetic ranking-per-place so we can reuse PlaceAnnotationView.
+    /// `qualifiedStays` and `totalMinutes` here are scoped to this day only.
+    private func rankings() -> [PlaceRanking] {
+        let calendar = Calendar.current
+        let dayStart = calendar.startOfDay(for: day)
+        let dayEnd = calendar.date(byAdding: .day, value: 1, to: dayStart)!
+        return dayPlaces.map { place in
+            let visitsToday = place.visits.filter {
+                $0.arrivalDate >= dayStart && $0.arrivalDate < dayEnd
+            }
+            let minutesToday = visitsToday.reduce(0) { $0 + $1.durationMinutes }
+            return PlaceRanking(
+                place: place,
+                qualifiedStays: visitsToday.count,
+                totalMinutes: minutesToday
+            )
+        }
+    }
+
+    private func load() async {
+        let calendar = Calendar.current
+        let dayStart = calendar.startOfDay(for: day)
+        let dayEnd = calendar.date(byAdding: .day, value: 1, to: dayStart)!
+
+        let sampleDescriptor = FetchDescriptor<RawLocationSample>(
+            predicate: #Predicate {
+                $0.timestamp >= dayStart
+                && $0.timestamp < dayEnd
+                && $0.filterStatus == "accepted"
+            },
+            sortBy: [SortDescriptor(\.timestamp)]
+        )
+        let samples = (try? modelContext.fetch(sampleDescriptor)) ?? []
+
+        let placeDescriptor = FetchDescriptor<Place>()
+        let allPlaces = (try? modelContext.fetch(placeDescriptor)) ?? []
+        let placesToday = allPlaces.filter { place in
+            place.visits.contains { $0.arrivalDate >= dayStart && $0.arrivalDate < dayEnd }
+        }
+
+        let builtSegments = TrajectoryBuilder.build(samples: samples, day: day)
+        let computedStats = TrajectoryBuilder.computeStats(
+            segments: builtSegments,
+            placeCount: placesToday.count
+        )
+
+        await MainActor.run {
+            self.segments = builtSegments
+            self.dayPlaces = placesToday
+            self.stats = computedStats
+            self.cameraPosition = initialCamera(segments: builtSegments, places: placesToday)
+        }
+    }
+
+    private func initialCamera(
+        segments: [TrajectorySegment],
+        places: [Place]
+    ) -> MapCameraPosition {
+        var coords: [CLLocationCoordinate2D] = []
+        coords.append(contentsOf: segments.flatMap { $0.points.map(\.coordinate) })
+        coords.append(contentsOf: places.map(\.coordinate))
+        guard !coords.isEmpty else { return .automatic }
+
+        let lats = coords.map(\.latitude)
+        let lons = coords.map(\.longitude)
+        let center = CLLocationCoordinate2D(
+            latitude: (lats.min()! + lats.max()!) / 2,
+            longitude: (lons.min()! + lons.max()!) / 2
+        )
+        let span = MKCoordinateSpan(
+            latitudeDelta: max(0.005, (lats.max()! - lats.min()!) * 1.4),
+            longitudeDelta: max(0.005, (lons.max()! - lons.min()!) * 1.4)
+        )
+        return .region(MKCoordinateRegion(center: center, span: span))
+    }
+}

--- a/PlaceNotes/Views/DayTrajectoryView.swift
+++ b/PlaceNotes/Views/DayTrajectoryView.swift
@@ -28,7 +28,7 @@ struct DayTrajectoryView: View {
     }
 
     var body: some View {
-        ZStack(alignment: .top) {
+        ZStack {
             Map(position: $cameraPosition, selection: $selectedPlace) {
                 TrajectoryPolyline(segments: segments, colorMode: .time)
 
@@ -48,9 +48,33 @@ struct DayTrajectoryView: View {
                 MapScaleView()
             }
 
-            TrajectoryHeaderCard(day: day, stats: stats, isPathAvailable: isPathAvailable)
-                .padding(.horizontal, 16)
-                .padding(.top, 8)
+            VStack {
+                TrajectoryHeaderCard(day: day, stats: stats, isPathAvailable: isPathAvailable)
+                    .padding(.horizontal, 16)
+                    .padding(.top, 8)
+                Spacer()
+            }
+
+            VStack {
+                Spacer()
+                HStack {
+                    Spacer()
+                    Button {
+                        withAnimation {
+                            cameraPosition = initialCamera(segments: segments, places: dayPlaces)
+                        }
+                    } label: {
+                        Image(systemName: "scope")
+                            .font(.title3)
+                            .padding(12)
+                            .background(.regularMaterial)
+                            .clipShape(Circle())
+                            .shadow(radius: 2)
+                    }
+                    .padding(.trailing, 16)
+                    .padding(.bottom, 24)
+                }
+            }
 
             if !isPathAvailable && dayPlaces.isEmpty {
                 emptyOverlay
@@ -124,6 +148,7 @@ struct DayTrajectoryView: View {
         let builtSegments = TrajectoryBuilder.build(samples: samples, day: day)
         let computedStats = TrajectoryBuilder.computeStats(
             segments: builtSegments,
+            rawSampleCount: samples.count,
             placeCount: placesToday.count
         )
 

--- a/PlaceNotes/Views/DayTrajectoryView.swift
+++ b/PlaceNotes/Views/DayTrajectoryView.swift
@@ -11,9 +11,21 @@ struct DayTrajectoryView: View {
     @State private var dayPlaces: [Place] = []
     @State private var selectedPlace: Place?
     @State private var cameraPosition: MapCameraPosition = .automatic
-    @State private var hasLoaded = false
+
+    private static let navTitleFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "MMM d"
+        return f
+    }()
 
     private var isPathAvailable: Bool { !segments.isEmpty }
+
+    private var dayRange: (start: Date, end: Date) {
+        let calendar = Calendar.current
+        let start = calendar.startOfDay(for: day)
+        let end = calendar.date(byAdding: .day, value: 1, to: start) ?? start.addingTimeInterval(86_400)
+        return (start, end)
+    }
 
     var body: some View {
         ZStack(alignment: .top) {
@@ -50,17 +62,13 @@ struct DayTrajectoryView: View {
             PlaceDetailSheet(place: place)
                 .presentationDetents([.medium])
         }
-        .task {
-            guard !hasLoaded else { return }
-            hasLoaded = true
+        .task(id: day) {
             await load()
         }
     }
 
     private var navTitle: String {
-        let f = DateFormatter()
-        f.dateFormat = "MMM d"
-        return f.string(from: day)
+        Self.navTitleFormatter.string(from: day)
     }
 
     private var emptyOverlay: some View {
@@ -78,12 +86,10 @@ struct DayTrajectoryView: View {
     /// Build a synthetic ranking-per-place so we can reuse PlaceAnnotationView.
     /// `qualifiedStays` and `totalMinutes` here are scoped to this day only.
     private func rankings() -> [PlaceRanking] {
-        let calendar = Calendar.current
-        let dayStart = calendar.startOfDay(for: day)
-        let dayEnd = calendar.date(byAdding: .day, value: 1, to: dayStart)!
+        let range = dayRange
         return dayPlaces.map { place in
             let visitsToday = place.visits.filter {
-                $0.arrivalDate >= dayStart && $0.arrivalDate < dayEnd
+                $0.arrivalDate >= range.start && $0.arrivalDate < range.end
             }
             let minutesToday = visitsToday.reduce(0) { $0 + $1.durationMinutes }
             return PlaceRanking(
@@ -95,9 +101,9 @@ struct DayTrajectoryView: View {
     }
 
     private func load() async {
-        let calendar = Calendar.current
-        let dayStart = calendar.startOfDay(for: day)
-        let dayEnd = calendar.date(byAdding: .day, value: 1, to: dayStart)!
+        let range = dayRange
+        let dayStart = range.start
+        let dayEnd = range.end
 
         let sampleDescriptor = FetchDescriptor<RawLocationSample>(
             predicate: #Predicate {
@@ -121,12 +127,10 @@ struct DayTrajectoryView: View {
             placeCount: placesToday.count
         )
 
-        await MainActor.run {
-            self.segments = builtSegments
-            self.dayPlaces = placesToday
-            self.stats = computedStats
-            self.cameraPosition = initialCamera(segments: builtSegments, places: placesToday)
-        }
+        self.segments = builtSegments
+        self.dayPlaces = placesToday
+        self.stats = computedStats
+        self.cameraPosition = initialCamera(segments: builtSegments, places: placesToday)
     }
 
     private func initialCamera(
@@ -136,17 +140,23 @@ struct DayTrajectoryView: View {
         var coords: [CLLocationCoordinate2D] = []
         coords.append(contentsOf: segments.flatMap { $0.points.map(\.coordinate) })
         coords.append(contentsOf: places.map(\.coordinate))
-        guard !coords.isEmpty else { return .automatic }
 
         let lats = coords.map(\.latitude)
         let lons = coords.map(\.longitude)
+        guard let minLat = lats.min(),
+              let maxLat = lats.max(),
+              let minLon = lons.min(),
+              let maxLon = lons.max() else {
+            return .automatic
+        }
+
         let center = CLLocationCoordinate2D(
-            latitude: (lats.min()! + lats.max()!) / 2,
-            longitude: (lons.min()! + lons.max()!) / 2
+            latitude: (minLat + maxLat) / 2,
+            longitude: (minLon + maxLon) / 2
         )
         let span = MKCoordinateSpan(
-            latitudeDelta: max(0.005, (lats.max()! - lats.min()!) * 1.4),
-            longitudeDelta: max(0.005, (lons.max()! - lons.min()!) * 1.4)
+            latitudeDelta: max(0.005, (maxLat - minLat) * 1.4),
+            longitudeDelta: max(0.005, (maxLon - minLon) * 1.4)
         )
         return .region(MKCoordinateRegion(center: center, span: span))
     }

--- a/PlaceNotes/Views/LogbookView.swift
+++ b/PlaceNotes/Views/LogbookView.swift
@@ -10,6 +10,7 @@ struct LogbookView: View {
     @State private var visitToDelete: Visit?
     @State private var showDeleteConfirmation = false
     @State private var refreshID = UUID()
+    @State private var trajectoryDay: Date?
 
     private var groupedVisits: [(year: Int, months: [(month: Int, visits: [Visit])])] {
         let minStay = settings.minStayMinutes
@@ -63,6 +64,9 @@ struct LogbookView: View {
                                         onDelete: { visit in
                                             visitToDelete = visit
                                             showDeleteConfirmation = true
+                                        },
+                                        onShowTrajectory: { arrival in
+                                            trajectoryDay = Calendar.current.startOfDay(for: arrival)
                                         }
                                     )
                                 }
@@ -82,6 +86,9 @@ struct LogbookView: View {
                 }
             }
             .navigationTitle("Logbook")
+            .navigationDestination(item: $trajectoryDay) { day in
+                DayTrajectoryView(day: day)
+            }
             .sheet(item: $visitForAlternatives) { visit in
                 AlternativePlacePicker(visit: visit) {
                     refreshID = UUID()
@@ -289,6 +296,7 @@ private struct MonthSection: View {
     let visits: [Visit]
     var onPickAlternative: ((Visit) -> Void)?
     var onDelete: ((Visit) -> Void)?
+    var onShowTrajectory: ((Date) -> Void)?
 
     private var monthName: String {
         let formatter = DateFormatter()
@@ -319,6 +327,14 @@ private struct MonthSection: View {
                         }
                     }
                     .buttonStyle(.plain)
+                    .swipeActions(edge: .leading, allowsFullSwipe: false) {
+                        Button {
+                            onShowTrajectory?(visit.arrivalDate)
+                        } label: {
+                            Label("Map", systemImage: "map")
+                        }
+                        .tint(.blue)
+                    }
                     .swipeActions(edge: .trailing, allowsFullSwipe: false) {
                         Button {
                             onDelete?(visit)

--- a/PlaceNotes/Views/SettingsView.swift
+++ b/PlaceNotes/Views/SettingsView.swift
@@ -173,6 +173,27 @@ struct SettingsView: View {
                 Section("About") {
                     LabeledContent("Version", value: "1.0.0")
                 }
+
+                #if DEBUG
+                Section {
+                    Button("Seed Sample Trajectory") {
+                        DebugSeed.seedSampleTrajectories(in: modelContext)
+                        refreshRawSampleCount()
+                        refreshStorageSize()
+                    }
+                    Button(role: .destructive) {
+                        DebugSeed.clearAllData(in: modelContext)
+                        refreshRawSampleCount()
+                        refreshStorageSize()
+                    } label: {
+                        Text("Clear All Data (Debug)")
+                    }
+                } header: {
+                    Text("Debug")
+                } footer: {
+                    Text("Seeds 4 days of synthetic trajectory data anchored to today: golden path, samples-but-no-visits, visits-but-no-samples, and a >10 min phone-off gap. All samples marked accepted to demonstrate the feature.")
+                }
+                #endif
             }
             .navigationTitle("Settings")
             .alert("Delete All Data?", isPresented: $showClearDataConfirmation) {

--- a/PlaceNotes/Views/TrajectoryHeaderCard.swift
+++ b/PlaceNotes/Views/TrajectoryHeaderCard.swift
@@ -5,20 +5,29 @@ struct TrajectoryHeaderCard: View {
     let stats: TrajectoryStats?
     let isPathAvailable: Bool
 
-    private var dayString: String {
+    private static let dayFormatter: DateFormatter = {
         let f = DateFormatter()
         f.dateStyle = .full
         f.timeStyle = .none
-        return f.string(from: day)
+        return f
+    }()
+
+    private static let distanceFormatter: MeasurementFormatter = {
+        let f = MeasurementFormatter()
+        f.unitOptions = .naturalScale
+        f.numberFormatter.maximumFractionDigits = 1
+        f.numberFormatter.minimumFractionDigits = 0
+        return f
+    }()
+
+    private var dayString: String {
+        Self.dayFormatter.string(from: day)
     }
 
     private var distanceString: String {
         guard let meters = stats?.totalDistanceMeters else { return "—" }
-        let formatter = MeasurementFormatter()
-        formatter.unitOptions = .naturalScale
-        formatter.numberFormatter.maximumFractionDigits = meters >= 1000 ? 1 : 0
         let measurement = Measurement(value: meters, unit: UnitLength.meters)
-        return formatter.string(from: measurement)
+        return Self.distanceFormatter.string(from: measurement)
     }
 
     private var summaryString: String {

--- a/PlaceNotes/Views/TrajectoryHeaderCard.swift
+++ b/PlaceNotes/Views/TrajectoryHeaderCard.swift
@@ -1,0 +1,62 @@
+import SwiftUI
+
+struct TrajectoryHeaderCard: View {
+    let day: Date
+    let stats: TrajectoryStats?
+    let isPathAvailable: Bool
+
+    private var dayString: String {
+        let f = DateFormatter()
+        f.dateStyle = .full
+        f.timeStyle = .none
+        return f.string(from: day)
+    }
+
+    private var distanceString: String {
+        guard let meters = stats?.totalDistanceMeters else { return "—" }
+        let formatter = MeasurementFormatter()
+        formatter.unitOptions = .naturalScale
+        formatter.numberFormatter.maximumFractionDigits = meters >= 1000 ? 1 : 0
+        let measurement = Measurement(value: meters, unit: UnitLength.meters)
+        return formatter.string(from: measurement)
+    }
+
+    private var summaryString: String {
+        guard let stats else { return "" }
+        return "\(stats.placeCount) places · \(stats.sampleCount) samples"
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(dayString)
+                .font(.subheadline.bold())
+            HStack(spacing: 8) {
+                if isPathAvailable {
+                    Text(distanceString)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Text("·")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                    Text(summaryString)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else {
+                    Text("Path data not available for this day")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            if isPathAvailable {
+                Text("AM → PM")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .padding(.vertical, 8)
+        .padding(.horizontal, 12)
+        .background(.regularMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .shadow(color: .black.opacity(0.1), radius: 4, y: 2)
+    }
+}

--- a/PlaceNotes/Views/TrajectoryHeaderCard.swift
+++ b/PlaceNotes/Views/TrajectoryHeaderCard.swift
@@ -32,7 +32,7 @@ struct TrajectoryHeaderCard: View {
 
     private var summaryString: String {
         guard let stats else { return "" }
-        return "\(stats.placeCount) places · \(stats.sampleCount) samples"
+        return "\(stats.placeCount) places · \(stats.rawSampleCount) samples"
     }
 
     var body: some View {

--- a/PlaceNotes/Views/TrajectoryPolyline.swift
+++ b/PlaceNotes/Views/TrajectoryPolyline.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+import MapKit
+
+struct TrajectoryPolyline: MapContent {
+    let segments: [TrajectorySegment]
+    let colorMode: TrajectoryColorMode
+
+    var body: some MapContent {
+        ForEach(Array(segments.enumerated()), id: \.offset) { _, segment in
+            ForEach(0..<max(0, segment.points.count - 1), id: \.self) { i in
+                let a = segment.points[i]
+                let b = segment.points[i + 1]
+                MapPolyline(coordinates: [a.coordinate, b.coordinate])
+                    .stroke(color(for: a, b), style: StrokeStyle(
+                        lineWidth: 4,
+                        lineCap: .round,
+                        lineJoin: .round
+                    ))
+            }
+        }
+    }
+
+    private func color(for a: TrajectoryPoint, _ b: TrajectoryPoint) -> Color {
+        switch colorMode {
+        case .time:
+            let mid = (a.normalizedTimeOfDay + b.normalizedTimeOfDay) / 2
+            return Self.timeColor(normalized: mid)
+        case .speed, .plain:
+            return .accentColor
+        }
+    }
+
+    /// Maps 0...1 → AM yellow → PM orange → evening purple.
+    static func timeColor(normalized t: Double) -> Color {
+        let clamped = min(1.0, max(0.0, t))
+        let amYellow = (r: 251.0/255, g: 191.0/255, b: 36.0/255)   // #fbbf24
+        let pmOrange = (r: 251.0/255, g: 146.0/255, b: 60.0/255)   // #fb923c
+        let evePurple = (r: 124.0/255, g: 58.0/255, b: 237.0/255)  // #7c3aed
+        if clamped < 0.5 {
+            let t2 = clamped / 0.5
+            return Color(
+                red: amYellow.r + (pmOrange.r - amYellow.r) * t2,
+                green: amYellow.g + (pmOrange.g - amYellow.g) * t2,
+                blue: amYellow.b + (pmOrange.b - amYellow.b) * t2
+            )
+        } else {
+            let t2 = (clamped - 0.5) / 0.5
+            return Color(
+                red: pmOrange.r + (evePurple.r - pmOrange.r) * t2,
+                green: pmOrange.g + (evePurple.g - pmOrange.g) * t2,
+                blue: pmOrange.b + (evePurple.b - pmOrange.b) * t2
+            )
+        }
+    }
+}

--- a/PlaceNotes/Views/TrajectoryPolyline.swift
+++ b/PlaceNotes/Views/TrajectoryPolyline.swift
@@ -6,7 +6,8 @@ struct TrajectoryPolyline: MapContent {
     let colorMode: TrajectoryColorMode
 
     var body: some MapContent {
-        ForEach(Array(segments.enumerated()), id: \.offset) { _, segment in
+        ForEach(segments.indices, id: \.self) { idx in
+            let segment = segments[idx]
             ForEach(0..<max(0, segment.points.count - 1), id: \.self) { i in
                 let a = segment.points[i]
                 let b = segment.points[i + 1]
@@ -26,6 +27,7 @@ struct TrajectoryPolyline: MapContent {
             let mid = (a.normalizedTimeOfDay + b.normalizedTimeOfDay) / 2
             return Self.timeColor(normalized: mid)
         case .speed, .plain:
+            // Not implemented in v1; returns accent color so callers can switch modes without crashing.
             return .accentColor
         }
     }

--- a/PlaceNotesTests/TrajectoryBuilderTests.swift
+++ b/PlaceNotesTests/TrajectoryBuilderTests.swift
@@ -185,4 +185,77 @@ final class TrajectoryBuilderTests: XCTestCase {
         XCTAssertEqual(stats.segmentCount, 1)
         XCTAssertEqual(stats.placeCount, 0)
     }
+
+    // MARK: - build
+
+    private func startOfDay(year: Int, month: Int, day: Int) -> Date {
+        var comps = DateComponents()
+        comps.year = year; comps.month = month; comps.day = day
+        comps.hour = 0; comps.minute = 0; comps.second = 0
+        return Calendar.current.date(from: comps)!
+    }
+
+    func testBuildEmptyReturnsEmpty() {
+        let day = startOfDay(year: 2026, month: 4, day: 18)
+        let result = TrajectoryBuilder.build(samples: [], day: day)
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testBuildAssignsNormalizedTimeOfDay() {
+        let day = startOfDay(year: 2026, month: 4, day: 18)
+        // 06:00 → 0.25, 12:00 → 0.5, 18:00 → 0.75
+        let samples = [
+            sample(offsetSeconds: 6 * 3600, from: day, lat: 37.78, lon: -122.41),
+            sample(offsetSeconds: 12 * 3600, from: day, lat: 37.79, lon: -122.42),
+            sample(offsetSeconds: 18 * 3600, from: day, lat: 37.80, lon: -122.43)
+        ]
+        let result = TrajectoryBuilder.build(samples: samples, day: day)
+        // The 12h gap > 600s default → 3 segments of 1 point each → all dropped
+        // (single-point segments are suppressed). Use a larger gap window to keep them:
+        let allKept = TrajectoryBuilder.build(
+            samples: samples,
+            day: day,
+            epsilonMeters: 0,
+            maxGapSeconds: 24 * 3600
+        )
+        XCTAssertEqual(allKept.count, 1)
+        XCTAssertEqual(allKept[0].points.count, 3)
+        XCTAssertEqual(allKept[0].points[0].normalizedTimeOfDay, 0.25, accuracy: 0.001)
+        XCTAssertEqual(allKept[0].points[1].normalizedTimeOfDay, 0.5, accuracy: 0.001)
+        XCTAssertEqual(allKept[0].points[2].normalizedTimeOfDay, 0.75, accuracy: 0.001)
+
+        // Default (600s gap) splits at every gap → all single-point segments → dropped.
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testBuildDropsSegmentsWithFewerThanTwoPoints() {
+        let day = startOfDay(year: 2026, month: 4, day: 18)
+        // Two close samples + one isolated sample → segment 1 keeps 2 pts, segment 2 drops.
+        let samples = [
+            sample(offsetSeconds: 6 * 3600, from: day),
+            sample(offsetSeconds: 6 * 3600 + 60, from: day),
+            sample(offsetSeconds: 18 * 3600, from: day)  // 12h gap
+        ]
+        let result = TrajectoryBuilder.build(samples: samples, day: day)
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result[0].points.count, 2)
+    }
+
+    func testBuildClampsNormalizedTimeOfDayToZeroOne() {
+        // A sample whose timestamp is just before midnight of `day` (e.g., feature
+        // pulls in samples that nominally landed in another day due to TZ rounding)
+        // should not produce a negative normalizedTimeOfDay.
+        let day = startOfDay(year: 2026, month: 4, day: 18)
+        let earlier = sample(offsetSeconds: -10, from: day, lat: 37.78)
+        let later = sample(offsetSeconds: 10, from: day, lat: 37.78)
+        let result = TrajectoryBuilder.build(
+            samples: [earlier, later],
+            day: day,
+            epsilonMeters: 0,
+            maxGapSeconds: 600
+        )
+        XCTAssertEqual(result.count, 1)
+        XCTAssertGreaterThanOrEqual(result[0].points[0].normalizedTimeOfDay, 0)
+        XCTAssertLessThanOrEqual(result[0].points[1].normalizedTimeOfDay, 1)
+    }
 }

--- a/PlaceNotesTests/TrajectoryBuilderTests.swift
+++ b/PlaceNotesTests/TrajectoryBuilderTests.swift
@@ -86,4 +86,56 @@ final class TrajectoryBuilderTests: XCTestCase {
         XCTAssertEqual(segments[1].count, 1)
         XCTAssertEqual(segments[2].count, 2)
     }
+
+    // MARK: - simplify (Douglas–Peucker)
+
+    private func point(lat: Double, lon: Double) -> TrajectoryPoint {
+        TrajectoryPoint(
+            coordinate: CLLocationCoordinate2D(latitude: lat, longitude: lon),
+            timestamp: Date(timeIntervalSince1970: 1_700_000_000),
+            normalizedTimeOfDay: 0.5,
+            speedMetersPerSecond: 1.0
+        )
+    }
+
+    func testSimplifyEmptyReturnsEmpty() {
+        let result = TrajectoryBuilder.simplify([], epsilonMeters: 5)
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testSimplifyTwoPointsReturnedUnchanged() {
+        let pts = [point(lat: 37.78, lon: -122.41), point(lat: 37.79, lon: -122.42)]
+        let result = TrajectoryBuilder.simplify(pts, epsilonMeters: 5)
+        XCTAssertEqual(result.count, 2)
+    }
+
+    func testSimplifyColinearMiddleIsRemoved() {
+        let pts = [
+            point(lat: 37.7800, lon: -122.4100),
+            point(lat: 37.7850, lon: -122.4100),
+            point(lat: 37.7900, lon: -122.4100)
+        ]
+        let result = TrajectoryBuilder.simplify(pts, epsilonMeters: 5)
+        XCTAssertEqual(result.count, 2)
+        XCTAssertEqual(result.first?.coordinate.latitude ?? 0, 37.7800, accuracy: 1e-6)
+        XCTAssertEqual(result.last?.coordinate.latitude ?? 0, 37.7900, accuracy: 1e-6)
+    }
+
+    func testSimplifySharpCornerIsKept() {
+        let pts = [
+            point(lat: 37.7800, lon: -122.4100),
+            point(lat: 37.7800, lon: -122.4000),
+            point(lat: 37.7900, lon: -122.4000)
+        ]
+        let result = TrajectoryBuilder.simplify(pts, epsilonMeters: 50)
+        XCTAssertEqual(result.count, 3)
+    }
+
+    func testSimplifyDenseColinearCollapses() {
+        let pts = (0..<10).map { i in
+            point(lat: 37.78 + Double(i) * 0.0005, lon: -122.41)
+        }
+        let result = TrajectoryBuilder.simplify(pts, epsilonMeters: 5)
+        XCTAssertEqual(result.count, 2)
+    }
 }

--- a/PlaceNotesTests/TrajectoryBuilderTests.swift
+++ b/PlaceNotesTests/TrajectoryBuilderTests.swift
@@ -183,5 +183,6 @@ final class TrajectoryBuilderTests: XCTestCase {
         XCTAssertEqual(stats.totalDistanceMeters, 0)
         XCTAssertEqual(stats.sampleCount, 1)
         XCTAssertEqual(stats.segmentCount, 1)
+        XCTAssertEqual(stats.placeCount, 0)
     }
 }

--- a/PlaceNotesTests/TrajectoryBuilderTests.swift
+++ b/PlaceNotesTests/TrajectoryBuilderTests.swift
@@ -138,4 +138,50 @@ final class TrajectoryBuilderTests: XCTestCase {
         let result = TrajectoryBuilder.simplify(pts, epsilonMeters: 5)
         XCTAssertEqual(result.count, 2)
     }
+
+    // MARK: - computeStats
+
+    func testComputeStatsEmpty() {
+        let stats = TrajectoryBuilder.computeStats(segments: [], placeCount: 0)
+        XCTAssertEqual(stats.totalDistanceMeters, 0)
+        XCTAssertEqual(stats.sampleCount, 0)
+        XCTAssertEqual(stats.segmentCount, 0)
+        XCTAssertEqual(stats.placeCount, 0)
+    }
+
+    func testComputeStatsSingleSegmentTwoPoints() {
+        let seg = TrajectorySegment(points: [
+            point(lat: 37.78000, lon: -122.41),
+            point(lat: 37.78100, lon: -122.41)
+        ])
+        let stats = TrajectoryBuilder.computeStats(segments: [seg], placeCount: 2)
+        XCTAssertEqual(stats.totalDistanceMeters, 111.32, accuracy: 1.0)
+        XCTAssertEqual(stats.sampleCount, 2)
+        XCTAssertEqual(stats.segmentCount, 1)
+        XCTAssertEqual(stats.placeCount, 2)
+    }
+
+    func testComputeStatsMultipleSegmentsSumDistances() {
+        let seg1 = TrajectorySegment(points: [
+            point(lat: 37.78000, lon: -122.41),
+            point(lat: 37.78100, lon: -122.41)
+        ])
+        let seg2 = TrajectorySegment(points: [
+            point(lat: 37.79000, lon: -122.41),
+            point(lat: 37.79200, lon: -122.41)
+        ])
+        let stats = TrajectoryBuilder.computeStats(segments: [seg1, seg2], placeCount: 3)
+        XCTAssertEqual(stats.totalDistanceMeters, 333.96, accuracy: 2.0)
+        XCTAssertEqual(stats.sampleCount, 4)
+        XCTAssertEqual(stats.segmentCount, 2)
+        XCTAssertEqual(stats.placeCount, 3)
+    }
+
+    func testComputeStatsSinglePointSegmentContributesZeroDistance() {
+        let seg = TrajectorySegment(points: [point(lat: 37.78, lon: -122.41)])
+        let stats = TrajectoryBuilder.computeStats(segments: [seg], placeCount: 0)
+        XCTAssertEqual(stats.totalDistanceMeters, 0)
+        XCTAssertEqual(stats.sampleCount, 1)
+        XCTAssertEqual(stats.segmentCount, 1)
+    }
 }

--- a/PlaceNotesTests/TrajectoryBuilderTests.swift
+++ b/PlaceNotesTests/TrajectoryBuilderTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+import CoreLocation
+@testable import PlaceNotes
+
+final class TrajectoryBuilderTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func sample(
+        offsetSeconds: TimeInterval,
+        from base: Date = Date(timeIntervalSince1970: 1_700_000_000),
+        lat: Double = 37.78,
+        lon: Double = -122.41,
+        speed: Double = 0.5,
+        accuracy: Double = 10
+    ) -> RawLocationSample {
+        RawLocationSample(
+            latitude: lat,
+            longitude: lon,
+            timestamp: base.addingTimeInterval(offsetSeconds),
+            horizontalAccuracy: accuracy,
+            speed: speed,
+            filterStatus: "accepted"
+        )
+    }
+
+    // MARK: - splitIntoSegments
+
+    func testSplitEmptyReturnsEmpty() {
+        let segments = TrajectoryBuilder.splitIntoSegments([], maxGapSeconds: 600)
+        XCTAssertTrue(segments.isEmpty)
+    }
+
+    func testSplitSingleSampleReturnsOneSegment() {
+        let s = [sample(offsetSeconds: 0)]
+        let segments = TrajectoryBuilder.splitIntoSegments(s, maxGapSeconds: 600)
+        XCTAssertEqual(segments.count, 1)
+        XCTAssertEqual(segments[0].count, 1)
+    }
+
+    func testSplitNoGapStaysInOneSegment() {
+        let s = [
+            sample(offsetSeconds: 0),
+            sample(offsetSeconds: 60),
+            sample(offsetSeconds: 120),
+            sample(offsetSeconds: 180)
+        ]
+        let segments = TrajectoryBuilder.splitIntoSegments(s, maxGapSeconds: 600)
+        XCTAssertEqual(segments.count, 1)
+        XCTAssertEqual(segments[0].count, 4)
+    }
+
+    func testSplitOnGapAboveThreshold() {
+        let s = [
+            sample(offsetSeconds: 0),
+            sample(offsetSeconds: 60),
+            sample(offsetSeconds: 1000),  // 940s gap > 600s
+            sample(offsetSeconds: 1060)
+        ]
+        let segments = TrajectoryBuilder.splitIntoSegments(s, maxGapSeconds: 600)
+        XCTAssertEqual(segments.count, 2)
+        XCTAssertEqual(segments[0].count, 2)
+        XCTAssertEqual(segments[1].count, 2)
+    }
+
+    func testSplitGapAtExactlyThresholdStaysInSameSegment() {
+        let s = [
+            sample(offsetSeconds: 0),
+            sample(offsetSeconds: 600)  // gap == threshold
+        ]
+        let segments = TrajectoryBuilder.splitIntoSegments(s, maxGapSeconds: 600)
+        XCTAssertEqual(segments.count, 1)
+        XCTAssertEqual(segments[0].count, 2)
+    }
+
+    func testSplitMultipleGapsProduceMultipleSegments() {
+        let s = [
+            sample(offsetSeconds: 0),
+            sample(offsetSeconds: 700),   // gap 700 > 600
+            sample(offsetSeconds: 1400),  // gap 700 > 600
+            sample(offsetSeconds: 1460)
+        ]
+        let segments = TrajectoryBuilder.splitIntoSegments(s, maxGapSeconds: 600)
+        XCTAssertEqual(segments.count, 3)
+        XCTAssertEqual(segments[0].count, 1)
+        XCTAssertEqual(segments[1].count, 1)
+        XCTAssertEqual(segments[2].count, 2)
+    }
+}

--- a/PlaceNotesTests/TrajectoryBuilderTests.swift
+++ b/PlaceNotesTests/TrajectoryBuilderTests.swift
@@ -142,9 +142,9 @@ final class TrajectoryBuilderTests: XCTestCase {
     // MARK: - computeStats
 
     func testComputeStatsEmpty() {
-        let stats = TrajectoryBuilder.computeStats(segments: [], placeCount: 0)
+        let stats = TrajectoryBuilder.computeStats(segments: [], rawSampleCount: 0, placeCount: 0)
         XCTAssertEqual(stats.totalDistanceMeters, 0)
-        XCTAssertEqual(stats.sampleCount, 0)
+        XCTAssertEqual(stats.rawSampleCount, 0)
         XCTAssertEqual(stats.segmentCount, 0)
         XCTAssertEqual(stats.placeCount, 0)
     }
@@ -154,9 +154,9 @@ final class TrajectoryBuilderTests: XCTestCase {
             point(lat: 37.78000, lon: -122.41),
             point(lat: 37.78100, lon: -122.41)
         ])
-        let stats = TrajectoryBuilder.computeStats(segments: [seg], placeCount: 2)
+        let stats = TrajectoryBuilder.computeStats(segments: [seg], rawSampleCount: 2, placeCount: 2)
         XCTAssertEqual(stats.totalDistanceMeters, 111.32, accuracy: 1.0)
-        XCTAssertEqual(stats.sampleCount, 2)
+        XCTAssertEqual(stats.rawSampleCount, 2)
         XCTAssertEqual(stats.segmentCount, 1)
         XCTAssertEqual(stats.placeCount, 2)
     }
@@ -170,18 +170,18 @@ final class TrajectoryBuilderTests: XCTestCase {
             point(lat: 37.79000, lon: -122.41),
             point(lat: 37.79200, lon: -122.41)
         ])
-        let stats = TrajectoryBuilder.computeStats(segments: [seg1, seg2], placeCount: 3)
+        let stats = TrajectoryBuilder.computeStats(segments: [seg1, seg2], rawSampleCount: 4, placeCount: 3)
         XCTAssertEqual(stats.totalDistanceMeters, 333.96, accuracy: 2.0)
-        XCTAssertEqual(stats.sampleCount, 4)
+        XCTAssertEqual(stats.rawSampleCount, 4)
         XCTAssertEqual(stats.segmentCount, 2)
         XCTAssertEqual(stats.placeCount, 3)
     }
 
     func testComputeStatsSinglePointSegmentContributesZeroDistance() {
         let seg = TrajectorySegment(points: [point(lat: 37.78, lon: -122.41)])
-        let stats = TrajectoryBuilder.computeStats(segments: [seg], placeCount: 0)
+        let stats = TrajectoryBuilder.computeStats(segments: [seg], rawSampleCount: 1, placeCount: 0)
         XCTAssertEqual(stats.totalDistanceMeters, 0)
-        XCTAssertEqual(stats.sampleCount, 1)
+        XCTAssertEqual(stats.rawSampleCount, 1)
         XCTAssertEqual(stats.segmentCount, 1)
         XCTAssertEqual(stats.placeCount, 0)
     }

--- a/docs/superpowers/plans/2026-04-24-day-trajectory-on-map.md
+++ b/docs/superpowers/plans/2026-04-24-day-trajectory-on-map.md
@@ -1,0 +1,1261 @@
+# Day Trajectory on Map — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render a single day's GPS trajectory on a map (gradient by time of day) overlaid with that day's Place pins, reachable from each visit row in the Logbook.
+
+**Architecture:** A new `DayTrajectoryView(day: Date)` SwiftUI screen queries `RawLocationSample` for the day, hands the samples to a pure `TrajectoryBuilder` (segment-split → point-convert → Douglas-Peucker simplify), and renders the result as N short `MapPolyline` segments — each colored by its midpoint's normalized time-of-day. Reuses the existing `PlaceAnnotationView` and `PlaceDetailSheet`.
+
+**Tech Stack:** Swift 5.9, SwiftUI, SwiftData, MapKit (`Map`, `MapPolyline`), CoreLocation, XCTest, XcodeGen.
+
+**Spec:** [`docs/superpowers/specs/2026-04-24-day-trajectory-on-map-design.md`](../specs/2026-04-24-day-trajectory-on-map-design.md)
+
+**GitHub issue:** [#48](https://github.com/ychu824/PlaceNotes/issues/48)
+
+---
+
+## File Structure
+
+**Create:**
+- `PlaceNotes/Services/TrajectoryBuilder.swift` — pure `enum` with static methods: `splitIntoSegments`, `convertToPoints`, `simplify`, `computeStats`, `build`
+- `PlaceNotes/Services/TrajectoryTypes.swift` — value types: `TrajectoryPoint`, `TrajectorySegment`, `TrajectoryStats`, `TrajectoryColorMode`
+- `PlaceNotes/Views/TrajectoryHeaderCard.swift` — floating header card (date, distance, counts, AM→PM hint)
+- `PlaceNotes/Views/TrajectoryPolyline.swift` — `MapContent`-conforming type that emits one `MapPolyline` per simplified pair, colored by midpoint normalized time-of-day
+- `PlaceNotes/Views/DayTrajectoryView.swift` — the screen itself: query, transform, compose
+- `PlaceNotesTests/TrajectoryBuilderTests.swift` — unit tests for the pure helpers
+
+**Modify:**
+- `PlaceNotes/Views/LogbookView.swift` — add a leading `swipeActions` "Map" button on `LogbookVisitRow`; push `DayTrajectoryView(day:)`
+
+**Unchanged (reused):**
+- `PlaceNotes/Models/RawLocationSample.swift`
+- `PlaceNotes/Models/Visit.swift`, `Place.swift`
+- `PlaceAnnotationView` and `PlaceDetailSheet` (both currently in `Views/FrequentPlacesMapView.swift`)
+
+---
+
+## Build & Test Commands
+
+The project uses XcodeGen. Whenever you create a new `.swift` file under `PlaceNotes/` or `PlaceNotesTests/`, regenerate the Xcode project before building:
+
+```bash
+xcodegen generate
+```
+
+Run the test suite (adjust `name=iPhone 15 Pro` to whatever simulator is available locally — try `xcrun simctl list devices available` if unsure):
+
+```bash
+xcodebuild test \
+  -scheme PlaceNotes \
+  -destination 'platform=iOS Simulator,OS=latest,name=iPhone 15 Pro' \
+  -only-testing:PlaceNotesTests/TrajectoryBuilderTests \
+  | xcpretty
+```
+
+Whole-suite build for the final task:
+
+```bash
+xcodebuild build \
+  -scheme PlaceNotes \
+  -destination 'platform=iOS Simulator,OS=latest,name=iPhone 15 Pro' \
+  | xcpretty
+```
+
+---
+
+## Task 1: Add value types
+
+**Files:**
+- Create: `PlaceNotes/Services/TrajectoryTypes.swift`
+
+These are plain value types with no behavior — they don't need tests. Creating them first gives every later task its vocabulary.
+
+- [ ] **Step 1: Write the file**
+
+```swift
+import Foundation
+import CoreLocation
+
+struct TrajectoryPoint {
+    let coordinate: CLLocationCoordinate2D
+    let timestamp: Date
+    /// Position within the day's local 0:00–24:00 window, clamped to 0...1.
+    let normalizedTimeOfDay: Double
+    let speedMetersPerSecond: Double
+}
+
+struct TrajectorySegment {
+    let points: [TrajectoryPoint]
+}
+
+struct TrajectoryStats {
+    let totalDistanceMeters: Double
+    let sampleCount: Int
+    let segmentCount: Int
+    let placeCount: Int
+}
+
+enum TrajectoryColorMode {
+    case time
+    case speed
+    case plain
+}
+```
+
+- [ ] **Step 2: Regenerate the Xcode project**
+
+Run: `xcodegen generate`
+Expected: prints "Created project at …/PlaceNotes.xcodeproj"
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add PlaceNotes/Services/TrajectoryTypes.swift project.yml
+git commit -m "feat(trajectory): add value types for trajectory rendering"
+```
+
+---
+
+## Task 2: `TrajectoryBuilder.splitIntoSegments` (TDD)
+
+**Files:**
+- Create: `PlaceNotes/Services/TrajectoryBuilder.swift`
+- Create: `PlaceNotesTests/TrajectoryBuilderTests.swift`
+
+Goal: split a chronologically sorted `[RawLocationSample]` into runs where consecutive samples are within `maxGapSeconds` of each other. A gap **strictly greater than** `maxGapSeconds` starts a new segment. A gap exactly equal to the threshold stays in the same segment.
+
+- [ ] **Step 1: Create the empty module file (so the test file compiles)**
+
+```swift
+// PlaceNotes/Services/TrajectoryBuilder.swift
+import Foundation
+import CoreLocation
+
+enum TrajectoryBuilder {
+    static func splitIntoSegments(
+        _ samples: [RawLocationSample],
+        maxGapSeconds: TimeInterval
+    ) -> [[RawLocationSample]] {
+        fatalError("not implemented")
+    }
+}
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `PlaceNotesTests/TrajectoryBuilderTests.swift`:
+
+```swift
+import XCTest
+import CoreLocation
+@testable import PlaceNotes
+
+final class TrajectoryBuilderTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func sample(
+        offsetSeconds: TimeInterval,
+        from base: Date = Date(timeIntervalSince1970: 1_700_000_000),
+        lat: Double = 37.78,
+        lon: Double = -122.41,
+        speed: Double = 0.5,
+        accuracy: Double = 10
+    ) -> RawLocationSample {
+        RawLocationSample(
+            latitude: lat,
+            longitude: lon,
+            timestamp: base.addingTimeInterval(offsetSeconds),
+            horizontalAccuracy: accuracy,
+            speed: speed,
+            filterStatus: "accepted"
+        )
+    }
+
+    // MARK: - splitIntoSegments
+
+    func testSplitEmptyReturnsEmpty() {
+        let segments = TrajectoryBuilder.splitIntoSegments([], maxGapSeconds: 600)
+        XCTAssertTrue(segments.isEmpty)
+    }
+
+    func testSplitSingleSampleReturnsOneSegment() {
+        let s = [sample(offsetSeconds: 0)]
+        let segments = TrajectoryBuilder.splitIntoSegments(s, maxGapSeconds: 600)
+        XCTAssertEqual(segments.count, 1)
+        XCTAssertEqual(segments[0].count, 1)
+    }
+
+    func testSplitNoGapStaysInOneSegment() {
+        let s = [
+            sample(offsetSeconds: 0),
+            sample(offsetSeconds: 60),
+            sample(offsetSeconds: 120),
+            sample(offsetSeconds: 180)
+        ]
+        let segments = TrajectoryBuilder.splitIntoSegments(s, maxGapSeconds: 600)
+        XCTAssertEqual(segments.count, 1)
+        XCTAssertEqual(segments[0].count, 4)
+    }
+
+    func testSplitOnGapAboveThreshold() {
+        let s = [
+            sample(offsetSeconds: 0),
+            sample(offsetSeconds: 60),
+            sample(offsetSeconds: 1000),  // 940s gap > 600s
+            sample(offsetSeconds: 1060)
+        ]
+        let segments = TrajectoryBuilder.splitIntoSegments(s, maxGapSeconds: 600)
+        XCTAssertEqual(segments.count, 2)
+        XCTAssertEqual(segments[0].count, 2)
+        XCTAssertEqual(segments[1].count, 2)
+    }
+
+    func testSplitGapAtExactlyThresholdStaysInSameSegment() {
+        let s = [
+            sample(offsetSeconds: 0),
+            sample(offsetSeconds: 600)  // gap == threshold
+        ]
+        let segments = TrajectoryBuilder.splitIntoSegments(s, maxGapSeconds: 600)
+        XCTAssertEqual(segments.count, 1)
+        XCTAssertEqual(segments[0].count, 2)
+    }
+
+    func testSplitMultipleGapsProduceMultipleSegments() {
+        let s = [
+            sample(offsetSeconds: 0),
+            sample(offsetSeconds: 700),   // gap 700 > 600
+            sample(offsetSeconds: 1400),  // gap 700 > 600
+            sample(offsetSeconds: 1460)
+        ]
+        let segments = TrajectoryBuilder.splitIntoSegments(s, maxGapSeconds: 600)
+        XCTAssertEqual(segments.count, 3)
+        XCTAssertEqual(segments[0].count, 1)
+        XCTAssertEqual(segments[1].count, 1)
+        XCTAssertEqual(segments[2].count, 2)
+    }
+}
+```
+
+- [ ] **Step 3: Regenerate and run tests — verify they fail**
+
+```bash
+xcodegen generate
+xcodebuild test \
+  -scheme PlaceNotes \
+  -destination 'platform=iOS Simulator,OS=latest,name=iPhone 15 Pro' \
+  -only-testing:PlaceNotesTests/TrajectoryBuilderTests \
+  | xcpretty
+```
+Expected: tests crash or fail with "not implemented" / fatalError.
+
+- [ ] **Step 4: Implement `splitIntoSegments`**
+
+Replace the file body with:
+
+```swift
+import Foundation
+import CoreLocation
+
+enum TrajectoryBuilder {
+    /// Split a chronologically sorted run of samples wherever the temporal gap
+    /// between consecutive samples is **strictly greater than** `maxGapSeconds`.
+    /// Without this we would draw a "teleport" line across the gap.
+    static func splitIntoSegments(
+        _ samples: [RawLocationSample],
+        maxGapSeconds: TimeInterval
+    ) -> [[RawLocationSample]] {
+        guard !samples.isEmpty else { return [] }
+
+        var result: [[RawLocationSample]] = []
+        var current: [RawLocationSample] = [samples[0]]
+
+        for i in 1..<samples.count {
+            let prev = samples[i - 1]
+            let next = samples[i]
+            if next.timestamp.timeIntervalSince(prev.timestamp) > maxGapSeconds {
+                result.append(current)
+                current = [next]
+            } else {
+                current.append(next)
+            }
+        }
+        result.append(current)
+        return result
+    }
+}
+```
+
+- [ ] **Step 5: Re-run tests — verify they pass**
+
+Run the same `xcodebuild test` command from Step 3.
+Expected: all 6 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add PlaceNotes/Services/TrajectoryBuilder.swift PlaceNotesTests/TrajectoryBuilderTests.swift project.yml
+git commit -m "feat(trajectory): split sorted samples into segments at temporal gaps"
+```
+
+---
+
+## Task 3: `TrajectoryBuilder.simplify` — Douglas–Peucker (TDD)
+
+**Files:**
+- Modify: `PlaceNotes/Services/TrajectoryBuilder.swift`
+- Modify: `PlaceNotesTests/TrajectoryBuilderTests.swift`
+
+Operates on `[TrajectoryPoint]`. The classic Douglas–Peucker algorithm: find the point with the largest perpendicular distance from the line between the first and last points; if that distance exceeds `epsilonMeters`, recurse on both halves; otherwise drop all interior points. Uses great-circle approximation: convert lat/lon to local meters via a flat-earth approximation around the segment's midpoint (good enough for the few-km scales we render).
+
+- [ ] **Step 1: Add the failing tests**
+
+Append to `PlaceNotesTests/TrajectoryBuilderTests.swift` (inside the existing class, after the previous tests):
+
+```swift
+    // MARK: - simplify (Douglas–Peucker)
+
+    private func point(lat: Double, lon: Double) -> TrajectoryPoint {
+        TrajectoryPoint(
+            coordinate: CLLocationCoordinate2D(latitude: lat, longitude: lon),
+            timestamp: Date(timeIntervalSince1970: 1_700_000_000),
+            normalizedTimeOfDay: 0.5,
+            speedMetersPerSecond: 1.0
+        )
+    }
+
+    func testSimplifyEmptyReturnsEmpty() {
+        let result = TrajectoryBuilder.simplify([], epsilonMeters: 5)
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testSimplifyTwoPointsReturnedUnchanged() {
+        let pts = [point(lat: 37.78, lon: -122.41), point(lat: 37.79, lon: -122.42)]
+        let result = TrajectoryBuilder.simplify(pts, epsilonMeters: 5)
+        XCTAssertEqual(result.count, 2)
+    }
+
+    func testSimplifyColinearMiddleIsRemoved() {
+        // Three points on roughly the same straight line — middle should drop.
+        let pts = [
+            point(lat: 37.7800, lon: -122.4100),
+            point(lat: 37.7850, lon: -122.4100),
+            point(lat: 37.7900, lon: -122.4100)
+        ]
+        let result = TrajectoryBuilder.simplify(pts, epsilonMeters: 5)
+        XCTAssertEqual(result.count, 2)
+        XCTAssertEqual(result.first?.coordinate.latitude, 37.7800, accuracy: 1e-6)
+        XCTAssertEqual(result.last?.coordinate.latitude, 37.7900, accuracy: 1e-6)
+    }
+
+    func testSimplifySharpCornerIsKept() {
+        // Three points forming a clear corner, far apart enough that the corner
+        // exceeds the epsilon — middle should stay.
+        let pts = [
+            point(lat: 37.7800, lon: -122.4100),
+            point(lat: 37.7800, lon: -122.4000),  // ~880m east
+            point(lat: 37.7900, lon: -122.4000)   // ~1100m north
+        ]
+        let result = TrajectoryBuilder.simplify(pts, epsilonMeters: 50)
+        XCTAssertEqual(result.count, 3)
+    }
+
+    func testSimplifyDenseColinearCollapses() {
+        // 10 evenly spaced points on a straight line — should collapse to 2.
+        let pts = (0..<10).map { i in
+            point(lat: 37.78 + Double(i) * 0.0005, lon: -122.41)
+        }
+        let result = TrajectoryBuilder.simplify(pts, epsilonMeters: 5)
+        XCTAssertEqual(result.count, 2)
+    }
+```
+
+- [ ] **Step 2: Run tests — verify they fail to compile**
+
+```bash
+xcodebuild test \
+  -scheme PlaceNotes \
+  -destination 'platform=iOS Simulator,OS=latest,name=iPhone 15 Pro' \
+  -only-testing:PlaceNotesTests/TrajectoryBuilderTests \
+  | xcpretty
+```
+Expected: compile error — `TrajectoryBuilder.simplify` does not exist.
+
+- [ ] **Step 3: Implement `simplify`**
+
+Append to `PlaceNotes/Services/TrajectoryBuilder.swift` (inside the `enum TrajectoryBuilder { … }` body):
+
+```swift
+    /// Douglas–Peucker line simplification. Drops points whose perpendicular
+    /// distance from the local approximation line is < `epsilonMeters`.
+    /// Uses an equirectangular projection around the input's midpoint — good
+    /// enough at the few-km scale a single day's path occupies.
+    static func simplify(
+        _ points: [TrajectoryPoint],
+        epsilonMeters: Double
+    ) -> [TrajectoryPoint] {
+        guard points.count > 2 else { return points }
+
+        let midLat = (points.first!.coordinate.latitude + points.last!.coordinate.latitude) / 2
+        let metersPerDegLat = 111_320.0
+        let metersPerDegLon = 111_320.0 * cos(midLat * .pi / 180)
+
+        func project(_ c: CLLocationCoordinate2D) -> (x: Double, y: Double) {
+            (x: c.longitude * metersPerDegLon, y: c.latitude * metersPerDegLat)
+        }
+
+        func perpendicularDistance(
+            _ p: CLLocationCoordinate2D,
+            from a: CLLocationCoordinate2D,
+            to b: CLLocationCoordinate2D
+        ) -> Double {
+            let pp = project(p), pa = project(a), pb = project(b)
+            let dx = pb.x - pa.x
+            let dy = pb.y - pa.y
+            let lengthSq = dx * dx + dy * dy
+            if lengthSq == 0 {
+                let ex = pp.x - pa.x, ey = pp.y - pa.y
+                return (ex * ex + ey * ey).squareRoot()
+            }
+            // |cross product| / |segment length|
+            let cross = abs((pp.x - pa.x) * dy - (pp.y - pa.y) * dx)
+            return cross / lengthSq.squareRoot()
+        }
+
+        // Recursive DP using indices into `points`.
+        func recurse(start: Int, end: Int, into keep: inout [Bool]) {
+            guard end > start + 1 else { return }
+            var maxDist = 0.0
+            var maxIdx = start
+            let a = points[start].coordinate
+            let b = points[end].coordinate
+            for i in (start + 1)..<end {
+                let d = perpendicularDistance(points[i].coordinate, from: a, to: b)
+                if d > maxDist {
+                    maxDist = d
+                    maxIdx = i
+                }
+            }
+            if maxDist > epsilonMeters {
+                keep[maxIdx] = true
+                recurse(start: start, end: maxIdx, into: &keep)
+                recurse(start: maxIdx, end: end, into: &keep)
+            }
+        }
+
+        var keep = [Bool](repeating: false, count: points.count)
+        keep[0] = true
+        keep[points.count - 1] = true
+        recurse(start: 0, end: points.count - 1, into: &keep)
+
+        return zip(points, keep).compactMap { $0.1 ? $0.0 : nil }
+    }
+```
+
+- [ ] **Step 4: Re-run tests — verify they pass**
+
+Run the same `xcodebuild test` command from Step 2.
+Expected: all simplify tests pass alongside the earlier split tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add PlaceNotes/Services/TrajectoryBuilder.swift PlaceNotesTests/TrajectoryBuilderTests.swift
+git commit -m "feat(trajectory): add Douglas-Peucker simplify for trajectory points"
+```
+
+---
+
+## Task 4: `TrajectoryBuilder.computeStats` (TDD)
+
+**Files:**
+- Modify: `PlaceNotes/Services/TrajectoryBuilder.swift`
+- Modify: `PlaceNotesTests/TrajectoryBuilderTests.swift`
+
+Sums distances within each segment using `CLLocation.distance(from:)` for accurate great-circle math, plus aggregates counts.
+
+- [ ] **Step 1: Add the failing tests**
+
+Append inside the test class:
+
+```swift
+    // MARK: - computeStats
+
+    func testComputeStatsEmpty() {
+        let stats = TrajectoryBuilder.computeStats(segments: [], placeCount: 0)
+        XCTAssertEqual(stats.totalDistanceMeters, 0)
+        XCTAssertEqual(stats.sampleCount, 0)
+        XCTAssertEqual(stats.segmentCount, 0)
+        XCTAssertEqual(stats.placeCount, 0)
+    }
+
+    func testComputeStatsSingleSegmentTwoPoints() {
+        // Two points ~111m apart in latitude (1/1000 of a degree).
+        let seg = TrajectorySegment(points: [
+            point(lat: 37.78000, lon: -122.41),
+            point(lat: 37.78100, lon: -122.41)
+        ])
+        let stats = TrajectoryBuilder.computeStats(segments: [seg], placeCount: 2)
+        XCTAssertEqual(stats.totalDistanceMeters, 111.32, accuracy: 1.0)
+        XCTAssertEqual(stats.sampleCount, 2)
+        XCTAssertEqual(stats.segmentCount, 1)
+        XCTAssertEqual(stats.placeCount, 2)
+    }
+
+    func testComputeStatsMultipleSegmentsSumDistances() {
+        let seg1 = TrajectorySegment(points: [
+            point(lat: 37.78000, lon: -122.41),
+            point(lat: 37.78100, lon: -122.41)  // ~111m
+        ])
+        let seg2 = TrajectorySegment(points: [
+            point(lat: 37.79000, lon: -122.41),
+            point(lat: 37.79200, lon: -122.41)  // ~222m
+        ])
+        let stats = TrajectoryBuilder.computeStats(segments: [seg1, seg2], placeCount: 3)
+        XCTAssertEqual(stats.totalDistanceMeters, 333.96, accuracy: 2.0)
+        XCTAssertEqual(stats.sampleCount, 4)
+        XCTAssertEqual(stats.segmentCount, 2)
+        XCTAssertEqual(stats.placeCount, 3)
+    }
+
+    func testComputeStatsSinglePointSegmentContributesZeroDistance() {
+        let seg = TrajectorySegment(points: [point(lat: 37.78, lon: -122.41)])
+        let stats = TrajectoryBuilder.computeStats(segments: [seg], placeCount: 0)
+        XCTAssertEqual(stats.totalDistanceMeters, 0)
+        XCTAssertEqual(stats.sampleCount, 1)
+        XCTAssertEqual(stats.segmentCount, 1)
+    }
+```
+
+- [ ] **Step 2: Run tests — verify compile failure**
+
+Run the `xcodebuild test` command. Expected: compile error — `TrajectoryBuilder.computeStats` does not exist.
+
+- [ ] **Step 3: Implement `computeStats`**
+
+Append inside `enum TrajectoryBuilder { … }`:
+
+```swift
+    static func computeStats(
+        segments: [TrajectorySegment],
+        placeCount: Int
+    ) -> TrajectoryStats {
+        var totalDistance: Double = 0
+        var totalSamples = 0
+
+        for segment in segments {
+            totalSamples += segment.points.count
+            guard segment.points.count > 1 else { continue }
+            for i in 1..<segment.points.count {
+                let a = segment.points[i - 1].coordinate
+                let b = segment.points[i].coordinate
+                let aLoc = CLLocation(latitude: a.latitude, longitude: a.longitude)
+                let bLoc = CLLocation(latitude: b.latitude, longitude: b.longitude)
+                totalDistance += aLoc.distance(from: bLoc)
+            }
+        }
+
+        return TrajectoryStats(
+            totalDistanceMeters: totalDistance,
+            sampleCount: totalSamples,
+            segmentCount: segments.count,
+            placeCount: placeCount
+        )
+    }
+```
+
+- [ ] **Step 4: Re-run tests — verify they pass**
+
+Run the `xcodebuild test` command.
+Expected: all stats tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add PlaceNotes/Services/TrajectoryBuilder.swift PlaceNotesTests/TrajectoryBuilderTests.swift
+git commit -m "feat(trajectory): compute aggregate stats from segments"
+```
+
+---
+
+## Task 5: `TrajectoryBuilder.build` — top-level composition (TDD)
+
+**Files:**
+- Modify: `PlaceNotes/Services/TrajectoryBuilder.swift`
+- Modify: `PlaceNotesTests/TrajectoryBuilderTests.swift`
+
+`build(samples:day:epsilonMeters:maxGapSeconds:)` glues the pieces:
+
+1. Split samples into segments by temporal gap.
+2. For each segment, convert `RawLocationSample`s to `TrajectoryPoint`s, computing `normalizedTimeOfDay` from the **local-day** start.
+3. Simplify each segment's points.
+4. Drop segments that end up with < 2 points (not drawable as a polyline; per spec).
+
+Defaults baked into the function: `epsilonMeters: 5`, `maxGapSeconds: 600` — callers can override.
+
+- [ ] **Step 1: Add the failing tests**
+
+Append inside the test class:
+
+```swift
+    // MARK: - build
+
+    private func startOfDay(year: Int, month: Int, day: Int) -> Date {
+        var comps = DateComponents()
+        comps.year = year; comps.month = month; comps.day = day
+        comps.hour = 0; comps.minute = 0; comps.second = 0
+        return Calendar.current.date(from: comps)!
+    }
+
+    func testBuildEmptyReturnsEmpty() {
+        let day = startOfDay(year: 2026, month: 4, day: 18)
+        let result = TrajectoryBuilder.build(samples: [], day: day)
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testBuildAssignsNormalizedTimeOfDay() {
+        let day = startOfDay(year: 2026, month: 4, day: 18)
+        // 06:00 → 0.25, 12:00 → 0.5, 18:00 → 0.75
+        let samples = [
+            sample(offsetSeconds: 6 * 3600, from: day, lat: 37.78, lon: -122.41),
+            sample(offsetSeconds: 12 * 3600, from: day, lat: 37.79, lon: -122.42),
+            sample(offsetSeconds: 18 * 3600, from: day, lat: 37.80, lon: -122.43)
+        ]
+        let result = TrajectoryBuilder.build(samples: samples, day: day)
+        // The 12h gap > 600s default → 3 segments of 1 point each → all dropped
+        // (single-point segments are suppressed). Use a larger gap window to keep them:
+        let allKept = TrajectoryBuilder.build(
+            samples: samples,
+            day: day,
+            epsilonMeters: 0,
+            maxGapSeconds: 24 * 3600
+        )
+        XCTAssertEqual(allKept.count, 1)
+        XCTAssertEqual(allKept[0].points.count, 3)
+        XCTAssertEqual(allKept[0].points[0].normalizedTimeOfDay, 0.25, accuracy: 0.001)
+        XCTAssertEqual(allKept[0].points[1].normalizedTimeOfDay, 0.5, accuracy: 0.001)
+        XCTAssertEqual(allKept[0].points[2].normalizedTimeOfDay, 0.75, accuracy: 0.001)
+
+        // Default (600s gap) splits at every gap → all single-point segments → dropped.
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testBuildDropsSegmentsWithFewerThanTwoPoints() {
+        let day = startOfDay(year: 2026, month: 4, day: 18)
+        // Two close samples + one isolated sample → segment 1 keeps 2 pts, segment 2 drops.
+        let samples = [
+            sample(offsetSeconds: 6 * 3600, from: day),
+            sample(offsetSeconds: 6 * 3600 + 60, from: day),
+            sample(offsetSeconds: 18 * 3600, from: day)  // 12h gap
+        ]
+        let result = TrajectoryBuilder.build(samples: samples, day: day)
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result[0].points.count, 2)
+    }
+
+    func testBuildClampsNormalizedTimeOfDayToZeroOne() {
+        // A sample whose timestamp is just before midnight of `day` (e.g., feature
+        // pulls in samples that nominally landed in another day due to TZ rounding)
+        // should not produce a negative normalizedTimeOfDay.
+        let day = startOfDay(year: 2026, month: 4, day: 18)
+        let earlier = sample(offsetSeconds: -10, from: day, lat: 37.78)
+        let later = sample(offsetSeconds: 10, from: day, lat: 37.78)
+        let result = TrajectoryBuilder.build(
+            samples: [earlier, later],
+            day: day,
+            epsilonMeters: 0,
+            maxGapSeconds: 600
+        )
+        XCTAssertEqual(result.count, 1)
+        XCTAssertGreaterThanOrEqual(result[0].points[0].normalizedTimeOfDay, 0)
+        XCTAssertLessThanOrEqual(result[0].points[1].normalizedTimeOfDay, 1)
+    }
+```
+
+- [ ] **Step 2: Run tests — verify compile failure**
+
+Run the `xcodebuild test` command. Expected: compile error — `TrajectoryBuilder.build` does not exist.
+
+- [ ] **Step 3: Implement `build` and the small `convertToPoints` helper**
+
+Append inside `enum TrajectoryBuilder { … }`:
+
+```swift
+    static func build(
+        samples: [RawLocationSample],
+        day: Date,
+        epsilonMeters: Double = 5,
+        maxGapSeconds: TimeInterval = 600
+    ) -> [TrajectorySegment] {
+        let dayStart = Calendar.current.startOfDay(for: day)
+        let raw = splitIntoSegments(samples, maxGapSeconds: maxGapSeconds)
+
+        return raw.compactMap { rawSegment in
+            let points = convertToPoints(rawSegment, dayStart: dayStart)
+            let simplified = simplify(points, epsilonMeters: epsilonMeters)
+            guard simplified.count >= 2 else { return nil }
+            return TrajectorySegment(points: simplified)
+        }
+    }
+
+    static func convertToPoints(
+        _ samples: [RawLocationSample],
+        dayStart: Date
+    ) -> [TrajectoryPoint] {
+        let dayLength: TimeInterval = 86_400
+        return samples.map { s in
+            let raw = s.timestamp.timeIntervalSince(dayStart) / dayLength
+            let normalized = min(1.0, max(0.0, raw))
+            return TrajectoryPoint(
+                coordinate: CLLocationCoordinate2D(latitude: s.latitude, longitude: s.longitude),
+                timestamp: s.timestamp,
+                normalizedTimeOfDay: normalized,
+                speedMetersPerSecond: max(0, s.speed)
+            )
+        }
+    }
+```
+
+- [ ] **Step 4: Re-run tests — verify they pass**
+
+Run the `xcodebuild test` command. Expected: all `TrajectoryBuilderTests` (split, simplify, computeStats, build) pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add PlaceNotes/Services/TrajectoryBuilder.swift PlaceNotesTests/TrajectoryBuilderTests.swift
+git commit -m "feat(trajectory): top-level build composes split/convert/simplify"
+```
+
+---
+
+## Task 6: `TrajectoryHeaderCard` view
+
+**Files:**
+- Create: `PlaceNotes/Views/TrajectoryHeaderCard.swift`
+
+A small material-backed card. SwiftUI view with no internal logic — no unit tests in this codebase for views. Verified manually in Task 10.
+
+- [ ] **Step 1: Write the file**
+
+```swift
+import SwiftUI
+
+struct TrajectoryHeaderCard: View {
+    let day: Date
+    let stats: TrajectoryStats?
+    let isPathAvailable: Bool
+
+    private var dayString: String {
+        let f = DateFormatter()
+        f.dateStyle = .full
+        f.timeStyle = .none
+        return f.string(from: day)
+    }
+
+    private var distanceString: String {
+        guard let meters = stats?.totalDistanceMeters else { return "—" }
+        let formatter = MeasurementFormatter()
+        formatter.unitOptions = .naturalScale
+        formatter.numberFormatter.maximumFractionDigits = meters >= 1000 ? 1 : 0
+        let measurement = Measurement(value: meters, unit: UnitLength.meters)
+        return formatter.string(from: measurement)
+    }
+
+    private var summaryString: String {
+        guard let stats else { return "" }
+        return "\(stats.placeCount) places · \(stats.sampleCount) samples"
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(dayString)
+                .font(.subheadline.bold())
+            HStack(spacing: 8) {
+                if isPathAvailable {
+                    Text(distanceString)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Text("·")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                    Text(summaryString)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else {
+                    Text("Path data not available for this day")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            if isPathAvailable {
+                Text("AM → PM")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .padding(.vertical, 8)
+        .padding(.horizontal, 12)
+        .background(.regularMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .shadow(color: .black.opacity(0.1), radius: 4, y: 2)
+    }
+}
+```
+
+- [ ] **Step 2: Regenerate and build (no tests for views)**
+
+```bash
+xcodegen generate
+xcodebuild build \
+  -scheme PlaceNotes \
+  -destination 'platform=iOS Simulator,OS=latest,name=iPhone 15 Pro' \
+  | xcpretty
+```
+Expected: build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add PlaceNotes/Views/TrajectoryHeaderCard.swift project.yml
+git commit -m "feat(trajectory): add header card view (date, distance, counts)"
+```
+
+---
+
+## Task 7: `TrajectoryPolyline` map content
+
+**Files:**
+- Create: `PlaceNotes/Views/TrajectoryPolyline.swift`
+
+Renders the gradient by emitting one `MapPolyline` per consecutive point pair, colored by the pair's midpoint normalized time-of-day. Implemented as a `MapContent`-conforming type so it composes inside a SwiftUI `Map { … }` content builder.
+
+The `colorMode` parameter is wired in as the v2 extensibility seam — only `.time` is implemented for v1; `.speed` and `.plain` use a sensible fallback (plain accent color) so future code can flip the enum without crashing.
+
+- [ ] **Step 1: Write the file**
+
+```swift
+import SwiftUI
+import MapKit
+
+struct TrajectoryPolyline: MapContent {
+    let segments: [TrajectorySegment]
+    let colorMode: TrajectoryColorMode
+
+    var body: some MapContent {
+        ForEach(Array(segments.enumerated()), id: \.offset) { _, segment in
+            ForEach(0..<max(0, segment.points.count - 1), id: \.self) { i in
+                let a = segment.points[i]
+                let b = segment.points[i + 1]
+                MapPolyline(coordinates: [a.coordinate, b.coordinate])
+                    .stroke(color(for: a, b), style: StrokeStyle(
+                        lineWidth: 4,
+                        lineCap: .round,
+                        lineJoin: .round
+                    ))
+            }
+        }
+    }
+
+    private func color(for a: TrajectoryPoint, _ b: TrajectoryPoint) -> Color {
+        switch colorMode {
+        case .time:
+            let mid = (a.normalizedTimeOfDay + b.normalizedTimeOfDay) / 2
+            return Self.timeColor(normalized: mid)
+        case .speed, .plain:
+            return .accentColor
+        }
+    }
+
+    /// Maps 0...1 → AM yellow → PM orange → evening purple.
+    static func timeColor(normalized t: Double) -> Color {
+        let clamped = min(1.0, max(0.0, t))
+        let amYellow = (r: 251.0/255, g: 191.0/255, b: 36.0/255)   // #fbbf24
+        let pmOrange = (r: 251.0/255, g: 146.0/255, b: 60.0/255)   // #fb923c
+        let evePurple = (r: 124.0/255, g: 58.0/255, b: 237.0/255)  // #7c3aed
+        if clamped < 0.5 {
+            let t2 = clamped / 0.5
+            return Color(
+                red: amYellow.r + (pmOrange.r - amYellow.r) * t2,
+                green: amYellow.g + (pmOrange.g - amYellow.g) * t2,
+                blue: amYellow.b + (pmOrange.b - amYellow.b) * t2
+            )
+        } else {
+            let t2 = (clamped - 0.5) / 0.5
+            return Color(
+                red: pmOrange.r + (evePurple.r - pmOrange.r) * t2,
+                green: pmOrange.g + (evePurple.g - pmOrange.g) * t2,
+                blue: pmOrange.b + (evePurple.b - pmOrange.b) * t2
+            )
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Regenerate and build**
+
+```bash
+xcodegen generate
+xcodebuild build \
+  -scheme PlaceNotes \
+  -destination 'platform=iOS Simulator,OS=latest,name=iPhone 15 Pro' \
+  | xcpretty
+```
+Expected: build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add PlaceNotes/Views/TrajectoryPolyline.swift project.yml
+git commit -m "feat(trajectory): render gradient polyline as per-pair MapPolylines"
+```
+
+---
+
+## Task 8: `DayTrajectoryView` — the screen
+
+**Files:**
+- Create: `PlaceNotes/Views/DayTrajectoryView.swift`
+
+Composes everything: queries samples and visits for the day, runs `TrajectoryBuilder.build`, renders header card + polyline + place pins inside a `Map`. Empty/sparse states handled per the spec.
+
+Reuses `PlaceAnnotationView` and `PlaceDetailSheet` already defined in `FrequentPlacesMapView.swift`.
+
+- [ ] **Step 1: Write the file**
+
+```swift
+import SwiftUI
+import SwiftData
+import MapKit
+
+struct DayTrajectoryView: View {
+    @Environment(\.modelContext) private var modelContext
+    let day: Date
+
+    @State private var segments: [TrajectorySegment] = []
+    @State private var stats: TrajectoryStats?
+    @State private var dayPlaces: [Place] = []
+    @State private var selectedPlace: Place?
+    @State private var cameraPosition: MapCameraPosition = .automatic
+    @State private var hasLoaded = false
+
+    private var isPathAvailable: Bool { !segments.isEmpty }
+
+    var body: some View {
+        ZStack(alignment: .top) {
+            Map(position: $cameraPosition, selection: $selectedPlace) {
+                TrajectoryPolyline(segments: segments, colorMode: .time)
+
+                ForEach(rankings(), id: \.id) { ranking in
+                    Annotation(
+                        ranking.place.displayName,
+                        coordinate: ranking.place.coordinate
+                    ) {
+                        PlaceAnnotationView(ranking: ranking)
+                    }
+                    .tag(ranking.place)
+                }
+            }
+            .mapStyle(.standard(showsTraffic: false))
+            .mapControls {
+                MapCompass()
+                MapScaleView()
+            }
+
+            TrajectoryHeaderCard(day: day, stats: stats, isPathAvailable: isPathAvailable)
+                .padding(.horizontal, 16)
+                .padding(.top, 8)
+
+            if !isPathAvailable && dayPlaces.isEmpty {
+                emptyOverlay
+            }
+        }
+        .navigationTitle(navTitle)
+        .navigationBarTitleDisplayMode(.inline)
+        .sheet(item: $selectedPlace) { place in
+            PlaceDetailSheet(place: place)
+                .presentationDetents([.medium])
+        }
+        .task {
+            guard !hasLoaded else { return }
+            hasLoaded = true
+            await load()
+        }
+    }
+
+    private var navTitle: String {
+        let f = DateFormatter()
+        f.dateFormat = "MMM d"
+        return f.string(from: day)
+    }
+
+    private var emptyOverlay: some View {
+        VStack {
+            Spacer()
+            Text("No location data recorded for this day")
+                .font(.callout)
+                .padding(12)
+                .background(.regularMaterial)
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+                .padding(.bottom, 32)
+        }
+    }
+
+    /// Build a synthetic ranking-per-place so we can reuse PlaceAnnotationView.
+    /// `qualifiedStays` and `totalMinutes` here are scoped to this day only.
+    private func rankings() -> [PlaceRanking] {
+        let calendar = Calendar.current
+        let dayStart = calendar.startOfDay(for: day)
+        let dayEnd = calendar.date(byAdding: .day, value: 1, to: dayStart)!
+        return dayPlaces.map { place in
+            let visitsToday = place.visits.filter {
+                $0.arrivalDate >= dayStart && $0.arrivalDate < dayEnd
+            }
+            let minutesToday = visitsToday.reduce(0) { $0 + $1.durationMinutes }
+            return PlaceRanking(
+                place: place,
+                qualifiedStays: visitsToday.count,
+                totalMinutes: minutesToday
+            )
+        }
+    }
+
+    private func load() async {
+        let calendar = Calendar.current
+        let dayStart = calendar.startOfDay(for: day)
+        let dayEnd = calendar.date(byAdding: .day, value: 1, to: dayStart)!
+
+        let sampleDescriptor = FetchDescriptor<RawLocationSample>(
+            predicate: #Predicate {
+                $0.timestamp >= dayStart
+                && $0.timestamp < dayEnd
+                && $0.filterStatus == "accepted"
+            },
+            sortBy: [SortDescriptor(\.timestamp)]
+        )
+        let samples = (try? modelContext.fetch(sampleDescriptor)) ?? []
+
+        let placeDescriptor = FetchDescriptor<Place>()
+        let allPlaces = (try? modelContext.fetch(placeDescriptor)) ?? []
+        let placesToday = allPlaces.filter { place in
+            place.visits.contains { $0.arrivalDate >= dayStart && $0.arrivalDate < dayEnd }
+        }
+
+        let builtSegments = TrajectoryBuilder.build(samples: samples, day: day)
+        let computedStats = TrajectoryBuilder.computeStats(
+            segments: builtSegments,
+            placeCount: placesToday.count
+        )
+
+        await MainActor.run {
+            self.segments = builtSegments
+            self.dayPlaces = placesToday
+            self.stats = computedStats
+            self.cameraPosition = initialCamera(segments: builtSegments, places: placesToday)
+        }
+    }
+
+    private func initialCamera(
+        segments: [TrajectorySegment],
+        places: [Place]
+    ) -> MapCameraPosition {
+        var coords: [CLLocationCoordinate2D] = []
+        coords.append(contentsOf: segments.flatMap { $0.points.map(\.coordinate) })
+        coords.append(contentsOf: places.map(\.coordinate))
+        guard !coords.isEmpty else { return .automatic }
+
+        let lats = coords.map(\.latitude)
+        let lons = coords.map(\.longitude)
+        let center = CLLocationCoordinate2D(
+            latitude: (lats.min()! + lats.max()!) / 2,
+            longitude: (lons.min()! + lons.max()!) / 2
+        )
+        let span = MKCoordinateSpan(
+            latitudeDelta: max(0.005, (lats.max()! - lats.min()!) * 1.4),
+            longitudeDelta: max(0.005, (lons.max()! - lons.min()!) * 1.4)
+        )
+        return .region(MKCoordinateRegion(center: center, span: span))
+    }
+}
+```
+
+- [ ] **Step 2: Regenerate and build**
+
+```bash
+xcodegen generate
+xcodebuild build \
+  -scheme PlaceNotes \
+  -destination 'platform=iOS Simulator,OS=latest,name=iPhone 15 Pro' \
+  | xcpretty
+```
+Expected: build succeeds. If `PlaceRanking` or `PlaceDetailSheet` are not visible, they live in `FrequentPlacesMapView.swift` — they're internal and should resolve from the same module.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add PlaceNotes/Views/DayTrajectoryView.swift project.yml
+git commit -m "feat(trajectory): DayTrajectoryView screen with map, header, pins"
+```
+
+---
+
+## Task 9: Wire entry point into `LogbookView`
+
+**Files:**
+- Modify: `PlaceNotes/Views/LogbookView.swift`
+
+Add a leading `swipeActions` "Map" button on every `LogbookVisitRow` (defined at the bottom of `LogbookView.swift`). Tapping it pushes `DayTrajectoryView(day:)` for the visit's local-day. The push uses a `NavigationLink` driven by an `@State` selection, so the swipe action just sets state.
+
+- [ ] **Step 1: Add navigation state to `LogbookView`**
+
+In `PlaceNotes/Views/LogbookView.swift`, inside the `LogbookView` struct's `@State` declarations (around line 9-12), add:
+
+```swift
+    @State private var trajectoryDay: Date?
+```
+
+- [ ] **Step 2: Add a `navigationDestination` to the root `NavigationStack`**
+
+`navigationDestination(item:)` requires the item type to be `Hashable` — `Date` already is, so no wrapper is needed. Find the `.navigationTitle("Logbook")` modifier (around line 84). Replace:
+
+```swift
+            .navigationTitle("Logbook")
+            .sheet(item: $visitForAlternatives) { visit in
+```
+
+with:
+
+```swift
+            .navigationTitle("Logbook")
+            .navigationDestination(item: $trajectoryDay) { day in
+                DayTrajectoryView(day: day)
+            }
+            .sheet(item: $visitForAlternatives) { visit in
+```
+
+- [ ] **Step 3: Pass an `onShowTrajectory` callback through `MonthSection` to `LogbookVisitRow`**
+
+`MonthSection` (around line 285) needs to receive and forward a callback. Update its declaration:
+
+```swift
+private struct MonthSection: View {
+    let year: Int
+    let month: Int
+    let visits: [Visit]
+    var onPickAlternative: ((Visit) -> Void)?
+    var onDelete: ((Visit) -> Void)?
+    var onShowTrajectory: ((Date) -> Void)?
+```
+
+Inside `MonthSection.body`, find where `LogbookVisitRow` is constructed inside `.swipeActions(...)` (around line 321). Add a leading swipe action just above the existing trailing one:
+
+```swift
+                    .swipeActions(edge: .leading, allowsFullSwipe: false) {
+                        Button {
+                            onShowTrajectory?(visit.arrivalDate)
+                        } label: {
+                            Label("Map", systemImage: "map")
+                        }
+                        .tint(.blue)
+                    }
+                    .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                        Button {
+                            onDelete?(visit)
+                        } label: {
+                            Label("Delete", systemImage: "trash")
+                        }
+                        .tint(.red)
+                    }
+```
+
+- [ ] **Step 4: Pass the callback from `LogbookView` into `MonthSection`**
+
+In `LogbookView.body`, find the `MonthSection(...)` call (around line 56-67) and add the `onShowTrajectory` argument:
+
+```swift
+                                    MonthSection(
+                                        year: yearGroup.year,
+                                        month: monthGroup.month,
+                                        visits: monthGroup.visits,
+                                        onPickAlternative: { visit in
+                                            visitForAlternatives = visit
+                                        },
+                                        onDelete: { visit in
+                                            visitToDelete = visit
+                                            showDeleteConfirmation = true
+                                        },
+                                        onShowTrajectory: { arrival in
+                                            trajectoryDay = Calendar.current.startOfDay(for: arrival)
+                                        }
+                                    )
+```
+
+- [ ] **Step 5: Regenerate and build**
+
+```bash
+xcodegen generate
+xcodebuild build \
+  -scheme PlaceNotes \
+  -destination 'platform=iOS Simulator,OS=latest,name=iPhone 15 Pro' \
+  | xcpretty
+```
+Expected: build succeeds.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add PlaceNotes/Views/LogbookView.swift
+git commit -m "feat(trajectory): add Map swipe action on Logbook visit rows"
+```
+
+---
+
+## Task 10: Manual verification on simulator
+
+**No code changes.** Spec compliance check on simulator with realistic data.
+
+- [ ] **Step 1: Run all unit tests**
+
+```bash
+xcodebuild test \
+  -scheme PlaceNotes \
+  -destination 'platform=iOS Simulator,OS=latest,name=iPhone 15 Pro' \
+  | xcpretty
+```
+Expected: all tests (existing + new `TrajectoryBuilderTests`) pass.
+
+- [ ] **Step 2: Launch the app in simulator with seeded location data**
+
+If the project has a debug seed action, use it. Otherwise: enable tracking in the simulator (Features → Location → Freeway Drive or Custom Location) for a few minutes to accumulate `RawLocationSample` rows and at least one `Visit`.
+
+- [ ] **Step 3: Verify the golden path**
+
+1. Open **Logbook** tab.
+2. Expand a Month with at least one Visit.
+3. Swipe right on a Visit row → blue **Map** button appears.
+4. Tap **Map** → `DayTrajectoryView` pushes onto the nav stack.
+5. Map shows: gradient polyline (yellow → purple), Place pins for that day's visits, header card with date / distance / counts.
+6. Tap a Place pin → `PlaceDetailSheet` opens.
+7. Back arrow → returns to Logbook.
+
+- [ ] **Step 4: Verify edge cases**
+
+- **Visit on a day with no `RawLocationSample` data** (e.g., a historical visit before tracking was on): header reads "Path data not available for this day", no overlay (because there are still pins), no path drawn.
+- **A day with samples but no visits** (e.g., briefly tracked but never met dwell threshold): path renders alone, header reads "0 places · {n} samples".
+- **Day with a phone-off gap > 10 minutes**: polyline visibly breaks at the gap (no straight line across).
+
+- [ ] **Step 5: Final commit and push**
+
+If verification surfaced no issues, no further commit needed. Otherwise commit fixes with descriptive messages, then:
+
+```bash
+git push -u origin feature/day-trajectory-on-map
+```
+
+(Only push when the user explicitly asks — confirm before running this step.)
+
+---
+
+## Summary
+
+10 tasks: 5 of them strict TDD on `TrajectoryBuilder` (the algorithmic core), 3 view-creation tasks, 1 integration task on `LogbookView`, 1 manual verification. All commits on `feature/day-trajectory-on-map`. No changes to `LocationManager`, `RawLocationSample`, or any model layer.

--- a/docs/superpowers/specs/2026-04-24-day-trajectory-on-map-design.md
+++ b/docs/superpowers/specs/2026-04-24-day-trajectory-on-map-design.md
@@ -1,0 +1,222 @@
+# Day Trajectory on Map — Design
+
+**Date:** 2026-04-24
+**Status:** Approved (brainstorm); pending implementation plan
+
+## Purpose
+
+Let the user see the path they walked/drove on a chosen day, rendered on a map and overlaid with the day's Place pins. The feature serves two intents the user identified during brainstorming:
+
+1. **Memory / journaling** — "what did Saturday look like?"
+2. **Insight** — "how did I move that day?"
+
+Both are satisfied by a single-day, view-only trajectory map in v1. Date-range views, speed-coloring, and a timeline scrubber are deliberately deferred to later versions but accommodated by the architecture.
+
+## Non-Goals (v1)
+
+- Date-range trajectories (week, trip)
+- All-time heatmap / route aggregation
+- Tap-to-inspect a polyline point (timestamp/speed popover)
+- Animated playback / timeline scrubber
+- Speed-coded or plain-color modes (only time-gradient ships)
+- Live-tailing while tracking is active
+- Cross-midnight stitched trajectories
+- Debug visualization of rejected samples
+
+## User Flow
+
+1. User opens the **Logbook** tab and scrolls to a day.
+2. Each day section header shows a small trailing **map** button (e.g., `Image(systemName: "map")`).
+3. Tapping it pushes `DayTrajectoryView` onto the existing `NavigationStack`.
+4. The screen shows a full-bleed map with that day's path (gradient by time of day) and the day's Place pins.
+5. Tapping a Place pin opens the existing `PlaceDetailSheet` (same component already used by the map tab).
+6. Back button returns to the Logbook.
+
+## Visual Design
+
+- **Polyline color:** time-of-day gradient — morning warm yellow → afternoon orange → evening purple. The gradient is the primary v1 encoding.
+- **Place pins:** reuse `PlaceAnnotationView` from `FrequentPlacesMapView` for visual consistency.
+- **Header card:** small material-backed card pinned top-center showing:
+  - Day formatted (e.g., "Saturday, April 18")
+  - Total distance (locale-aware km / mi)
+  - "{n} places · {n} samples"
+  - Subtitle hint "AM → PM" indicating the gradient direction (no separate legend in v1)
+- **Recenter button:** bottom-right floating button matching `FrequentPlacesMapView`.
+- **Polyline interactivity:** none in v1 (view-only).
+
+## Architecture
+
+### New files
+
+```
+Services/
+  TrajectoryBuilder.swift     – pure helpers (enum with static methods)
+  TrajectoryStats.swift       – struct of aggregate counts/distance
+
+Views/
+  DayTrajectoryView.swift     – the screen
+  TrajectoryPolyline.swift    – gradient renderer (View)
+  TrajectoryHeaderCard.swift  – floating header
+```
+
+### Modified files
+
+- `Views/LogbookView.swift` — add trailing map button to each day section header; push `DayTrajectoryView(day:)` on tap.
+
+### No changes to
+
+- `LocationManager` (raw samples already persisted at `LocationManager.swift:275`)
+- `RawLocationSample` model
+- `Place`, `Visit`, `PlaceAnnotationView`, `PlaceDetailSheet`
+
+### Type sketches
+
+```swift
+struct TrajectoryPoint {
+    let coordinate: CLLocationCoordinate2D
+    let timestamp: Date
+    let normalizedTimeOfDay: Double   // 0..1, computed from local-day boundaries
+    let speedMetersPerSecond: Double  // carried for v2 speed-coloring
+}
+
+struct TrajectorySegment {
+    let points: [TrajectoryPoint]     // contiguous, no gap > maxGapSeconds
+}
+
+struct TrajectoryStats {
+    let totalDistanceMeters: Double
+    let sampleCount: Int
+    let segmentCount: Int
+    let placeCount: Int
+}
+
+enum TrajectoryColorMode {
+    case time     // v1 default (only mode shipped)
+    case speed    // v2
+    case plain    // v2
+}
+
+enum TrajectoryBuilder {
+    static func build(samples: [RawLocationSample], day: Date) -> [TrajectorySegment]
+    static func splitIntoSegments(_ samples: [RawLocationSample], maxGapSeconds: TimeInterval) -> [[RawLocationSample]]
+    static func simplify(_ points: [TrajectoryPoint], epsilonMeters: Double) -> [TrajectoryPoint]
+    static func computeStats(segments: [TrajectorySegment], placeCount: Int) -> TrajectoryStats
+}
+```
+
+## Data Flow
+
+`DayTrajectoryView` takes a `Date` (the day) as input.
+
+### Sample query
+
+```swift
+let calendar = Calendar.current
+let startOfDay = calendar.startOfDay(for: day)
+let endOfDay = calendar.date(byAdding: .day, value: 1, to: startOfDay)!
+
+let descriptor = FetchDescriptor<RawLocationSample>(
+    predicate: #Predicate {
+        $0.timestamp >= startOfDay
+        && $0.timestamp < endOfDay
+        && $0.filterStatus == "accepted"
+    },
+    sortBy: [SortDescriptor(\.timestamp)]
+)
+```
+
+Only `filterStatus == "accepted"` samples are rendered — rejected (low-accuracy / jittery) samples would visually corrupt the path.
+
+### Visit query
+
+A separate `FetchDescriptor<Visit>` with the same date predicate provides pins; each `Visit.place` drives the existing `PlaceAnnotationView`.
+
+### Transformation pipeline
+
+```
+[RawLocationSample] (sorted by timestamp)
+   → splitIntoSegments(maxGapSeconds: 600)     // break at >10min gaps
+   → map each sample → TrajectoryPoint         // compute normalizedTimeOfDay
+   → simplify(epsilon: derived from zoom)      // Douglas-Peucker
+   → [TrajectorySegment]
+```
+
+### Threading
+
+Query + transformation run in a `Task` off the main actor; results hop back to `@MainActor` for `@State` assignment. Mirrors the existing pattern in `LocationManager`.
+
+## Rendering
+
+### Gradient strategy
+
+MapKit's `MapPolyline` only supports a single stroke color, not a per-vertex gradient. v1 draws the path as **N short `MapPolyline` segments**, each colored by its midpoint's `normalizedTimeOfDay`.
+
+With Douglas-Peucker keeping the on-screen vertex count ≤ ~500, this produces a smooth perceived gradient at acceptable cost. A future optimization (drop to UIKit `MKMapView` + custom `MKOverlayRenderer`) is possible but rejected for v1 — adds significant complexity and breaks SwiftUI-`Map` consistency with the rest of the app.
+
+### `TrajectoryPolyline` view
+
+Takes `[TrajectorySegment]` and a `TrajectoryColorMode`. Returns a `MapContentBuilder` of the per-segment polylines. The `ColorMode` enum is the single seam where v2 toggles plug in — adding `.speed` or `.plain` is one additional case in the color function plus a toolbar `Picker`.
+
+## Performance
+
+- **Query:** date + status predicate, sorted; expected to run in milliseconds for a single day.
+- **Simplification:** Douglas-Peucker with epsilon ≈ a few meters, capped to ≤ ~500 on-screen vertices. Runs once on appear and once on significant zoom change (debounced).
+- **Render:** ~500 short `MapPolyline` segments + ≤ ~10 `PlaceAnnotationView` pins. Within MapKit's comfort zone.
+- **Memory:** a day's `RawLocationSample` rows are well under a few MB even at high update rates. SwiftData objects are held only inside the loading `Task`; only transformed `TrajectorySegment` values are retained in `@State`.
+- **No new background work, no new permissions, no battery impact** — the feature is read-only on data already collected.
+
+## Privacy
+
+Raw GPS samples never leave the device. Same posture as the rest of the app — SwiftData only, no analytics, no remote calls.
+
+## Edge Cases
+
+| Case | Behavior |
+|---|---|
+| 0 accepted samples for the day | Map centered on day's visits (or last-known if none); overlay message "No location data recorded for this day". The Logbook button is still shown — it is **not** conditionally hidden per-day. |
+| Samples but no visits | Path renders alone. Header reads "0 places · {n} samples". |
+| Visits but no samples (e.g., feature added after some history existed) | Pins only. Header card shows "Path data not available for this day". |
+| Single-point segment after splitting | Suppressed (not drawable as polyline). Not rendered in v1. |
+| Gap > 10 minutes between samples | Polyline breaks at the gap — no "teleport" line drawn across. |
+| Today, mid-day | Shows what's been recorded so far. Refreshes only on appear (no live tail in v1). |
+| Crossing midnight | Out of scope — local-day filter only. Long stays/drives spanning midnight appear truncated to the selected day. |
+| Future date | Cannot occur via Logbook entry (only days with visits are listed). Defensive: clamp input to `Date.now`. |
+| DST transition day | `Calendar.startOfDay` handles correctly. |
+
+## Testing
+
+- **Unit tests on `TrajectoryBuilder`** (pure functions, primary coverage):
+  - `splitIntoSegments` — boundaries at exactly the gap threshold, multiple gaps, single sample, empty input.
+  - `simplify` (Douglas-Peucker) — straight line stays straight, sharp corners preserved, dense colinear points collapse.
+  - `computeStats` — distance math against known coordinates, empty input.
+- **`DayTrajectoryView`:** no automated test in v1 — view is mostly composition over MapKit and the project does not currently have a snapshot harness. Verify manually on simulator with seeded data.
+
+## Extensibility (Deliberately Reserved)
+
+These are *not* built in v1, but the architecture won't fight us:
+
+- **`ColorMode` toggle** (time / speed / plain) — single enum, single render-time switch, single new toolbar `Picker`.
+- **Tap-to-inspect** — `TrajectoryPoint` already carries `timestamp` and `speedMetersPerSecond`; add a tap gesture and a popover.
+- **Timeline scrubber** — bottom overlay finding nearest point by `timestamp`; `TrajectoryPoint`s in `@State` are sufficient.
+- **Date range** — swap `Date` input for a `DateInterval`, broaden the predicate; rendering layer unchanged.
+- **Heatmap / aggregate routes** — can compose on top of `TrajectoryBuilder` since it's pure and SwiftData-free.
+
+No placeholder code, no empty hooks, no unused protocols. Extension points are real types (the enum, the point fields).
+
+## Coding Conventions Adhered To
+
+- `TrajectoryBuilder` is an `enum` with static methods — matches `StayDetector` pattern.
+- All SwiftData mutations stay on `@MainActor`; off-main work uses `Task` + hop-back.
+- Reuses existing components (`PlaceAnnotationView`, `PlaceDetailSheet`) rather than re-inventing.
+- No comments except where the *why* is non-obvious (e.g., gap-splitting rationale, gradient-via-many-segments rationale).
+- Pure helpers separated from view code, in `Services/`.
+
+## Implementation Order (high-level — detailed plan to follow)
+
+1. `TrajectoryPoint`, `TrajectorySegment`, `TrajectoryStats`, `TrajectoryColorMode` types.
+2. `TrajectoryBuilder` pure helpers + unit tests.
+3. `TrajectoryHeaderCard` view.
+4. `TrajectoryPolyline` view.
+5. `DayTrajectoryView` composition.
+6. `LogbookView` button wiring.
+7. Manual simulator verification with seeded data covering golden path + edge cases from the table above.

--- a/docs/superpowers/specs/2026-04-24-day-trajectory-on-map-design.md
+++ b/docs/superpowers/specs/2026-04-24-day-trajectory-on-map-design.md
@@ -25,12 +25,14 @@ Both are satisfied by a single-day, view-only trajectory map in v1. Date-range v
 
 ## User Flow
 
-1. User opens the **Logbook** tab and scrolls to a day.
-2. Each day section header shows a small trailing **map** button (e.g., `Image(systemName: "map")`).
-3. Tapping it pushes `DayTrajectoryView` onto the existing `NavigationStack`.
-4. The screen shows a full-bleed map with that day's path (gradient by time of day) and the day's Place pins.
+1. User opens the **Logbook** tab and expands a Month section.
+2. Each `LogbookVisitRow` exposes a leading `swipeActions` button (`Image(systemName: "map")`, blue tint) labeled "Map".
+3. Swiping a visit row right and tapping **Map** pushes `DayTrajectoryView(day:)` onto the existing `NavigationStack`, with `day` set to the local-day of that visit's `arrivalDate`.
+4. The screen shows a full-bleed map with that day's path (gradient by time of day) and that day's Place pins.
 5. Tapping a Place pin opens the existing `PlaceDetailSheet` (same component already used by the map tab).
 6. Back button returns to the Logbook.
+
+**Note on placement:** `LogbookView` currently groups Year → Month → flat list of visits — no day sub-grouping exists. A per-visit entry was chosen over restructuring Logbook into day sections to minimize churn in an unrelated component. Adding day sub-grouping later is independent of this feature.
 
 ## Visual Design
 
@@ -61,7 +63,7 @@ Views/
 
 ### Modified files
 
-- `Views/LogbookView.swift` — add trailing map button to each day section header; push `DayTrajectoryView(day:)` on tap.
+- `Views/LogbookView.swift` — add a leading `swipeActions` "Map" button on `LogbookVisitRow`; push `DayTrajectoryView(day:)` for the visit's local-day on tap.
 
 ### No changes to
 


### PR DESCRIPTION
Closes #48

## Summary

- Adds `DayTrajectoryView` — a new full-screen map showing a single day's GPS path overlaid with that day's Place pins. Polyline is colored by time-of-day (morning yellow → afternoon orange → evening purple).
- Reachable from the **Logbook** tab: leading swipe on any visit row → blue **Map** action → opens the trajectory for that visit's local day.
- Pure helpers in `TrajectoryBuilder` (segment-split on >10min gaps, Douglas-Peucker simplify, stats, top-level build) covered by 19 new unit tests. 114/114 in the full suite passing.
- No new permissions, no background work, no network calls — read-only on `RawLocationSample` rows the app already collects.

## Architecture

- `Services/TrajectoryTypes.swift` — value types (`TrajectoryPoint`, `TrajectorySegment`, `TrajectoryStats`, `TrajectoryColorMode`).
- `Services/TrajectoryBuilder.swift` — pure `enum` with static methods, mirrors `StayDetector`.
- `Views/TrajectoryHeaderCard.swift` — floating material header card.
- `Views/TrajectoryPolyline.swift` — `MapContent` rendering the gradient as N short `MapPolyline` segments (SwiftUI `Map` doesn't support per-vertex gradients).
- `Views/DayTrajectoryView.swift` — composes everything; queries on `.task(id: day)`.
- `Views/LogbookView.swift` — adds the leading swipe action and `navigationDestination`.

`TrajectoryColorMode` is the v2 extensibility seam — `.speed` and `.plain` are reserved cases that fall back to accent color so future toggles can flip the enum without crashing.

## Spec & Plan

- Design: [`docs/superpowers/specs/2026-04-24-day-trajectory-on-map-design.md`](https://github.com/ychu824/PlaceNotes/blob/feature/day-trajectory-on-map/docs/superpowers/specs/2026-04-24-day-trajectory-on-map-design.md)
- Implementation plan: [`docs/superpowers/plans/2026-04-24-day-trajectory-on-map.md`](https://github.com/ychu824/PlaceNotes/blob/feature/day-trajectory-on-map/docs/superpowers/plans/2026-04-24-day-trajectory-on-map.md)

## Test plan

- [x] Open Logbook tab; expand a month with at least one Visit.
- [x] Swipe right on a Visit row → confirm blue **Map** action appears.
- [x] Tap **Map** → confirm `DayTrajectoryView` pushes onto the nav stack.
- [ ] Confirm the screen shows: gradient polyline (yellow → purple), Place pins for that day's visits, header card (date + distance + counts), recenter button bottom-right.
- [x] Tap a Place pin → confirm `PlaceDetailSheet` opens.
- [x] Back arrow → confirm returns to Logbook.
- [x] Edge case: a historical Visit on a day with no `RawLocationSample` data → header reads "Path data not available for this day"; pins still visible; no path drawn.
- [ ] Edge case: a day with samples but no qualifying Visits → path renders alone, header reads "0 places · {n} samples".
- [ ] Edge case: a day with a phone-off gap > 10 min → polyline visibly breaks at the gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)