### PR TITLE
feat: add appearance mode picker (system/light/dark)

### DIFF
--- a/PlaceNotes/Models/AppSettings.swift
+++ b/PlaceNotes/Models/AppSettings.swift
@@ -1,10 +1,39 @@
 import Foundation
+import SwiftUI
+
+enum AppearanceMode: String, CaseIterable, Identifiable {
+    case system
+    case light
+    case dark
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .system: return "System"
+        case .light: return "Light"
+        case .dark: return "Dark"
+        }
+    }
+
+    var colorScheme: ColorScheme? {
+        switch self {
+        case .system: return nil
+        case .light: return .light
+        case .dark: return .dark
+        }
+    }
+}
 
 final class AppSettings: ObservableObject {
     static let shared = AppSettings()
 
     @Published var minStayMinutes: Int {
         didSet { UserDefaults.standard.set(minStayMinutes, forKey: "minStayMinutes") }
+    }
+
+    @Published var appearanceMode: AppearanceMode {
+        didSet { UserDefaults.standard.set(appearanceMode.rawValue, forKey: "appearanceMode") }
     }
 
     @Published var milestoneVisitCounts: [Int] {
@@ -32,6 +61,13 @@ final class AppSettings: ObservableObject {
 
         let savedRetention = UserDefaults.standard.integer(forKey: "rawLocationRetentionDays")
         self.rawLocationRetentionDays = savedRetention > 0 ? savedRetention : 30
+
+        if let raw = UserDefaults.standard.string(forKey: "appearanceMode"),
+           let mode = AppearanceMode(rawValue: raw) {
+            self.appearanceMode = mode
+        } else {
+            self.appearanceMode = .system
+        }
 
         if let data = UserDefaults.standard.data(forKey: "trackingState"),
            let state = try? JSONDecoder().decode(TrackingState.self, from: data) {

--- a/PlaceNotes/PlaceNotesApp.swift
+++ b/PlaceNotes/PlaceNotesApp.swift
@@ -6,7 +6,7 @@ private let logger = Logger(subsystem: "com.placenotes.app", category: "App")
 
 @main
 struct PlaceNotesApp: App {
-    let settings: AppSettings
+    @ObservedObject var settings: AppSettings
     let locationManager: LocationManager
     let trackingManager: TrackingManager
     let modelContainer: ModelContainer
@@ -81,6 +81,7 @@ struct PlaceNotesApp: App {
                 .environmentObject(locationManager)
                 .environmentObject(makeTrackingViewModel())
                 .environmentObject(makeQuickCaptureViewModel())
+                .preferredColorScheme(settings.appearanceMode.colorScheme)
                 .onAppear {
                     NotificationManager.shared.requestAuthorization()
                     Self.removeOldSharedStore()

--- a/PlaceNotes/Views/SettingsView.swift
+++ b/PlaceNotes/Views/SettingsView.swift
@@ -106,6 +106,18 @@ struct SettingsView: View {
                     Text("You'll be notified when any place reaches these visit counts.")
                 }
 
+                Section {
+                    Picker("Appearance", selection: $settings.appearanceMode) {
+                        ForEach(AppearanceMode.allCases) { mode in
+                            Text(mode.label).tag(mode)
+                        }
+                    }
+                } header: {
+                    Text("Appearance")
+                } footer: {
+                    Text("System matches your device's Light/Dark setting.")
+                }
+
                 Section("Tracking Status") {
                     LabeledContent("Status", value: trackingViewModel.statusText)
 


### PR DESCRIPTION
## Summary
- Add `AppearanceMode` enum (system/light/dark) persisted in UserDefaults via `AppSettings`
- Apply `.preferredColorScheme` at app root so the choice takes effect immediately
- New "Appearance" section in `SettingsView` with a picker

## Test plan
- [x] Toggle Settings → Appearance between System / Light / Dark, confirm UI flips live
- [x] Kill + relaunch app, confirm chosen mode persists
- [x] With Appearance = System, change device dark/light, confirm app follows
- [x] Verify all main screens (Logbook, Place detail, Map, Trajectory, Reports) render correctly in dark

🤖 Generated with [Claude Code](https://claude.com/claude-code)