### PR TITLE
chore: rename app to Placelore

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@
 
 ## App Overview
 
-**PlaceNotes** is an iOS app (Swift / SwiftUI / SwiftData) that passively tracks the user's location and logs meaningful "stays" as named places with timestamped visits. Users can attach journal entries and photos to places, view a logbook of past visits, and generate reports.
+**Placelore** (codebase identifier: `PlaceNotes`) is an iOS app (Swift / SwiftUI / SwiftData) that passively tracks the user's location and logs meaningful "stays" as named places with timestamped visits. Users can attach journal entries and photos to places, view a logbook of past visits, and generate reports. The Xcode target, scheme, bundle ID, and folder names all remain `PlaceNotes`; only the App Store display name is `Placelore`.
 
 ---
 

--- a/PlaceNotes/Info.plist
+++ b/PlaceNotes/Info.plist
@@ -7,7 +7,7 @@
     <key>CFBundleName</key>
     <string>$(PRODUCT_NAME)</string>
     <key>CFBundleDisplayName</key>
-    <string>PlaceNotes</string>
+    <string>Placelore</string>
     <key>CFBundleExecutable</key>
     <string>$(EXECUTABLE_NAME)</string>
     <key>CFBundlePackageType</key>
@@ -32,11 +32,11 @@
         <string>UIInterfaceOrientationPortrait</string>
     </array>
     <key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
-    <string>PlaceNotes uses your location in the background to automatically detect the places you visit, so your logbook stays up to date without you opening the app.</string>
+    <string>Placelore uses your location in the background to automatically detect the places you visit, so your logbook stays up to date without you opening the app.</string>
     <key>NSLocationWhenInUseUsageDescription</key>
-    <string>PlaceNotes uses your current location to log the place you are visiting and attach it to your notes.</string>
+    <string>Placelore uses your current location to log the place you are visiting and attach it to your notes.</string>
     <key>NSCameraUsageDescription</key>
-    <string>PlaceNotes uses the camera to attach photos to your visits and journal entries for a place.</string>
+    <string>Placelore uses the camera to attach photos to your visits and journal entries for a place.</string>
     <key>ITSAppUsesNonExemptEncryption</key>
     <false/>
     <key>UIBackgroundModes</key>

--- a/PlaceNotes/Views/TrackingControlView.swift
+++ b/PlaceNotes/Views/TrackingControlView.swift
@@ -40,7 +40,7 @@ struct TrackingControlView: View {
                     .transition(.move(edge: .bottom).combined(with: .opacity))
                 }
             }
