### PR TITLE
fix: avoid wall-clock duration for stranded visits

### DIFF
--- a/PlaceNotes/Models/Visit.swift
+++ b/PlaceNotes/Models/Visit.swift
@@ -58,12 +58,33 @@ final class Visit {
     }
 
     var durationMinutes: Int {
-        let end = departureDate ?? Date()
+        effectiveDurationMinutes(cappedAt: nil)
+    }
+
+    /// Pass the next visit's `arrivalDate` as `cap` so stranded past-day visits don't fall back to `Date()`.
+    func effectiveDurationMinutes(cappedAt cap: Date?) -> Int {
+        let end: Date
+        if let departureDate {
+            end = departureDate
+        } else if let cap {
+            end = cap
+        } else if Calendar.current.isDateInToday(arrivalDate) {
+            end = Date()
+        } else {
+            return 0
+        }
         return max(0, Int(end.timeIntervalSince(arrivalDate) / 60))
     }
 
     var durationString: String {
-        let mins = durationMinutes
+        Self.formatDuration(durationMinutes)
+    }
+
+    func effectiveDurationString(cappedAt cap: Date?) -> String {
+        Self.formatDuration(effectiveDurationMinutes(cappedAt: cap))
+    }
+
+    private static func formatDuration(_ mins: Int) -> String {
         if mins >= 60 {
             let h = mins / 60
             let m = mins % 60

--- a/PlaceNotes/Views/LogbookView.swift
+++ b/PlaceNotes/Views/LogbookView.swift
@@ -320,12 +320,17 @@ private struct MonthSection: View {
 
     var body: some View {
         DisclosureGroup {
-            ForEach(visits) { visit in
+            ForEach(Array(visits.enumerated()), id: \.element.id) { index, visit in
                 if let place = visit.place {
+                    let nextSameDay: Date? = {
+                        guard index > 0 else { return nil }
+                        let next = visits[index - 1]
+                        return Calendar.current.isDate(next.arrivalDate, inSameDayAs: visit.arrivalDate) ? next.arrivalDate : nil
+                    }()
                     NavigationLink {
                         PlaceDetailView(place: place)
                     } label: {
-                        LogbookVisitRow(visit: visit, place: place) {
+                        LogbookVisitRow(visit: visit, place: place, nextSameDayArrival: nextSameDay) {
                             onPickAlternative?(visit)
                         }
                     }
@@ -369,6 +374,7 @@ private struct MonthSection: View {
 private struct LogbookVisitRow: View {
     let visit: Visit
     let place: Place
+    let nextSameDayArrival: Date?
     var onPickAlternative: (() -> Void)?
 
     private var dateString: String {
@@ -432,7 +438,7 @@ private struct LogbookVisitRow: View {
                     Text(dateString)
                         .font(.caption)
                         .foregroundStyle(.secondary)
-                    Text(visit.durationString)
+                    Text(visit.effectiveDurationString(cappedAt: nextSameDayArrival))
                         .font(.caption.bold())
                         .foregroundStyle(Color.accentColor)
                     #if DEBUG

--- a/PlaceNotes/Views/TrajectoryTimelineStrip.swift
+++ b/PlaceNotes/Views/TrajectoryTimelineStrip.swift
@@ -11,10 +11,21 @@ struct TrajectoryTimelineStrip: View {
         return f
     }()
 
+    private var rows: [VisitRow] {
+        let placed = visits.compactMap { visit -> (Visit, Place)? in
+            guard let place = visit.place else { return nil }
+            return (visit, place)
+        }
+        return placed.enumerated().map { index, pair in
+            let nextArrival = index + 1 < placed.count ? placed[index + 1].0.arrivalDate : nil
+            return VisitRow(visit: pair.0, place: pair.1, nextArrival: nextArrival)
+        }
+    }
+
     var body: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             LazyHStack(spacing: 12) {
-                ForEach(visits.compactMap(VisitRow.init), id: \.visit.id) { row in
+                ForEach(rows, id: \.visit.id) { row in
                     TimelineCard(
                         row: row,
                         isSelected: row.visit.id == selectedVisitID
@@ -36,12 +47,7 @@ struct TrajectoryTimelineStrip: View {
 private struct VisitRow {
     let visit: Visit
     let place: Place
-
-    init?(visit: Visit) {
-        guard let place = visit.place else { return nil }
-        self.visit = visit
-        self.place = place
-    }
+    let nextArrival: Date?
 }
 
 private struct TimelineCard: View {
@@ -61,7 +67,7 @@ private struct TimelineCard: View {
                 Text(arrivalString)
                     .font(.caption.bold())
                     .foregroundStyle(.primary)
-                Text(row.visit.durationString)
+                Text(row.visit.effectiveDurationString(cappedAt: row.nextArrival))
                     .font(.caption2)
                     .foregroundStyle(.secondary)
             }

--- a/PlaceNotesTests/VisitTests.swift
+++ b/PlaceNotesTests/VisitTests.swift
@@ -149,6 +149,39 @@ final class VisitTests: XCTestCase {
         XCTAssertEqual(visit.durationString, "0m")
     }
 
+    // MARK: - Stranded visits (no departureDate, past day)
+
+    func testDurationStrandedPastDayReturnsZero() {
+        let arrival = Calendar.current.date(byAdding: .day, value: -3, to: Date())!
+        let visit = Visit(arrivalDate: arrival, departureDate: nil)
+        XCTAssertEqual(visit.durationMinutes, 0)
+        XCTAssertEqual(visit.durationString, "0m")
+    }
+
+    func testEffectiveDurationUsesCapWhenDepartureMissing() {
+        let arrival = Calendar.current.date(byAdding: .day, value: -3, to: Date())!
+        let cap = arrival.addingTimeInterval(45 * 60)
+        let visit = Visit(arrivalDate: arrival, departureDate: nil)
+        XCTAssertEqual(visit.effectiveDurationMinutes(cappedAt: cap), 45)
+        XCTAssertEqual(visit.effectiveDurationString(cappedAt: cap), "45m")
+    }
+
+    func testEffectiveDurationPrefersDepartureOverCap() {
+        let arrival = Date(timeIntervalSince1970: 1_700_000_000)
+        let departure = arrival.addingTimeInterval(20 * 60)
+        let cap = arrival.addingTimeInterval(60 * 60)
+        let visit = Visit(arrivalDate: arrival, departureDate: departure)
+        XCTAssertEqual(visit.effectiveDurationMinutes(cappedAt: cap), 20)
+    }
+
+    func testEffectiveDurationTodayUsesNowWhenNoCap() {
+        let arrival = Date().addingTimeInterval(-15 * 60)
+        let visit = Visit(arrivalDate: arrival, departureDate: nil)
+        let mins = visit.effectiveDurationMinutes(cappedAt: nil)
+        XCTAssertGreaterThanOrEqual(mins, 14)
+        XCTAssertLessThanOrEqual(mins, 16)
+    }
+
     // MARK: - Helpers
 
     private func makeVisit(hour: Int) -> Visit {


### PR DESCRIPTION
Visits without a departureDate previously fell back to Date(), producing
durations that grew without bound for past-day records. The Logbook strip
shown in issue: a visit at 18:44 displayed "4h 27m" even though the next
visit started at 18:45 because 18:44's departure was never recorded.

- Visit.effectiveDurationMinutes(cappedAt:) accepts the next visit's
  arrival as a cap; for past-day records with no cap and no departure,
  return 0 instead of growing with Date().
- TrajectoryTimelineStrip and LogbookView pass the next chronological
  visit's arrival (same-day only) so display matches reality.
- Place rollups and ReportGenerator now ignore stranded past-day visits
  rather than inflating totals against wall-clock time.