### PR TITLE
chore: prep Info.plist for App Store submission

### DIFF
--- a/PlaceNotes/Info.plist
+++ b/PlaceNotes/Info.plist
@@ -32,11 +32,13 @@
         <string>UIInterfaceOrientationPortrait</string>
     </array>
     <key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
-    <string>PlaceNotes tracks the places you visit to generate summaries and reports about your frequent locations.</string>
+    <string>PlaceNotes uses your location in the background to automatically detect the places you visit, so your logbook stays up to date without you opening the app.</string>
     <key>NSLocationWhenInUseUsageDescription</key>
-    <string>PlaceNotes needs your location to track the places you visit.</string>
+    <string>PlaceNotes uses your current location to log the place you are visiting and attach it to your notes.</string>
     <key>NSCameraUsageDescription</key>
-    <string>PlaceNotes uses the camera to let you capture a photo and log the current place as a visit.</string>
+    <string>PlaceNotes uses the camera to attach photos to your visits and journal entries for a place.</string>
+    <key>ITSAppUsesNonExemptEncryption</key>
+    <false/>
     <key>UIBackgroundModes</key>
     <array>
         <string>location</string>


### PR DESCRIPTION
- Add ITSAppUsesNonExemptEncryption=NO to skip the export-compliance
  prompt on every TestFlight upload.
- Tighten location and camera usage descriptions so App Review can
  see exactly when and why each permission is requested.

Closes #57