### PR TITLE
chore: restrict device family to iPhone only

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -8,7 +8,7 @@ options:
 settings:
   base:
     SWIFT_VERSION: "5.9"
-    TARGETED_DEVICE_FAMILY: "1,2"
+    TARGETED_DEVICE_FAMILY: "1"
     DEVELOPMENT_TEAM: H63486AZ9Y
     CODE_SIGN_STYLE: Automatic
   configs:


### PR DESCRIPTION
## Summary
- Changes `TARGETED_DEVICE_FAMILY` from `"1,2"` to `"1"` in `project.yml`
- Drops nominal iPad support so the App Store listing no longer requires iPad screenshots or iPad-specific UI validation
- Placelore's SwiftUI is portrait-only and tuned for iPhone; shipping as universal without dedicated iPad layouts risks rejection

## Test plan
- [x] `xcodegen generate` succeeds
- [x] Release build succeeds on iPhone 17 Pro Max simulator
- [x] Confirm App Store Connect Media Manager no longer prompts for iPad screenshots after upload

🤖 Generated with [Claude Code](https://claude.com/claude-code)