### PR TITLE
chore: add App Store marketing copy doc (#62)

### DIFF
--- a/docs/app-store-marketing-copy.md
+++ b/docs/app-store-marketing-copy.md
@@ -1,0 +1,128 @@
+# App Store Marketing Copy — Placelore v1.0.0
+
+Source of truth for App Store Connect metadata. Paste each block into the matching field. Character counts are pre-verified against App Store limits.
+
+---
+
+## App Name
+
+```
+Placelore
+```
+
+(9 / 30 chars)
+
+---
+
+## Subtitle
+
+```
+Journal the places you visit
+```
+
+(28 / 30 chars)
+
+---
+
+## Promotional Text
+
+Editable after release without App Review — use it for fresh-launch messaging.
+
+```
+Placelore quietly logs the places you visit and lets you keep notes, photos, and visit counts for each one. On-device only. No account. No tracking.
+```
+
+(148 / 170 chars)
+
+---
+
+## Description
+
+```
+Placelore is a private place journal for your real life.
+
+It runs quietly in the background, notices when you've actually settled somewhere, and turns each stay into a place you can name, revisit, and write about. No check-ins. No feed. No friends list. Just your own log of where you've been.
+
+WHAT IT DOES
+• Detects places automatically from how long you stay, not from what's nearby.
+• Lets you rename, recategorize, or merge places so the log matches how you actually think about them.
+• Attaches journal entries and photos to each place — a quick note from a coffee shop, a longer entry from a trip.
+• Counts visits and tracked time so you can see your real-world patterns over a week, a month, or longer.
+• Shows your day on a map: the places you stopped, the path between them, and how long each stay lasted.
+• Sends gentle milestone notifications when a place reaches 5, 10, 25, 50, or 100 visits.
+• Categorizes places by type — Restaurant, Cafe, Gym, Park, and more — using Apple Maps, with custom categories you can add yourself.
+
+WHY IT'S DIFFERENT
+Most location apps want to broadcast where you are. Placelore is the opposite: it's a logbook you keep for yourself. The dwell-based detection means you only get places you actually spent time at, not every storefront you walked past. The journal and photo attachments turn raw location history into something worth looking back on.
+
+PRIVACY BY DEFAULT
+• All data is stored on your device. There is no Placelore server.
+• No accounts, no sign-in, no analytics SDKs, no advertising identifiers.
+• Your places, visits, photos, and journal entries never leave your iPhone unless you explicitly export them.
+• Background location is used only to detect dwell time. You can pause tracking for 1, 4, or 24 hours from inside the app.
+• You can delete every place, visit, photo, and journal entry from Settings at any time.
+
+CONTROL
+• Set the minimum stay duration that counts as a real visit (default: 30 minutes).
+• Pause and resume tracking whenever you want.
+• Export your raw location samples as CSV for your own analysis.
+• Delete individual places or wipe everything from Settings.
+
+REQUIREMENTS
+• iPhone running iOS 17 or later.
+• "Always" location permission for passive background detection.
+• Camera and Photos permissions only if you choose to attach pictures.
+
+Placelore is for people who want to remember their own life, quietly. If that's you, give it a try.
+```
+
+(2,425 / 4,000 chars)
+
+---
+
+## Keywords
+
+```
+journal,places,visits,location,travel,diary,logbook,notes,memory,trip
+```
+
+(69 / 100 chars)
+
+Notes:
+- Comma-separated, no spaces (Apple counts spaces against the limit).
+- Avoid repeating the app name and category — Apple already indexes those.
+- Reorder by perceived intent volume if ASO data later suggests it.
+
+---
+
+## Support URL
+
+```
+https://github.com/ychu824/Placelore/issues
+```
+
+---
+
+## Marketing URL (optional)
+
+```
+https://ychu824.github.io/Placelore/
+```
+
+---
+
+## Copyright
+
+```
+© 2026 Yucheng Hu
+```
+
+---
+
+## Update Checklist Before Submission
+
+- [ ] Re-count any edited block against the App Store limit.
+- [ ] Confirm Support URL resolves and accepts new issues from a logged-out browser.
+- [ ] Confirm Marketing URL renders the GitHub Pages site (not a 404).
+- [ ] Confirm copyright year matches the submission year.
+- [ ] Sanity-check description against the App Privacy nutrition label — claims must match.


### PR DESCRIPTION
## Summary
- Adds `docs/app-store-marketing-copy.md` with paste-ready App Store Connect metadata for v1.0.0
- Each block pre-counted against Apple's limits: subtitle 28/30, promo 148/170, description 2,425/4,000, keywords 69/100
- Privacy stance, dwell-detection differentiator, and on-device-only claims align with `docs/privacy-policy.md` and the App Privacy nutrition label plan in the spec

Refs #62, part of #53. Spec: `docs/superpowers/specs/2026-05-03-app-store-release-v1.0.0-design.md` §2.4.

## Test plan
- [ ] Open the doc and confirm each block paste-fits its App Store Connect field without truncation
- [ ] Verify Support URL (https://github.com/ychu824/Placelore/issues) resolves
- [ ] Verify Marketing URL (https://ychu824.github.io/Placelore/) resolves
- [ ] Confirm description claims match the App Privacy questionnaire selections (location + photos, App Functionality, not linked, not used for tracking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)