### PR TITLE
feat: 30m default min stay + dim wrong-place prompt after confirm

### DIFF
--- a/PlaceNotes/Models/AppSettings.swift
+++ b/PlaceNotes/Models/AppSettings.swift
@@ -25,7 +25,7 @@ final class AppSettings: ObservableObject {
 
     private init() {
         let savedMin = UserDefaults.standard.integer(forKey: "minStayMinutes")
-        self.minStayMinutes = savedMin > 0 ? savedMin : 10
+        self.minStayMinutes = savedMin > 0 ? savedMin : 30
 
         let savedMilestones = UserDefaults.standard.array(forKey: "milestoneVisitCounts") as? [Int]
         self.milestoneVisitCounts = savedMilestones ?? [5, 10, 25, 50, 100]

--- a/PlaceNotes/Models/Visit.swift
+++ b/PlaceNotes/Models/Visit.swift
@@ -33,6 +33,10 @@ final class Visit {
     /// Quick captures are short by design and bypass the logbook's minStayMinutes filter.
     var isQuickCapture: Bool = false
 
+    /// True once the user has explicitly confirmed the place (or picked an alternative).
+    /// Used to dim the "Not the right place?" affordance after a deliberate choice.
+    var placeConfirmed: Bool = false
+
     /// Journal entries explicitly tied to this visit. Quick-capture creates one;
     /// dwell-recorded visits start empty. Cascade-deletes when the visit is removed.
     @Relationship(deleteRule: .cascade, inverse: \JournalEntry.visit)

--- a/PlaceNotes/Views/LogbookView.swift
+++ b/PlaceNotes/Views/LogbookView.swift
@@ -224,6 +224,8 @@ private struct AlternativePlacePicker: View {
     }
 
     private func confirmPlace() {
+        visit.placeConfirmed = true
+        try? modelContext.save()
         onPlaceChanged?()
         dismiss()
     }
@@ -260,6 +262,7 @@ private struct AlternativePlacePicker: View {
         }
 
         visit.place = newPlace
+        visit.placeConfirmed = true
 
         var remaining = visit.alternativePlaces.filter { $0.id != candidate.id }
         if let prev = previousPlace, prev.id != newPlace.id {
@@ -442,9 +445,15 @@ private struct LogbookVisitRow: View {
                 Button {
                     onPickAlternative?()
                 } label: {
-                    Label("Not the right place?", systemImage: "arrow.triangle.swap")
-                        .font(.caption2)
-                        .foregroundStyle(.orange)
+                    if visit.placeConfirmed {
+                        Label("Place confirmed", systemImage: "checkmark.circle")
+                            .font(.caption2)
+                            .foregroundStyle(.tertiary)
+                    } else {
+                        Label("Not the right place?", systemImage: "arrow.triangle.swap")
+                            .font(.caption2)
+                            .foregroundStyle(.orange)
+                    }
                 }
                 .buttonStyle(.plain)
                 .padding(.leading, 40)


### PR DESCRIPTION
## Summary
- Raise default `minStayMinutes` from 10 → 30 (fresh installs only; existing saved values untouched).
- Add `Visit.placeConfirmed` flag, flipped true when user taps **Confirm** on the current place or selects an alternative in the "Wrong Place?" picker.
- Dim the row's "Not the right place?" affordance once `placeConfirmed` is true: replaced with a tertiary "Place confirmed" label. Still tappable to reopen the picker.

## Test plan
- [ ] Fresh install: Settings shows minimum stay = 30 min.
- [ ] Existing install with custom value: value preserved.
- [ ] Logbook row with alternatives: orange "Not the right place?" visible.
- [ ] Tap row → picker → tap current place "Confirm" → row affordance becomes tertiary "Place confirmed".
- [ ] Tap row → picker → pick alternative → reassigns visit AND row affordance becomes tertiary "Place confirmed".
- [ ] Confirmed row still tappable to reopen picker and change again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)