### PR TITLE
chore: change bundle id to dev.placelore.app

### DIFF
--- a/PlaceNotes/PlaceNotesApp.swift
+++ b/PlaceNotes/PlaceNotesApp.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import SwiftData
 import os
 
-private let logger = Logger(subsystem: "com.placenotes.app", category: "App")
+private let logger = Logger(subsystem: "dev.placelore.app", category: "App")
 
 @main
 struct PlaceNotesApp: App {

--- a/PlaceNotes/Services/LocationManager.swift
+++ b/PlaceNotes/Services/LocationManager.swift
@@ -3,7 +3,7 @@ import CoreLocation
 import SwiftData
 import os
 
-private let logger = Logger(subsystem: "com.placenotes.app", category: "LocationManager")
+private let logger = Logger(subsystem: "dev.placelore.app", category: "LocationManager")
 
 // MARK: - Location Sample
 

--- a/PlaceNotes/Services/LocationOneShot.swift
+++ b/PlaceNotes/Services/LocationOneShot.swift
@@ -2,7 +2,7 @@ import Foundation
 import CoreLocation
 import os
 
-private let logger = Logger(subsystem: "com.placenotes.app", category: "LocationOneShot")
+private let logger = Logger(subsystem: "dev.placelore.app", category: "LocationOneShot")
 
 @MainActor
 protocol LocationOneShotProviding {

--- a/PlaceNotes/Services/MockLocationProvider.swift
+++ b/PlaceNotes/Services/MockLocationProvider.swift
@@ -2,7 +2,7 @@ import Foundation
 import SwiftData
 import os
 
-private let logger = Logger(subsystem: "com.placenotes.app", category: "MockLocationProvider")
+private let logger = Logger(subsystem: "dev.placelore.app", category: "MockLocationProvider")
 
 /// Provides simulated location visits for debug builds and
 /// cleans up mock data when switching to release.

--- a/PlaceNotes/Services/NotificationManager.swift
+++ b/PlaceNotes/Services/NotificationManager.swift
@@ -2,7 +2,7 @@ import Foundation
 import UserNotifications
 import os
 
-private let logger = Logger(subsystem: "com.placenotes.app", category: "Notifications")
+private let logger = Logger(subsystem: "dev.placelore.app", category: "Notifications")
 
 final class NotificationManager {
     static let shared = NotificationManager()

--- a/PlaceNotes/Services/PlaceResolver.swift
+++ b/PlaceNotes/Services/PlaceResolver.swift
@@ -4,7 +4,7 @@ import MapKit
 import SwiftData
 import os
 
-private let logger = Logger(subsystem: "com.placenotes.app", category: "PlaceResolver")
+private let logger = Logger(subsystem: "dev.placelore.app", category: "PlaceResolver")
 
 private struct ResolvedPlace {
     let name: String

--- a/PlaceNotes/Services/QuickCaptureService.swift
+++ b/PlaceNotes/Services/QuickCaptureService.swift
@@ -3,7 +3,7 @@ import CoreLocation
 import SwiftData
 import os
 
-private let logger = Logger(subsystem: "com.placenotes.app", category: "QuickCaptureService")
+private let logger = Logger(subsystem: "dev.placelore.app", category: "QuickCaptureService")
 
 enum QuickCaptureResult {
     case newVisit(visitID: UUID, placeName: String, journalEntryID: UUID)

--- a/PlaceNotes/Services/TrackingManager.swift
+++ b/PlaceNotes/Services/TrackingManager.swift
@@ -2,7 +2,7 @@ import Foundation
 import Combine
 import os
 
-private let logger = Logger(subsystem: "com.placenotes.app", category: "TrackingManager")
+private let logger = Logger(subsystem: "dev.placelore.app", category: "TrackingManager")
 
 final class TrackingManager: ObservableObject {
     private let locationManager: LocationManager

--- a/PlaceNotes/ViewModels/QuickCaptureViewModel.swift
+++ b/PlaceNotes/ViewModels/QuickCaptureViewModel.swift
@@ -5,7 +5,7 @@ import SwiftData
 import UIKit
 import os
 
-private let logger = Logger(subsystem: "com.placenotes.app", category: "QuickCaptureViewModel")
+private let logger = Logger(subsystem: "dev.placelore.app", category: "QuickCaptureViewModel")
 
 @MainActor
 final class QuickCaptureViewModel: ObservableObject {

--- a/docs/qa/first-launch-checklist.md
+++ b/docs/qa/first-launch-checklist.md
@@ -77,7 +77,7 @@ iOS does **not** prompt for Always immediately. To force the upgrade prompt:
 
 ## Final verification
 
-- [ ] No `os_log` errors visible in Console.app filtered by subsystem `com.placenotes.app` and level **Error**.
+- [ ] No `os_log` errors visible in Console.app filtered by subsystem `dev.placelore.app` and level **Error**.
 - [ ] No `fatalError` hit. (The only one is `PlaceNotesApp.init` after a second store-create failure — should never fire on a clean install.)
 - [ ] Settings app → Placelore shows: Location = Always (or While Using), Notifications = On, Camera = On.
 

--- a/project.yml
+++ b/project.yml
@@ -1,6 +1,6 @@
 name: PlaceNotes
 options:
-  bundleIdPrefix: com.placenotes
+  bundleIdPrefix: dev.placelore
   deploymentTarget:
     iOS: "17.0"
   xcodeVersion: "15.0"
@@ -39,7 +39,7 @@ targets:
     settings:
       base:
         INFOPLIST_FILE: PlaceNotes/Info.plist
-        PRODUCT_BUNDLE_IDENTIFIER: com.placenotes.app
+        PRODUCT_BUNDLE_IDENTIFIER: dev.placelore.app
         MARKETING_VERSION: "1.0.0"
         CURRENT_PROJECT_VERSION: 1
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
@@ -62,7 +62,7 @@ targets:
       - target: PlaceNotes
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: com.placenotes.tests
+        PRODUCT_BUNDLE_IDENTIFIER: dev.placelore.tests
         GENERATE_INFOPLIST_FILE: YES
         TEST_HOST: "$(BUILT_PRODUCTS_DIR)/PlaceNotes.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/PlaceNotes"
         BUNDLE_LOADER: "$(TEST_HOST)"


### PR DESCRIPTION
## Summary
- Update bundle identifier from `com.placenotes.app` to `dev.placelore.app` (and tests bundle to `dev.placelore.tests`) so it aligns with the renamed Placelore product.
- Update `os.Logger` subsystem strings across 9 source files to match the new bundle ID — keeps Console.app filtering working.
- Update QA checklist reference to the new subsystem.

## Notes
- Apple does not verify domain ownership of bundle IDs, but the matching `placelore.dev` domain will be registered separately.
- Must be done **before** the App Store Connect record is created or the first TestFlight upload (whichever comes first) — bundle IDs are immutable post-submission.
- If an ASC record already exists with the old ID, it must be deleted and recreated.

## Test plan
- [x] `xcodegen generate` regenerates project cleanly
- [x] `xcodebuild build` succeeds (Debug, iPhone 17 Pro sim)
- [x] `xcodebuild test` — 156 tests pass, 0 failures
- [x] Register App ID `dev.placelore.app` in Apple Developer portal
- [x] Re-sign / regenerate provisioning profiles (Xcode auto-handles)
- [x] Verify log filtering with `subsystem == dev.placelore.app` in Console.app