### PR TITLE
fix: refresh map annotation label after place rename

### DIFF
--- a/PlaceNotes/Views/FrequentPlacesMapView.swift
+++ b/PlaceNotes/Views/FrequentPlacesMapView.swift
@@ -89,8 +89,8 @@ struct FrequentPlacesMapView: View {
                 viewModel.refresh(places: places)
                 rebuildAnnotations()
             }
-            .onChange(of: places) { _, newPlaces in
-                viewModel.refresh(places: newPlaces)
+            .onChange(of: placesDisplayKey) { _, _ in
+                viewModel.refresh(places: places)
                 rebuildAnnotations()
             }
             .alert("Tracking Disabled", isPresented: $showTrackingAlert) {
@@ -105,6 +105,12 @@ struct FrequentPlacesMapView: View {
     }
 
     // MARK: - Clustering
+
+    /// Captures display-affecting properties so onChange fires on rename / category
+    /// edits — `[Place]` alone compares by reference and stays "equal" after a rename.
+    private var placesDisplayKey: [String] {
+        places.map { "\($0.id)|\($0.displayName)|\($0.emoji)" }
+    }
 
     /// Rebuilds annotations only when region or data changes — not on every render.
     private func rebuildAnnotations() {
@@ -194,8 +200,9 @@ protocol MapAnnotationItem: Identifiable {
 struct SingleItem: MapAnnotationItem {
     let ranking: PlaceRanking
 
-    /// Stable ID derived from the place, so SwiftUI reuses the view.
-    var id: String { "single-\(ranking.place.id)" }
+    /// Includes displayName and emoji so a rename or category change forces
+    /// SwiftUI to rebuild the Annotation — its label is captured at body time.
+    var id: String { "single-\(ranking.place.id)-\(ranking.place.displayName)-\(ranking.place.emoji)" }
     var coordinate: CLLocationCoordinate2D { ranking.place.coordinate }
 }
 

--- a/PlaceNotesTests/MapAnnotationIdentityTests.swift
+++ b/PlaceNotesTests/MapAnnotationIdentityTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+@testable import PlaceNotes
+
+final class MapAnnotationIdentityTests: XCTestCase {
+
+    private func makeRanking(_ place: Place) -> PlaceRanking {
+        PlaceRanking(place: place, qualifiedStays: 1, totalMinutes: 60)
+    }
+
+    func testSingleItemIdChangesWhenNicknameChanges() {
+        let place = Place(name: "Original", latitude: 37.0, longitude: -122.0, category: "Cafe")
+        let idBefore = SingleItem(ranking: makeRanking(place)).id
+
+        place.nickname = "Renamed"
+        let idAfter = SingleItem(ranking: makeRanking(place)).id
+
+        XCTAssertNotEqual(idBefore, idAfter)
+    }
+
+    func testSingleItemIdChangesWhenEmojiChanges() {
+        let place = Place(name: "Spot", latitude: 37.0, longitude: -122.0, category: "Cafe")
+        let idBefore = SingleItem(ranking: makeRanking(place)).id
+
+        place.customEmoji = "🌟"
+        let idAfter = SingleItem(ranking: makeRanking(place)).id
+
+        XCTAssertNotEqual(idBefore, idAfter)
+    }
+
+    func testSingleItemIdStableWhenNothingDisplayRelevantChanges() {
+        let place = Place(name: "Spot", latitude: 37.0, longitude: -122.0, category: "Cafe")
+        let id1 = SingleItem(ranking: makeRanking(place)).id
+        let id2 = SingleItem(ranking: makeRanking(place)).id
+        XCTAssertEqual(id1, id2)
+    }
+
+    func testSingleItemIdEncodesPlaceUUID() {
+        let place = Place(name: "Spot", latitude: 0, longitude: 0)
+        let id = SingleItem(ranking: makeRanking(place)).id
+        XCTAssertTrue(id.contains(place.id.uuidString))
+        XCTAssertTrue(id.contains(place.displayName))
+    }
+}


### PR DESCRIPTION
The map cached annotations keyed only by Place UUID, so a rename never
invalidated the cache and the Annotation label stayed stale. Also
onChange(of: places) compared by reference and never fired on a
property mutation. Include displayName/emoji in the annotation id
and observe a derived display key.