### PR TITLE
chore: update Pages site GitHub link to renamed Placelore repo

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -7,4 +7,4 @@ title: Placelore
 Placelore is an iOS app that journals the places you visit.
 
 - [Privacy Policy](./privacy-policy.md)
-- [Source on GitHub](https://github.com/ychu824/PlaceNotes)
+- [Source on GitHub](https://github.com/ychu824/Placelore)


### PR DESCRIPTION
## Summary
- Repo renamed PlaceNotes → Placelore on GitHub. The "Source on GitHub" link on the Pages site still pointed to the old URL.
- Old URL still resolves via GitHub's repo-rename redirect, but use the canonical name publicly.

## Test plan
- [x] After merge, the link at https://ychu824.github.io/Placelore/ should land on https://github.com/ychu824/Placelore directly with no redirect hop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)