### PR TITLE
Batch raw location samples and fix background launch initialization

### DIFF
--- a/PlaceNotes/PlaceNotesApp.swift
+++ b/PlaceNotes/PlaceNotesApp.swift
@@ -3,9 +3,9 @@ import SwiftData
 
 @main
 struct PlaceNotesApp: App {
-    @StateObject private var settings = AppSettings.shared
-    @StateObject private var locationManager = LocationManager(settings: .shared)
-
+    let settings: AppSettings
+    let locationManager: LocationManager
+    let trackingManager: TrackingManager
     let modelContainer: ModelContainer
 
     init() {
@@ -28,29 +28,44 @@ struct PlaceNotesApp: App {
             return try ModelContainer(for: Place.self, Visit.self, CustomCategory.self, JournalEntry.self, RawLocationSample.self, configurations: config)
         }
 
+        let container: ModelContainer
         do {
-            modelContainer = try makeContainer()
+            container = try makeContainer()
         } catch {
             // Schema migration failed — delete the old store and retry.
             // This is expected when new model fields are added during development.
             print("[PlaceNotesApp] Store incompatible, resetting: \(error.localizedDescription)")
-            let fm = FileManager.default
-            for suffix in ["", "-wal", "-shm"] {
-                try? fm.removeItem(at: storeURL.appendingPathExtension(suffix.isEmpty ? "" : String(suffix.dropFirst())))
-                if suffix.isEmpty {
-                    try? fm.removeItem(at: storeURL)
-                } else {
-                    try? fm.removeItem(atPath: storeURL.path + suffix)
-                }
-            }
+            Self.deleteStoreFiles(at: storeURL)
             UserDefaults.standard.set(false, forKey: "mockDataSeeded_debug")
 
             do {
-                modelContainer = try makeContainer()
+                container = try makeContainer()
             } catch {
                 fatalError("Failed to create ModelContainer after reset: \(error)")
             }
         }
+        self.modelContainer = container
+
+        let settings = AppSettings.shared
+        self.settings = settings
+
+        // Wire up LocationManager with the model context in init() rather than
+        // onAppear so background-only relaunches via significant location changes
+        // (where the SwiftUI scene never appears) still persist samples and
+        // resume tracking.
+        let locationManager = LocationManager(settings: settings)
+        locationManager.configure(modelContext: container.mainContext)
+        locationManager.onVisitRecorded = { visit in
+            if let place = visit.place {
+                NotificationManager.shared.checkMilestone(for: place)
+            }
+        }
+        self.locationManager = locationManager
+
+        // TrackingManager.init -> checkPauseExpiry auto-resumes monitoring when
+        // the persisted state is .active, which is what makes background
+        // relaunches actually start collecting again.
+        self.trackingManager = TrackingManager(locationManager: locationManager, settings: settings)
     }
 
     var body: some Scene {
@@ -62,7 +77,6 @@ struct PlaceNotesApp: App {
                 .environmentObject(makeQuickCaptureViewModel())
                 .onAppear {
                     NotificationManager.shared.requestAuthorization()
-                    locationManager.configure(modelContext: modelContainer.mainContext)
                     Self.removeOldSharedStore()
 
                     #if DEBUG
@@ -71,6 +85,18 @@ struct PlaceNotesApp: App {
                 }
         }
         .modelContainer(modelContainer)
+    }
+
+    private static func deleteStoreFiles(at storeURL: URL) {
+        let fm = FileManager.default
+        let urls = [
+            storeURL,
+            URL(fileURLWithPath: storeURL.path + "-wal"),
+            URL(fileURLWithPath: storeURL.path + "-shm")
+        ]
+        for url in urls {
+            try? fm.removeItem(at: url)
+        }
     }
 
     /// One-time cleanup: remove the old shared `default.store` that was used
@@ -101,14 +127,6 @@ struct PlaceNotesApp: App {
 
     @MainActor
     private func makeTrackingViewModel() -> TrackingViewModel {
-        let trackingManager = TrackingManager(locationManager: locationManager, settings: settings)
-
-        locationManager.onVisitRecorded = { visit in
-            if let place = visit.place {
-                NotificationManager.shared.checkMilestone(for: place)
-            }
-        }
-
-        return TrackingViewModel(trackingManager: trackingManager)
+        TrackingViewModel(trackingManager: trackingManager)
     }
 }

--- a/PlaceNotes/Services/LocationManager.swift
+++ b/PlaceNotes/Services/LocationManager.swift
@@ -29,6 +29,19 @@ struct StayCluster {
     var isAmbiguous: Bool { spreadMeters > 100 }
 }
 
+/// Plain-data representation of a location update queued for batch persistence.
+private struct PendingRawSample {
+    let latitude: Double
+    let longitude: Double
+    let timestamp: Date
+    let horizontalAccuracy: Double
+    let speed: Double
+    let altitude: Double?
+    let verticalAccuracy: Double?
+    let course: Double?
+    let filterStatus: String
+}
+
 final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelegate {
     private let clManager = CLLocationManager()
     private var modelContext: ModelContext?
@@ -47,6 +60,11 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
     private var lastRecordedDwellLocation: CLLocation?
     private var dwellTimer: Timer?
     private let settings: AppSettings
+
+    /// In-memory buffer of raw samples awaiting batch insert into SwiftData.
+    /// Flushed when the buffer fills, on the dwell-timer tick, or on stop.
+    private var pendingRawSamples: [PendingRawSample] = []
+    private let rawSampleBatchSize = 50
 
     /// Distance (meters) the user must move before we consider them "left".
     private let dwellRadiusMeters: Double = 80
@@ -74,7 +92,8 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
         super.init()
         clManager.delegate = self
         clManager.allowsBackgroundLocationUpdates = true
-        clManager.pausesLocationUpdatesAutomatically = false
+        clManager.pausesLocationUpdatesAutomatically = true
+        clManager.activityType = .other
         clManager.desiredAccuracy = kCLLocationAccuracyBest
         clManager.distanceFilter = 10
         authorizationStatus = clManager.authorizationStatus
@@ -108,6 +127,7 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
         clManager.stopUpdatingLocation()
         dwellTimer?.invalidate()
         dwellTimer = nil
+        flushRawSamples()
         finalizeDwell()
         logger.notice("All monitoring stopped")
     }
@@ -123,6 +143,8 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
     }
 
     private func checkDwellStatus() {
+        flushRawSamples()
+
         guard !dwellSamples.isEmpty,
               let start = dwellStartDate,
               let modelContext else {
@@ -260,24 +282,19 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
             filterStatus = "accepted"
         }
 
-        let lat = location.coordinate.latitude
-        let lon = location.coordinate.longitude
-        let ts = location.timestamp
-        let hAcc = location.horizontalAccuracy
-        let spd = location.speed
-        let alt = location.altitude
-        let vAcc = location.verticalAccuracy
-        let crs = location.course >= 0 ? location.course : nil
-
-        Task { @MainActor [weak self] in
-            guard let ctx = self?.modelContext else { return }
-            let raw = RawLocationSample(
-                latitude: lat, longitude: lon, timestamp: ts,
-                horizontalAccuracy: hAcc, speed: spd,
-                altitude: alt, verticalAccuracy: vAcc, course: crs,
-                filterStatus: filterStatus
-            )
-            ctx.insert(raw)
+        pendingRawSamples.append(PendingRawSample(
+            latitude: location.coordinate.latitude,
+            longitude: location.coordinate.longitude,
+            timestamp: location.timestamp,
+            horizontalAccuracy: location.horizontalAccuracy,
+            speed: location.speed,
+            altitude: location.altitude,
+            verticalAccuracy: location.verticalAccuracy,
+            course: location.course >= 0 ? location.course : nil,
+            filterStatus: filterStatus
+        ))
+        if pendingRawSamples.count >= rawSampleBatchSize {
+            flushRawSamples()
         }
 
         let sample = LocationSample(
@@ -330,6 +347,36 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
         logger.error("Location error: \(error.localizedDescription)")
         if let clError = error as? CLError {
             logger.error("CLError code: \(clError.code.rawValue)")
+        }
+    }
+
+    // MARK: - Raw Sample Batching
+
+    private func flushRawSamples() {
+        guard !pendingRawSamples.isEmpty else { return }
+        let batch = pendingRawSamples
+        pendingRawSamples.removeAll(keepingCapacity: true)
+        Task { @MainActor [weak self] in
+            guard let ctx = self?.modelContext else { return }
+            for sample in batch {
+                ctx.insert(RawLocationSample(
+                    latitude: sample.latitude,
+                    longitude: sample.longitude,
+                    timestamp: sample.timestamp,
+                    horizontalAccuracy: sample.horizontalAccuracy,
+                    speed: sample.speed,
+                    altitude: sample.altitude,
+                    verticalAccuracy: sample.verticalAccuracy,
+                    course: sample.course,
+                    filterStatus: sample.filterStatus
+                ))
+            }
+            do {
+                try ctx.save()
+                logger.debug("Flushed \(batch.count) raw samples")
+            } catch {
+                logger.error("Failed to save raw sample batch: \(error.localizedDescription)")
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
This PR improves location data persistence performance and fixes initialization timing issues that prevented background-only app launches from properly resuming location tracking.

## Key Changes

**Location Sample Batching**
- Introduced `PendingRawSample` struct to buffer raw location updates in memory before batch insertion into SwiftData
- Raw samples are now accumulated in `pendingRawSamples` array and flushed when:
  - Buffer reaches 50 samples
  - Dwell status is checked
  - Location monitoring stops
- Replaced individual Task-based inserts with a single batched insert operation, reducing database transaction overhead

**Background Launch Initialization**
- Moved `LocationManager` and `TrackingManager` initialization from `onAppear` to `init()` in `PlaceNotesApp`
- This ensures location tracking resumes immediately on background-only relaunches (triggered by significant location changes) before any SwiftUI scene appears
- Changed `@StateObject` properties to regular stored properties since they're now initialized in `init()`
- Wired up `onVisitRecorded` callback and `TrackingManager` initialization in `init()` rather than in view setup

**Location Manager Configuration**
- Changed `pausesLocationUpdatesAutomatically` from `false` to `true` to allow system power optimization
- Added `activityType = .other` to provide activity context to the system

**Code Cleanup**
- Extracted store file deletion logic into `deleteStoreFiles(at:)` helper method
- Simplified `makeTrackingViewModel()` to use the pre-initialized `trackingManager`

## Implementation Details
The batching mechanism ensures that frequent location updates don't create excessive database transactions. The flush operation includes proper error handling and logging. The initialization refactoring is critical for background-only app launches where the SwiftUI scene never appears—without this change, location tracking would not resume until the user manually opens the app.

https://claude.ai/code/session_01LjEMgEWfuNyLytTeXcExmg