### PR TITLE
ci: re-enable triggers on push/PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,11 @@
 name: CI
 
-# Disabled for now — re-enable by uncommenting the triggers below
-# on:
-#   push:
-#     branches: [main]
-#   pull_request:
-#     branches: [main]
-on: workflow_dispatch  # manual trigger only
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
 
 concurrency:
   group: ci-${{ github.ref }}


### PR DESCRIPTION
## Summary
- Re-enable `push` (main) and `pull_request` (main) triggers on `.github/workflows/ci.yml`.
- Keep `workflow_dispatch` for manual runs.
- Leave optional (not branch-protection required) until pre-existing `VisitTests` failures and masked-failure `|| true` are addressed in follow-up.

## Test plan
- [x] CI workflow runs on this PR
- [x] Manual dispatch still works
- [x] Follow-up: fix VisitTests, drop `|| true`, then mark required

🤖 Generated with [Claude Code](https://claude.com/claude-code)