### PR TITLE
chore: pin Release build flags for App Store submission (#56)

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -11,6 +11,12 @@ settings:
     TARGETED_DEVICE_FAMILY: "1,2"
     DEVELOPMENT_TEAM: H63486AZ9Y
     CODE_SIGN_STYLE: Automatic
+  configs:
+    Release:
+      COPY_PHASE_STRIP: YES
+      STRIP_INSTALLED_PRODUCT: YES
+      DEAD_CODE_STRIPPING: YES
+      VALIDATE_PRODUCT: YES
 
 schemes:
   PlaceNotes:
@@ -38,6 +44,12 @@ targets:
         CURRENT_PROJECT_VERSION: 1
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         CODE_SIGN_ENTITLEMENTS: PlaceNotes/PlaceNotes.entitlements
+      configs:
+        Release:
+          COPY_PHASE_STRIP: YES
+          STRIP_INSTALLED_PRODUCT: YES
+          DEAD_CODE_STRIPPING: YES
+          VALIDATE_PRODUCT: YES
     entitlements:
       path: PlaceNotes/PlaceNotes.entitlements
 


### PR DESCRIPTION
## Summary
- Audited Release build config per #56 (part of #53 v1.0.0 release prep).
- Pinned `COPY_PHASE_STRIP`, `STRIP_INSTALLED_PRODUCT`, `DEAD_CODE_STRIPPING`, `VALIDATE_PRODUCT` to `YES` in Release at both project and target level via `project.yml`.

## Audit findings (Release configuration)

| Check | Status | Note |
|-------|--------|------|
| `SWIFT_OPTIMIZATION_LEVEL = -O` | ✅ | already set |
| `SWIFT_COMPILATION_MODE = wholemodule` | ✅ | already set |
| `DEBUG` flag absent in Release | ✅ | only Debug has `GCC_PREPROCESSOR_DEFINITIONS = DEBUG=1` and `SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG`; `#if DEBUG` blocks (`PlaceNotesApp`, `SettingsView`, `LogbookView`, `DebugSeed`) strip in Release |
| `ENABLE_NS_ASSERTIONS = NO` | ✅ | already set |
| `ENABLE_TESTABILITY` | ✅ | Debug-only; resolves to `NO` in Release |
| `DEBUG_INFORMATION_FORMAT = dwarf-with-dsym` | ✅ | already set |
| `COPY_PHASE_STRIP = YES` | ✅ (this PR) | was `NO`; now `YES` |
| `STRIP_INSTALLED_PRODUCT = YES` | ✅ (this PR) | now pinned explicitly |
| `DEAD_CODE_STRIPPING = YES` | ✅ (this PR) | now pinned explicitly |
| `VALIDATE_PRODUCT = YES` | ✅ (this PR) | now pinned explicitly |
| No test/dev flag leak | ✅ | `PlaceNotesTests` scoped to test scheme only; not built for archive |

Verified resolved Release settings via `xcodebuild -showBuildSettings` after `xcodegen generate`.

## Test plan
- [x] `xcodegen generate` succeeds with updated `project.yml`
- [x] `xcodebuild -showBuildSettings -configuration Release` confirms all four flags resolve to `YES`
- [x] `xcodebuild build -configuration Release -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO` → `BUILD SUCCEEDED`
- [x] Reviewer: verify Archive build (`Product > Archive` in Xcode) still produces a valid `.ipa` for App Store upload

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)