### PR TITLE
chore: crash & error-handling pass (#55)

### DIFF
--- a/PlaceNotes/PlaceNotesApp.swift
+++ b/PlaceNotes/PlaceNotesApp.swift
@@ -1,5 +1,8 @@
 import SwiftUI
 import SwiftData
+import os
+
+private let logger = Logger(subsystem: "com.placenotes.app", category: "App")
 
 @main
 struct PlaceNotesApp: App {
@@ -34,13 +37,16 @@ struct PlaceNotesApp: App {
         } catch {
             // Schema migration failed — delete the old store and retry.
             // This is expected when new model fields are added during development.
-            print("[PlaceNotesApp] Store incompatible, resetting: \(error.localizedDescription)")
+            logger.error("Store incompatible, resetting: \(error.localizedDescription, privacy: .public)")
             Self.deleteStoreFiles(at: storeURL)
             UserDefaults.standard.set(false, forKey: "mockDataSeeded_debug")
 
             do {
                 container = try makeContainer()
             } catch {
+                // Unrecoverable: persistence layer cannot initialize even after a clean reset
+                // (e.g. disk full, corrupt FS). The app cannot function without a ModelContainer,
+                // so crashing with a descriptive message is the correct behavior.
                 fatalError("Failed to create ModelContainer after reset: \(error)")
             }
         }

--- a/PlaceNotes/Services/MockLocationProvider.swift
+++ b/PlaceNotes/Services/MockLocationProvider.swift
@@ -1,5 +1,8 @@
 import Foundation
 import SwiftData
+import os
+
+private let logger = Logger(subsystem: "com.placenotes.app", category: "MockLocationProvider")
 
 /// Provides simulated location visits for debug builds and
 /// cleans up mock data when switching to release.
@@ -78,7 +81,7 @@ final class MockLocationProvider {
                 let durationMinutes = Int.random(in: 5...180)
 
                 var components = calendar.dateComponents([.year, .month, .day], from: now)
-                components.day! -= daysAgo
+                components.day = (components.day ?? 0) - daysAgo
                 components.hour = hour
                 components.minute = minute
 
@@ -89,7 +92,7 @@ final class MockLocationProvider {
 
                 // Assign a random confidence level for testing
                 let confidences: [PlaceConfidence] = [.high, .high, .high, .medium, .medium, .low]
-                visit.confidence = confidences.randomElement()!
+                visit.confidence = confidences.randomElement() ?? .high
                 visit.medianAccuracyMeters = Double.random(in: 5...60)
 
                 // Give ~half the visits some alternative place candidates so
@@ -116,7 +119,7 @@ final class MockLocationProvider {
         try? context.save()
         UserDefaults.standard.set(true, forKey: seededKey)
         UserDefaults.standard.set(seedVersion, forKey: seedVersionKey)
-        print("[MockLocationProvider] Seeded \(samplePlaces.count) places with sample visits (v\(seedVersion))")
+        logger.info("Seeded \(samplePlaces.count) places with sample visits (v\(seedVersion))")
     }
 
     /// Known mock place names used to detect legacy seeded data
@@ -145,6 +148,6 @@ final class MockLocationProvider {
 
         try? context.save()
         UserDefaults.standard.set(false, forKey: seededKey)
-        print("[MockLocationProvider] Purged mock data for release build")
+        logger.info("Purged mock data for release build")
     }
 }

--- a/PlaceNotes/Services/NotificationManager.swift
+++ b/PlaceNotes/Services/NotificationManager.swift
@@ -1,5 +1,8 @@
 import Foundation
 import UserNotifications
+import os
+
+private let logger = Logger(subsystem: "com.placenotes.app", category: "Notifications")
 
 final class NotificationManager {
     static let shared = NotificationManager()
@@ -9,7 +12,7 @@ final class NotificationManager {
     func requestAuthorization() {
         UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
             if let error {
-                print("Notification auth error: \(error.localizedDescription)")
+                logger.error("Notification auth error: \(error.localizedDescription, privacy: .public)")
             }
         }
     }

--- a/PlaceNotes/Services/ReportGenerator.swift
+++ b/PlaceNotes/Services/ReportGenerator.swift
@@ -43,7 +43,19 @@ final class ReportGenerator {
         referenceDate: Date = Date()
     ) -> MonthlyReport {
         let calendar = Calendar.current
-        let startOfMonth = calendar.date(from: calendar.dateComponents([.year, .month], from: referenceDate))!
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMMM yyyy"
+
+        guard let startOfMonth = calendar.date(from: calendar.dateComponents([.year, .month], from: referenceDate)) else {
+            return MonthlyReport(
+                month: formatter.string(from: referenceDate),
+                topPlaces: [],
+                totalTrackedMinutes: 0,
+                preferredTimeOfDay: .morning,
+                visitsByTimeOfDay: [:],
+                totalVisits: 0
+            )
+        }
 
         let allVisitsThisMonth = places.flatMap { $0.visits }
             .filter { $0.arrivalDate >= startOfMonth }
@@ -58,9 +70,6 @@ final class ReportGenerator {
         }
 
         let preferredTime = timeOfDayCounts.max(by: { $0.value < $1.value })?.key ?? .morning
-
-        let formatter = DateFormatter()
-        formatter.dateFormat = "MMMM yyyy"
 
         return MonthlyReport(
             month: formatter.string(from: referenceDate),

--- a/PlaceNotes/ViewModels/PlacesViewModel.swift
+++ b/PlaceNotes/ViewModels/PlacesViewModel.swift
@@ -14,8 +14,15 @@ final class PlacesViewModel: ObservableObject {
 
     func refresh(places: [Place]) {
         let now = Date()
-        let sevenDaysAgo = Calendar.current.date(byAdding: .day, value: -7, to: now)!
-        let thirtyDaysAgo = Calendar.current.date(byAdding: .day, value: -30, to: now)!
+        let calendar = Calendar.current
+        guard
+            let sevenDaysAgo = calendar.date(byAdding: .day, value: -7, to: now),
+            let thirtyDaysAgo = calendar.date(byAdding: .day, value: -30, to: now)
+        else {
+            weeklyPlaces = []
+            monthlyPlaces = []
+            return
+        }
 
         weeklyPlaces = ReportGenerator.frequentPlaces(
             from: places,


### PR DESCRIPTION
## Summary
- Replace force-unwraps in `Services/` + `ViewModels/` with guards or `??` fallbacks (`MockLocationProvider`, `ReportGenerator`, `PlacesViewModel`).
- Replace `print(` calls with `os.Logger` using existing `com.placenotes.app` subsystem (`PlaceNotesApp`, `MockLocationProvider`, `NotificationManager`).
- Annotate remaining `fatalError` in `PlaceNotesApp` (post-reset ModelContainer failure) with comment explaining why crash is correct.

Closes #55. Part of #53.

## Test plan
- [x] `xcodebuild build` succeeds
- [x] `xcodebuild test` — 150/152 pass; 2 pre-existing `VisitTests` failures present on `main`, unrelated to this diff
- [x] `grep -REn '!' PlaceNotes/Services PlaceNotes/ViewModels` shows no remaining force-unwraps in scope
- [x] `grep -REn 'print\(' PlaceNotes` (excl. tests) is empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)