-            .navigationTitle("PlaceNotes")
+            .navigationTitle("Placelore")
             .sheet(isPresented: $showTrackingSheet) { trackingSheet }
             .fullScreenCover(isPresented: $quickCapture.showCamera) {
                 CameraPickerView(
@@ -131,7 +131,7 @@ struct TrackingControlView: View {
         .alert("Camera access needed", isPresented: $showCameraPermissionAlert) {
             Button("OK", role: .cancel) {}
         } message: {
-            Text("Enable Camera access in Settings → PlaceNotes to capture photos.")
+            Text("Enable Camera access in Settings → Placelore to capture photos.")
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# PlaceNotes
+# Placelore
 
 An iOS app that tracks the places you visit and generates frequency reports and behavior summaries — with an offline-first trajectory analysis pipeline for trip detection and transportation mode inference.
+
+> The Xcode project, scheme, and bundle ID still use the original `PlaceNotes` identifiers. Only the user-facing display name is `Placelore`.
 
 ## Features
 
@@ -16,7 +18,7 @@ An iOS app that tracks the places you visit and generates frequency reports and 
 
 ## Research: Two-Stage ST-DBSCAN for On-Device Trip Detection
 
-PlaceNotes doubles as a research platform for studying lightweight trajectory analysis on mobile devices. The app collects rich GPS data (coordinates, timestamps, speed, course, accuracy) which feeds into an offline analysis pipeline.
+Placelore doubles as a research platform for studying lightweight trajectory analysis on mobile devices. The app collects rich GPS data (coordinates, timestamps, speed, course, accuracy) which feeds into an offline analysis pipeline.
 
 ### Background
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,4 +1,4 @@
-title: PlaceNotes
-description: Privacy policy and project pages for the PlaceNotes iOS app.
+title: Placelore
+description: Privacy policy and project pages for the Placelore iOS app.
 exclude:
   - superpowers/

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,10 @@
 ---
-title: PlaceNotes
+title: Placelore
 ---
 
-# PlaceNotes
+# Placelore
 
-PlaceNotes is an iOS app that journals the places you visit.
+Placelore is an iOS app that journals the places you visit.
 
 - [Privacy Policy](./privacy-policy.md)
 - [Source on GitHub](https://github.com/ychu824/PlaceNotes)

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -1,8 +1,8 @@
-# PlaceNotes Privacy Policy
+# Placelore Privacy Policy
 
-_Last updated: May 7, 2026_
+_Last updated: May 8, 2026_
 
-PlaceNotes ("the app") is an iOS application that helps you keep a personal journal of the places you visit. This policy explains what data the app handles and how.
+Placelore ("the app") is an iOS application that helps you keep a personal journal of the places you visit. This policy explains what data the app handles and how.
 
 ## Summary
 
@@ -13,7 +13,7 @@ PlaceNotes ("the app") is an iOS application that helps you keep a personal jour
 
 ## Data the app collects
 
-PlaceNotes accesses the following data **only on your device**:
+Placelore accesses the following data **only on your device**:
 
 ### Location
 
@@ -38,7 +38,7 @@ PlaceNotes accesses the following data **only on your device**:
 
 ## Data sharing
 
-PlaceNotes does not transmit your data to the developer or to any third party. There is no server to share data with.
+Placelore does not transmit your data to the developer or to any third party. There is no server to share data with.
 
 ## Data retention and deletion
 
@@ -55,7 +55,7 @@ You can revoke any of these permissions at any time in the iOS Settings app.
 
 ## Children
 
-PlaceNotes is not directed at children under 13 and does not knowingly collect data from them. Because the app does not collect personal information at all, no special children-data handling is needed.
+Placelore is not directed at children under 13 and does not knowingly collect data from them. Because the app does not collect personal information at all, no special children-data handling is needed.
 
 ## Changes to this policy
 

--- a/docs/qa/first-launch-checklist.md
+++ b/docs/qa/first-launch-checklist.md
@@ -12,14 +12,14 @@ permission prompt order, and zero crashes against an empty SwiftData store.
 
 - [ ] Install the build to a real device (TestFlight or Xcode → Product → Archive → Distribute → Development).
 - [ ] If the app was previously installed: **delete it from the home screen** (long-press → Remove App → Delete App). This wipes both the SwiftData store and `UserDefaults`.
-- [ ] In **Settings → PlaceNotes**, confirm the entry is gone after deletion (it should be — listed only after first install).
+- [ ] In **Settings → Placelore**, confirm the entry is gone after deletion (it should be — listed only after first install).
 - [ ] Force-stop any old build still in App Switcher.
 
 ## Cold launch
 
 - [ ] Launch the app from the home screen (not Xcode).
 - [ ] App opens to the **Tracking** tab without a splash crash.
-- [ ] **Prompt 1 — Notifications:** "PlaceNotes Would Like to Send You Notifications" appears within ~1s. Tap **Allow**.
+- [ ] **Prompt 1 — Notifications:** "Placelore Would Like to Send You Notifications" appears within ~1s. Tap **Allow**.
   - Source: `ContentView.onAppear` → `NotificationManager.shared.requestAuthorization()`.
 - [ ] No location prompt yet (tracking is `.disabled` by default — confirmed in `TrackingState.default`).
 - [ ] Tracking chip shows **Disabled** (gray location-slash icon).
@@ -37,19 +37,19 @@ Walk every tab and confirm no crash, no console assertion, no missing-data uglin
 ## Permission prompt 2 — Location
 
 - [ ] Tap the **Tracking chip** → **Enable Tracking** in the sheet.
-- [ ] iOS shows: "Allow PlaceNotes to use your location?" with **Allow Once / While Using App / Don't Allow** options.
+- [ ] iOS shows: "Allow Placelore to use your location?" with **Allow Once / While Using App / Don't Allow** options.
   - This is iOS 13+ behavior even though we call `requestAlwaysAuthorization()` — When-In-Use is shown first.
   - Verify the usage string matches `NSLocationWhenInUseUsageDescription` from `Info.plist`:
-    > "PlaceNotes uses your current location to log the place you are visiting and attach it to your notes."
+    > "Placelore uses your current location to log the place you are visiting and attach it to your notes."
 - [ ] Tap **Allow While Using App**. Tracking chip flips to **Active** (green).
 - [ ] No crash, no immediate Always-upgrade prompt (iOS only shows it after a heuristic delay / background-use observation).
 
 ## Permission prompt 3 — Camera
 
 - [ ] Tap the **shutter** button on the Tracking tab.
-- [ ] iOS shows: "PlaceNotes Would Like to Access the Camera"
+- [ ] iOS shows: "Placelore Would Like to Access the Camera"
   - Verify the string matches `NSCameraUsageDescription`:
-    > "PlaceNotes uses the camera to attach photos to your visits and journal entries for a place."
+    > "Placelore uses the camera to attach photos to your visits and journal entries for a place."
 - [ ] Tap **Allow**. Camera opens.
 - [ ] Cancel out of camera. No crash on dismiss.
 
@@ -59,8 +59,8 @@ iOS does **not** prompt for Always immediately. To force the upgrade prompt:
 
 - [ ] Lock the device with the app backgrounded for a few minutes.
 - [ ] Walk a short distance (or use Xcode → Debug → Simulate Location to move).
-- [ ] On next foregrounding, iOS may surface "PlaceNotes has been using your location in the background. Continue allowing?" — verify the **Always** option uses `NSLocationAlwaysAndWhenInUseUsageDescription`:
-  > "PlaceNotes uses your location in the background to automatically detect the places you visit, so your logbook stays up to date without you opening the app."
+- [ ] On next foregrounding, iOS may surface "Placelore has been using your location in the background. Continue allowing?" — verify the **Always** option uses `NSLocationAlwaysAndWhenInUseUsageDescription`:
+  > "Placelore uses your location in the background to automatically detect the places you visit, so your logbook stays up to date without you opening the app."
 - [ ] If the prompt does not appear within a session, this is acceptable — iOS schedules it on its own. Document outcome.
 
 ## Termination + relaunch
@@ -79,7 +79,7 @@ iOS does **not** prompt for Always immediately. To force the upgrade prompt:
 
 - [ ] No `os_log` errors visible in Console.app filtered by subsystem `com.placenotes.app` and level **Error**.
 - [ ] No `fatalError` hit. (The only one is `PlaceNotesApp.init` after a second store-create failure — should never fire on a clean install.)
-- [ ] Settings app → PlaceNotes shows: Location = Always (or While Using), Notifications = On, Camera = On.
+- [ ] Settings app → Placelore shows: Location = Always (or While Using), Notifications = On, Camera = On.
 
 ---
 


### PR DESCRIPTION
## Summary
- "PlaceNotes" name collided with an existing App Store listing during pre-submission checks. Rebrand the user-facing surface to **Placelore**.
- Internal identifiers stay as `PlaceNotes` (Xcode target/scheme/folder, bundle ID `com.placenotes.app`, struct `PlaceNotesApp`, repo URL). The bundle ID is independent of the App Store display name and is already registered.

## User-facing changes
- `Info.plist` — `CFBundleDisplayName` → `Placelore`; `NSLocationAlwaysAndWhenInUse`, `NSLocationWhenInUse`, and `NSCamera` usage strings reference Placelore.
- `TrackingControlView` — `navigationTitle("Placelore")` + camera-permission alert text references the new name.
- `docs/privacy-policy.md`, `docs/index.md`, `docs/_config.yml` — public site and policy.
- `docs/qa/first-launch-checklist.md` — permission-string excerpts updated to the new copy.
- `README.md`, `CLAUDE.md` — narrative references; explicit note that internal identifiers stay `PlaceNotes`.

## What did NOT change
- `project.yml` `name: PlaceNotes` (Xcode project name)
- `PlaceNotes.xcodeproj`, `PlaceNotes/` folder, `PlaceNotesApp.swift`
- Bundle ID `com.placenotes.app` (already registered)
- `.github/workflows/ci.yml` scheme/project args
- Repo URL `github.com/ychu824/PlaceNotes`

## Test plan
- [ ] Re-run `xcodegen generate` (no project.yml changes, but worth a sanity check).
- [ ] Build to a real device — home screen icon label reads **Placelore**.
- [ ] First-launch permission prompts read "Placelore would like to…" not "PlaceNotes…".
- [ ] In iOS Settings, the app appears under **Placelore**.
- [ ] App Store Connect — name field accepts `Placelore` without collision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)