### PR TITLE
Day Trajectory Timeline Strip

### DIFF
--- a/PlaceNotes/Models/Visit.swift
+++ b/PlaceNotes/Models/Visit.swift
@@ -58,6 +58,17 @@ final class Visit {
         return max(0, Int(end.timeIntervalSince(arrivalDate) / 60))
     }
 
+    /// Human-readable duration. "45m" / "1h" / "1h 15m" / "0m".
+    var durationString: String {
+        let mins = durationMinutes
+        if mins >= 60 {
+            let h = mins / 60
+            let m = mins % 60
+            return m > 0 ? "\(h)h \(m)m" : "\(h)h"
+        }
+        return "\(mins)m"
+    }
+
     var timeOfDay: TimeOfDay {
         let hour = Calendar.current.component(.hour, from: arrivalDate)
         switch hour {

--- a/PlaceNotes/Models/Visit.swift
+++ b/PlaceNotes/Models/Visit.swift
@@ -58,7 +58,6 @@ final class Visit {
         return max(0, Int(end.timeIntervalSince(arrivalDate) / 60))
     }
 
-    /// Human-readable duration. "45m" / "1h" / "1h 15m" / "0m".
     var durationString: String {
         let mins = durationMinutes
         if mins >= 60 {

--- a/PlaceNotes/Views/DayTrajectoryView.swift
+++ b/PlaceNotes/Views/DayTrajectoryView.swift
@@ -11,6 +11,8 @@ struct DayTrajectoryView: View {
     @State private var dayPlaces: [Place] = []
     @State private var selectedPlace: Place?
     @State private var cameraPosition: MapCameraPosition = .automatic
+    @State private var dayVisits: [Visit] = []
+    @State private var selectedVisit: Visit.ID?
 
     private static let navTitleFormatter: DateFormatter = {
         let f = DateFormatter()
@@ -60,6 +62,7 @@ struct DayTrajectoryView: View {
                 HStack {
                     Spacer()
                     Button {
+                        selectedVisit = nil
                         withAnimation {
                             cameraPosition = initialCamera(segments: segments, places: dayPlaces)
                         }
@@ -72,7 +75,20 @@ struct DayTrajectoryView: View {
                             .shadow(radius: 2)
                     }
                     .padding(.trailing, 16)
-                    .padding(.bottom, 24)
+                    .padding(.bottom, dayVisits.isEmpty ? 24 : 112)
+                }
+            }
+
+            if !dayVisits.isEmpty {
+                VStack {
+                    Spacer()
+                    TrajectoryTimelineStrip(
+                        visits: dayVisits,
+                        selectedVisitID: selectedVisit,
+                        onTapVisit: recenterToVisit
+                    )
+                    .padding(.horizontal, 12)
+                    .padding(.bottom, 12)
                 }
             }
 
@@ -145,6 +161,14 @@ struct DayTrajectoryView: View {
             place.visits.contains { $0.arrivalDate >= dayStart && $0.arrivalDate < dayEnd }
         }
 
+        let visitDescriptor = FetchDescriptor<Visit>(
+            predicate: #Predicate {
+                $0.arrivalDate >= dayStart && $0.arrivalDate < dayEnd
+            },
+            sortBy: [SortDescriptor(\.arrivalDate)]
+        )
+        let visitsToday = (try? modelContext.fetch(visitDescriptor)) ?? []
+
         let builtSegments = TrajectoryBuilder.build(samples: samples, day: day)
         let computedStats = TrajectoryBuilder.computeStats(
             segments: builtSegments,
@@ -154,8 +178,21 @@ struct DayTrajectoryView: View {
 
         self.segments = builtSegments
         self.dayPlaces = placesToday
+        self.dayVisits = visitsToday
         self.stats = computedStats
         self.cameraPosition = initialCamera(segments: builtSegments, places: placesToday)
+    }
+
+    private func recenterToVisit(_ visit: Visit) {
+        guard let place = visit.place else { return }
+        selectedVisit = visit.id
+        withAnimation {
+            cameraPosition = .region(MKCoordinateRegion(
+                center: place.coordinate,
+                latitudinalMeters: 200,
+                longitudinalMeters: 200
+            ))
+        }
     }
 
     private func initialCamera(

--- a/PlaceNotes/Views/DayTrajectoryView.swift
+++ b/PlaceNotes/Views/DayTrajectoryView.swift
@@ -75,6 +75,7 @@ struct DayTrajectoryView: View {
                             .shadow(radius: 2)
                     }
                     .padding(.trailing, 16)
+                    // 112 = 88 (strip height) + 12 (strip bottom padding) + 12 (gap above strip)
                     .padding(.bottom, dayVisits.isEmpty ? 24 : 112)
                 }
             }
@@ -180,6 +181,7 @@ struct DayTrajectoryView: View {
         self.dayPlaces = placesToday
         self.dayVisits = visitsToday
         self.stats = computedStats
+        self.selectedVisit = nil
         self.cameraPosition = initialCamera(segments: builtSegments, places: placesToday)
     }
 

--- a/PlaceNotes/Views/LogbookView.swift
+++ b/PlaceNotes/Views/LogbookView.swift
@@ -374,16 +374,6 @@ private struct LogbookVisitRow: View {
         return formatter.string(from: visit.arrivalDate)
     }
 
-    private var durationString: String {
-        let mins = visit.durationMinutes
-        if mins >= 60 {
-            let h = mins / 60
-            let m = mins % 60
-            return m > 0 ? "\(h)h \(m)m" : "\(h)h"
-        }
-        return "\(mins)m"
-    }
-
     private var hasPhoto: Bool {
         let start = visit.arrivalDate.addingTimeInterval(-5 * 60)
         let end = (visit.departureDate ?? visit.arrivalDate).addingTimeInterval(5 * 60)
@@ -439,7 +429,7 @@ private struct LogbookVisitRow: View {
                     Text(dateString)
                         .font(.caption)
                         .foregroundStyle(.secondary)
-                    Text(durationString)
+                    Text(visit.durationString)
                         .font(.caption.bold())
                         .foregroundStyle(Color.accentColor)
                     #if DEBUG

--- a/PlaceNotes/Views/TrajectoryTimelineStrip.swift
+++ b/PlaceNotes/Views/TrajectoryTimelineStrip.swift
@@ -66,6 +66,7 @@ private struct TimelineCard: View {
                     .foregroundStyle(.secondary)
             }
             .frame(width: 84, height: 76)
+            .contentShape(Rectangle())
             .background(
                 RoundedRectangle(cornerRadius: 10)
                     .fill(isSelected ? Color.accentColor.opacity(0.15) : Color.clear)

--- a/PlaceNotes/Views/TrajectoryTimelineStrip.swift
+++ b/PlaceNotes/Views/TrajectoryTimelineStrip.swift
@@ -1,0 +1,80 @@
+import SwiftUI
+
+struct TrajectoryTimelineStrip: View {
+    let visits: [Visit]
+    let selectedVisitID: Visit.ID?
+    let onTapVisit: (Visit) -> Void
+
+    fileprivate static let timeFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "H:mm"
+        return f
+    }()
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            LazyHStack(spacing: 12) {
+                ForEach(visits.compactMap(VisitRow.init), id: \.visit.id) { row in
+                    TimelineCard(
+                        row: row,
+                        isSelected: row.visit.id == selectedVisitID
+                    ) {
+                        onTapVisit(row.visit)
+                    }
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+        }
+        .frame(height: 88)
+        .background(.regularMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+        .shadow(color: .black.opacity(0.1), radius: 4, y: 2)
+    }
+}
+
+private struct VisitRow {
+    let visit: Visit
+    let place: Place
+
+    init?(visit: Visit) {
+        guard let place = visit.place else { return nil }
+        self.visit = visit
+        self.place = place
+    }
+}
+
+private struct TimelineCard: View {
+    let row: VisitRow
+    let isSelected: Bool
+    let onTap: () -> Void
+
+    private var arrivalString: String {
+        TrajectoryTimelineStrip.timeFormatter.string(from: row.visit.arrivalDate)
+    }
+
+    var body: some View {
+        Button(action: onTap) {
+            VStack(spacing: 4) {
+                Text(row.place.emoji)
+                    .font(.title2)
+                Text(arrivalString)
+                    .font(.caption.bold())
+                    .foregroundStyle(.primary)
+                Text(row.visit.durationString)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+            .frame(width: 84, height: 76)
+            .background(
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(isSelected ? Color.accentColor.opacity(0.15) : Color.clear)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                    .strokeBorder(isSelected ? Color.accentColor : Color.clear, lineWidth: 2)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/PlaceNotesTests/VisitTests.swift
+++ b/PlaceNotesTests/VisitTests.swift
@@ -115,6 +115,40 @@ final class VisitTests: XCTestCase {
         XCTAssertNil(visit.medianAccuracyMeters)
     }
 
+    // MARK: - durationString
+
+    func testDurationStringSubHourMinutes() {
+        let v = Visit(
+            arrivalDate: Date(timeIntervalSince1970: 1_700_000_000),
+            departureDate: Date(timeIntervalSince1970: 1_700_000_000 + 45 * 60)
+        )
+        XCTAssertEqual(v.durationString, "45m")
+    }
+
+    func testDurationStringExactHours() {
+        let v = Visit(
+            arrivalDate: Date(timeIntervalSince1970: 1_700_000_000),
+            departureDate: Date(timeIntervalSince1970: 1_700_000_000 + 60 * 60)
+        )
+        XCTAssertEqual(v.durationString, "1h")
+    }
+
+    func testDurationStringHoursAndMinutes() {
+        let v = Visit(
+            arrivalDate: Date(timeIntervalSince1970: 1_700_000_000),
+            departureDate: Date(timeIntervalSince1970: 1_700_000_000 + 75 * 60)
+        )
+        XCTAssertEqual(v.durationString, "1h 15m")
+    }
+
+    func testDurationStringZero() {
+        let v = Visit(
+            arrivalDate: Date(timeIntervalSince1970: 1_700_000_000),
+            departureDate: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+        XCTAssertEqual(v.durationString, "0m")
+    }
+
     // MARK: - Helpers
 
     private func makeVisit(hour: Int) -> Visit {

--- a/PlaceNotesTests/VisitTests.swift
+++ b/PlaceNotesTests/VisitTests.swift
@@ -118,35 +118,35 @@ final class VisitTests: XCTestCase {
     // MARK: - durationString
 
     func testDurationStringSubHourMinutes() {
-        let v = Visit(
+        let visit = Visit(
             arrivalDate: Date(timeIntervalSince1970: 1_700_000_000),
             departureDate: Date(timeIntervalSince1970: 1_700_000_000 + 45 * 60)
         )
-        XCTAssertEqual(v.durationString, "45m")
+        XCTAssertEqual(visit.durationString, "45m")
     }
 
     func testDurationStringExactHours() {
-        let v = Visit(
+        let visit = Visit(
             arrivalDate: Date(timeIntervalSince1970: 1_700_000_000),
             departureDate: Date(timeIntervalSince1970: 1_700_000_000 + 60 * 60)
         )
-        XCTAssertEqual(v.durationString, "1h")
+        XCTAssertEqual(visit.durationString, "1h")
     }
 
     func testDurationStringHoursAndMinutes() {
-        let v = Visit(
+        let visit = Visit(
             arrivalDate: Date(timeIntervalSince1970: 1_700_000_000),
             departureDate: Date(timeIntervalSince1970: 1_700_000_000 + 75 * 60)
         )
-        XCTAssertEqual(v.durationString, "1h 15m")
+        XCTAssertEqual(visit.durationString, "1h 15m")
     }
 
     func testDurationStringZero() {
-        let v = Visit(
+        let visit = Visit(
             arrivalDate: Date(timeIntervalSince1970: 1_700_000_000),
             departureDate: Date(timeIntervalSince1970: 1_700_000_000)
         )
-        XCTAssertEqual(v.durationString, "0m")
+        XCTAssertEqual(visit.durationString, "0m")
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
Builds on #50.

## Summary

- Adds a horizontal scrollable timeline strip pinned to the bottom of \`DayTrajectoryView\`, showing one card per visit (place emoji + arrival time + duration).
- Tap a card to recenter the map on that visit's place (200×200m). Card highlights with an accent border + tinted background. Recenter button (scope icon) repositioned above the strip; tapping it fits the day's bounds AND clears the selection.
- Selection is sticky — manual pan/zoom does not clear it (simpler mental model). Selection auto-clears on day-navigation via \`.task(id: day)\`.
- Strip hides entirely when the day has no visits; recenter button drops back to its original position.
- Pin tap behavior unchanged — opens \`PlaceDetailSheet\`. Strip and pin are independent ways to interact with a place.

## Architecture

- New \`Views/TrajectoryTimelineStrip.swift\` — strip + private \`VisitRow\` adapter (pre-filters nil-place visits via \`compactMap\`) + \`TimelineCard\`. Pure SwiftUI, no internal state.
- \`Models/Visit.swift\` — hoisted shared \`durationString\` property (was inlined in \`LogbookVisitRow\`). Both Logbook row and new card consume the same formatter.
- \`Views/DayTrajectoryView.swift\` — added \`dayVisits\` and \`selectedVisit\` state, predicate-driven \`Visit\` fetch in \`load()\`, strip overlay in the \`ZStack\`, conditional recenter button bottom padding, \`recenterToVisit(_:)\` method, selection reset on day change.
- 4 new unit tests on \`Visit.durationString\` (45m → \"45m\", 60m → \"1h\", 75m → \"1h 15m\", 0m → \"0m\"). Total: 130 → 134 tests.

## Visual

\`\`\`
┌──────────────────────────────┐
│ [Header card: date · stats]  │  ← top (existing)
│         [ Map ]              │
│                       [⊚]    │  ← recenter (above strip)
│ ╔══════════════════════════╗ │
│ ║ 🏠   ☕   🏢   🍜   🏠  ║ │  ← timeline strip (new)
│ ║ 8:00 8:40 9:20 18:00 19:50║│
│ ║ 30m  25m  8h  1h30m 2h10m ║│
│ ╚══════════════════════════╝ │
└──────────────────────────────┘
\`\`\`

## Test plan

- [x] Settings → Debug → \"Clear All Data\" then \"Seed Sample Trajectory\" (fresh seed).
- [x] Logbook → expand a Month → swipe right on today's \"Home\" visit → tap **Map**.
- [x] Confirm strip shows 5 cards chronologically: 🏠 8:00 30m → ☕ 8:40 25m → 🏢 9:20 8h → 🍜 18:00 1h30m → 🏠 19:50 2h10m.
- [x] Tap a card → map animates, card highlights with accent border + tinted background, other cards lose any prior highlight.
- [x] Tap recenter (scope) → map fits day's bounds AND highlight clears.
- [x] Tap a pin directly → \`PlaceDetailSheet\` opens; strip selection unaffected.
- [x] Edge: \"visits but no samples\" day (2 days ago) → strip shows cards, header reads \"Path data not available\", no polyline.
- [x] Edge: repeated place (today's two Home visits) → both cards present, distinguishable by time.
- [x] Selection sticky during pan/zoom; clears on recenter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)