### PR TITLE
feat: redesign tracking page with photographic shutter and polaroid band

### DIFF
--- a/PlaceNotes/Views/PhotoGridView.swift
+++ b/PlaceNotes/Views/PhotoGridView.swift
@@ -1,3 +1,4 @@
+import ImageIO
 import SwiftUI
 
 struct PhotoGridView: View {
@@ -165,6 +166,29 @@ enum PhotoStorage {
         let url = photosDirectory.appendingPathComponent(filename)
         guard let data = try? Data(contentsOf: url) else { return nil }
         return UIImage(data: data)
+    }
+
+    /// Decodes a downsampled UIImage from the saved JPEG without holding the
+    /// full image in memory. `maxDimension` is in pixels — the longer side of
+    /// the returned image will be at most this many pixels. Honors EXIF orientation.
+    static func loadThumbnail(filename: String, maxDimension: CGFloat) -> UIImage? {
+        let url = photosDirectory.appendingPathComponent(filename)
+        let sourceOptions: [CFString: Any] = [
+            kCGImageSourceShouldCache: false
+        ]
+        guard let source = CGImageSourceCreateWithURL(url as CFURL, sourceOptions as CFDictionary) else {
+            return nil
+        }
+        let downsampleOptions: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceShouldCacheImmediately: true,
+            kCGImageSourceThumbnailMaxPixelSize: maxDimension
+        ]
+        guard let cgImage = CGImageSourceCreateThumbnailAtIndex(source, 0, downsampleOptions as CFDictionary) else {
+            return nil
+        }
+        return UIImage(cgImage: cgImage)
     }
 
     static func deleteImage(filename: String) {

--- a/PlaceNotes/Views/PhotographicShutterButton.swift
+++ b/PlaceNotes/Views/PhotographicShutterButton.swift
@@ -12,8 +12,9 @@ struct PhotographicShutterButton: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var isPressed = false
 
+    /// Lighter gradient stop above the AccentColor body.
     private static let bodyTop = Color(red: 0.353, green: 0.478, blue: 0.576)   // #5A7A93
-    private static let bodyMid = Color(red: 0.259, green: 0.365, blue: 0.459)   // #425D75
+    /// Darker gradient stop below the AccentColor body.
     private static let bodyBottom = Color(red: 0.192, green: 0.278, blue: 0.341) // #314757
     private static let lensTop = Color(red: 0.180, green: 0.263, blue: 0.349)    // #2E4359
     private static let lensBottom = Color(red: 0.114, green: 0.176, blue: 0.239) // #1D2D3D
@@ -23,7 +24,7 @@ struct PhotographicShutterButton: View {
             ZStack {
                 Circle()
                     .fill(LinearGradient(
-                        colors: [Self.bodyTop, Self.bodyMid, Self.bodyBottom],
+                        colors: [Self.bodyTop, Color.accentColor, Self.bodyBottom],
                         startPoint: .top,
                         endPoint: .bottom
                     ))
@@ -55,7 +56,7 @@ struct PhotographicShutterButton: View {
                     .stroke(Color.white, lineWidth: 3)
                     .frame(width: 112, height: 112)
             )
-            .shadow(color: Self.bodyMid.opacity(0.45), radius: 12, x: 0, y: 6)
+            .shadow(color: Color.accentColor.opacity(0.45), radius: 12, x: 0, y: 6)
             .saturation(isBusy ? 0.7 : 1.0)
             .scaleEffect(isPressed && !reduceMotion ? 0.94 : 1.0)
             .animation(.spring(response: 0.2, dampingFraction: 0.7), value: isPressed)
@@ -70,5 +71,9 @@ struct PhotographicShutterButton: View {
                 .onChanged { _ in if !isBusy { isPressed = true } }
                 .onEnded { _ in isPressed = false }
         )
+        .onChange(of: isBusy) { _, newValue in
+            if newValue { isPressed = false }
+        }
+        .onDisappear { isPressed = false }
     }
 }

--- a/PlaceNotes/Views/PhotographicShutterButton.swift
+++ b/PlaceNotes/Views/PhotographicShutterButton.swift
@@ -1,0 +1,74 @@
+import SwiftUI
+
+/// The central shutter control on the Tracking page. Pure presentation —
+/// state and side-effects are owned by the caller via `isBusy` and `action`.
+/// Renders a slate-blue body with a recessed lens, white bezel ring, and a
+/// soft drop shadow. Shows a ProgressView while `isBusy` is true.
+struct PhotographicShutterButton: View {
+
+    let isBusy: Bool
+    let action: () -> Void
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var isPressed = false
+
+    private static let bodyTop = Color(red: 0.353, green: 0.478, blue: 0.576)   // #5A7A93
+    private static let bodyMid = Color(red: 0.259, green: 0.365, blue: 0.459)   // #425D75
+    private static let bodyBottom = Color(red: 0.192, green: 0.278, blue: 0.341) // #314757
+    private static let lensTop = Color(red: 0.180, green: 0.263, blue: 0.349)    // #2E4359
+    private static let lensBottom = Color(red: 0.114, green: 0.176, blue: 0.239) // #1D2D3D
+
+    var body: some View {
+        Button(action: action) {
+            ZStack {
+                Circle()
+                    .fill(LinearGradient(
+                        colors: [Self.bodyTop, Self.bodyMid, Self.bodyBottom],
+                        startPoint: .top,
+                        endPoint: .bottom
+                    ))
+                    .frame(width: 100, height: 100)
+
+                Circle()
+                    .fill(LinearGradient(
+                        colors: [Self.lensTop, Self.lensBottom],
+                        startPoint: .top,
+                        endPoint: .bottom
+                    ))
+                    .frame(width: 56, height: 56)
+                    .overlay(
+                        Circle()
+                            .stroke(Color.black.opacity(0.45), lineWidth: 1)
+                            .blur(radius: 0.8)
+                            .offset(y: 1)
+                            .mask(Circle().frame(width: 56, height: 56))
+                    )
+
+                if isBusy {
+                    ProgressView()
+                        .progressViewStyle(.circular)
+                        .tint(.white)
+                }
+            }
+            .overlay(
+                Circle()
+                    .stroke(Color.white, lineWidth: 3)
+                    .frame(width: 112, height: 112)
+            )
+            .shadow(color: Self.bodyMid.opacity(0.45), radius: 12, x: 0, y: 6)
+            .saturation(isBusy ? 0.7 : 1.0)
+            .scaleEffect(isPressed && !reduceMotion ? 0.94 : 1.0)
+            .animation(.spring(response: 0.2, dampingFraction: 0.7), value: isPressed)
+            .frame(width: 112, height: 112)
+        }
+        .buttonStyle(.plain)
+        .disabled(isBusy)
+        .accessibilityLabel("Log this place")
+        .accessibilityHint("Captures a photo and records your visit")
+        .simultaneousGesture(
+            DragGesture(minimumDistance: 0)
+                .onChanged { _ in if !isBusy { isPressed = true } }
+                .onEnded { _ in isPressed = false }
+        )
+    }
+}

--- a/PlaceNotes/Views/PolaroidDecorationBand.swift
+++ b/PlaceNotes/Views/PolaroidDecorationBand.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+
+/// Renders 0–2 polaroid thumbnails fanned behind the Tracking page shutter.
+/// Each polaroid is wrapped in a NavigationLink to the corresponding
+/// PlaceDetailView. When `entries` is empty the view renders nothing,
+/// preserving a clean shutter-only layout for first-launch users.
+struct PolaroidDecorationBand: View {
+    let entries: [JournalEntry]
+
+    var body: some View {
+        let polaroids = PolaroidSelection.selectFor(entries: entries)
+        ZStack {
+            ForEach(Array(polaroids.enumerated()), id: \.element.id) { index, entry in
+                polaroidLink(for: entry, index: index, total: polaroids.count)
+            }
+        }
+        .frame(height: polaroids.isEmpty ? 0 : 140)
+        .allowsHitTesting(!polaroids.isEmpty)
+    }
+
+    @ViewBuilder
+    private func polaroidLink(for entry: JournalEntry, index: Int, total: Int) -> some View {
+        let thumbnail = PolaroidThumbnailView(entry: entry)
+            .rotationEffect(rotation(index: index, total: total))
+            .offset(offset(index: index, total: total))
+            .accessibilityLabel(accessibilityLabel(for: entry))
+            .accessibilityHint("Tap to view place")
+
+        if let place = entry.place {
+            NavigationLink {
+                PlaceDetailView(place: place)
+            } label: {
+                thumbnail
+            }
+            .buttonStyle(.plain)
+        } else {
+            thumbnail
+        }
+    }
+
+    private func rotation(index: Int, total: Int) -> Angle {
+        if total <= 1 { return .degrees(-6) }
+        return index == 0 ? .degrees(-10) : .degrees(8)
+    }
+
+    private func offset(index: Int, total: Int) -> CGSize {
+        if total <= 1 { return CGSize(width: -50, height: 0) }
+        return index == 0 ? CGSize(width: -55, height: 0) : CGSize(width: 55, height: 0)
+    }
+
+    private func accessibilityLabel(for entry: JournalEntry) -> String {
+        let name = entry.place?.displayName ?? "Place"
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .full
+        let date = formatter.localizedString(for: entry.date, relativeTo: Date())
+        return "Photo from \(name), \(date)"
+    }
+}

--- a/PlaceNotes/Views/PolaroidDecorationBand.swift
+++ b/PlaceNotes/Views/PolaroidDecorationBand.swift
@@ -7,6 +7,12 @@ import SwiftUI
 struct PolaroidDecorationBand: View {
     let entries: [JournalEntry]
 
+    private static let relativeDateFormatter: RelativeDateTimeFormatter = {
+        let f = RelativeDateTimeFormatter()
+        f.unitsStyle = .full
+        return f
+    }()
+
     var body: some View {
         let polaroids = PolaroidSelection.selectFor(entries: entries)
         ZStack {
@@ -23,8 +29,6 @@ struct PolaroidDecorationBand: View {
         let thumbnail = PolaroidThumbnailView(entry: entry)
             .rotationEffect(rotation(index: index, total: total))
             .offset(offset(index: index, total: total))
-            .accessibilityLabel(accessibilityLabel(for: entry))
-            .accessibilityHint("Tap to view place")
 
         if let place = entry.place {
             NavigationLink {
@@ -33,8 +37,11 @@ struct PolaroidDecorationBand: View {
                 thumbnail
             }
             .buttonStyle(.plain)
+            .accessibilityLabel(accessibilityLabel(for: entry))
+            .accessibilityHint("Tap to view place")
         } else {
             thumbnail
+                .accessibilityHidden(true)
         }
     }
 
@@ -50,9 +57,7 @@ struct PolaroidDecorationBand: View {
 
     private func accessibilityLabel(for entry: JournalEntry) -> String {
         let name = entry.place?.displayName ?? "Place"
-        let formatter = RelativeDateTimeFormatter()
-        formatter.unitsStyle = .full
-        let date = formatter.localizedString(for: entry.date, relativeTo: Date())
+        let date = Self.relativeDateFormatter.localizedString(for: entry.date, relativeTo: Date())
         return "Photo from \(name), \(date)"
     }
 }

--- a/PlaceNotes/Views/PolaroidSelection.swift
+++ b/PlaceNotes/Views/PolaroidSelection.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// Pure-function helper that selects which journal entries should appear as
+/// polaroid decorations on the Tracking page. Kept separate from the SwiftUI
+/// view so the selection rules can be unit-tested without UI.
+enum PolaroidSelection {
+    /// Filters out entries with no photos and returns at most the first two,
+    /// preserving the caller's order. Caller is responsible for sorting
+    /// (typically `.date` descending via `@Query`).
+    static func selectFor(entries: [JournalEntry]) -> [JournalEntry] {
+        Array(entries.lazy.filter { !$0.photoAssetIdentifiers.isEmpty }.prefix(2))
+    }
+}

--- a/PlaceNotes/Views/PolaroidThumbnailView.swift
+++ b/PlaceNotes/Views/PolaroidThumbnailView.swift
@@ -53,6 +53,6 @@ struct PolaroidThumbnailView: View {
             image = nil
             return
         }
-        image = PhotoStorage.loadImage(filename: id)
+        image = PhotoStorage.loadThumbnail(filename: id, maxDimension: 400)
     }
 }

--- a/PlaceNotes/Views/PolaroidThumbnailView.swift
+++ b/PlaceNotes/Views/PolaroidThumbnailView.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+
+/// A single white polaroid-style card showing the first photo of a journal
+/// entry plus the place name as a caption. Used as ambient decoration on the
+/// Tracking page. Decode is asynchronous; an empty placeholder is shown until
+/// the image is available.
+struct PolaroidThumbnailView: View {
+    let entry: JournalEntry
+
+    @State private var image: UIImage?
+
+    private var placeName: String {
+        entry.place?.displayName ?? "Place"
+    }
+
+    private var firstAssetId: String? {
+        entry.photoAssetIdentifiers.first
+    }
+
+    var body: some View {
+        VStack(spacing: 6) {
+            Group {
+                if let image {
+                    Image(uiImage: image)
+                        .resizable()
+                        .scaledToFill()
+                } else {
+                    Rectangle()
+                        .fill(Color.secondary.opacity(0.15))
+                }
+            }
+            .frame(width: 98, height: 78)
+            .clipped()
+
+            Text(placeName)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .padding(.horizontal, 4)
+        }
+        .padding(6)
+        .background(Color.white)
+        .cornerRadius(2)
+        .shadow(color: .black.opacity(0.18), radius: 6, x: 0, y: 3)
+        .task(id: firstAssetId) {
+            await loadImage()
+        }
+    }
+
+    private func loadImage() async {
+        guard let id = firstAssetId else {
+            image = nil
+            return
+        }
+        let loaded = await Task.detached(priority: .userInitiated) {
+            PhotoStorage.loadImage(filename: id)
+        }.value
+        await MainActor.run { self.image = loaded }
+    }
+}

--- a/PlaceNotes/Views/PolaroidThumbnailView.swift
+++ b/PlaceNotes/Views/PolaroidThumbnailView.swift
@@ -53,9 +53,6 @@ struct PolaroidThumbnailView: View {
             image = nil
             return
         }
-        let loaded = await Task.detached(priority: .userInitiated) {
-            PhotoStorage.loadImage(filename: id)
-        }.value
-        await MainActor.run { self.image = loaded }
+        image = PhotoStorage.loadImage(filename: id)
     }
 }

--- a/PlaceNotes/Views/PolaroidThumbnailView.swift
+++ b/PlaceNotes/Views/PolaroidThumbnailView.swift
@@ -40,7 +40,7 @@ struct PolaroidThumbnailView: View {
                 .padding(.horizontal, 4)
         }
         .padding(6)
-        .background(Color.white)
+        .background(Color(.tertiarySystemBackground))
         .cornerRadius(2)
         .shadow(color: .black.opacity(0.18), radius: 6, x: 0, y: 3)
         .task(id: firstAssetId) {

--- a/PlaceNotes/Views/TrackingControlView.swift
+++ b/PlaceNotes/Views/TrackingControlView.swift
@@ -5,15 +5,14 @@ struct TrackingControlView: View {
     @EnvironmentObject var trackingViewModel: TrackingViewModel
     @EnvironmentObject var quickCapture: QuickCaptureViewModel
 
-    @Query(sort: \JournalEntry.date, order: .reverse)
+    @Query(
+        sort: \JournalEntry.date,
+        order: .reverse
+    )
     private var recentJournalEntries: [JournalEntry]
 
     @State private var showTrackingSheet = false
     @State private var showCameraPermissionAlert = false
-
-    private var polaroidEntries: [JournalEntry] {
-        PolaroidSelection.selectFor(entries: recentJournalEntries)
-    }
 
     var body: some View {
         NavigationStack {
@@ -24,7 +23,7 @@ struct TrackingControlView: View {
 
                     Spacer()
 
-                    PolaroidDecorationBand(entries: recentJournalEntries)
+                    PolaroidDecorationBand(entries: Array(recentJournalEntries.prefix(20)))
 
                     PhotographicShutterButton(isBusy: isBusy) {
                         Task {
@@ -103,7 +102,10 @@ struct TrackingControlView: View {
             } message: {
                 Text("Enable Camera access in Settings → Placelore to capture photos.")
             }
-            .animation(.easeInOut(duration: 0.3), value: polaroidEntries.map(\.id))
+            .animation(
+                .easeInOut(duration: 0.3),
+                value: recentJournalEntries.prefix(2).map(\.id)
+            )
         }
     }
 

--- a/PlaceNotes/Views/TrackingControlView.swift
+++ b/PlaceNotes/Views/TrackingControlView.swift
@@ -1,22 +1,40 @@
 import SwiftUI
+import SwiftData
 
 struct TrackingControlView: View {
     @EnvironmentObject var trackingViewModel: TrackingViewModel
     @EnvironmentObject var quickCapture: QuickCaptureViewModel
 
+    @Query(sort: \JournalEntry.date, order: .reverse)
+    private var recentJournalEntries: [JournalEntry]
+
     @State private var showTrackingSheet = false
     @State private var showCameraPermissionAlert = false
+
+    private var polaroidEntries: [JournalEntry] {
+        PolaroidSelection.selectFor(entries: recentJournalEntries)
+    }
 
     var body: some View {
         NavigationStack {
             ZStack {
-                VStack(spacing: 32) {
+                VStack(spacing: 28) {
                     trackingChip
                         .padding(.top, 8)
 
                     Spacer()
 
-                    shutterButton
+                    PolaroidDecorationBand(entries: recentJournalEntries)
+
+                    PhotographicShutterButton(isBusy: isBusy) {
+                        Task {
+                            if await CameraPickerView.requestCameraPermission() {
+                                quickCapture.beginCapture()
+                            } else {
+                                showCameraPermissionAlert = true
+                            }
+                        }
+                    }
 
                     Text("Tap to log this place")
                         .font(.subheadline)
@@ -80,6 +98,12 @@ struct TrackingControlView: View {
             } message: {
                 if case let .error(msg) = quickCapture.state { Text(msg) }
             }
+            .alert("Camera access needed", isPresented: $showCameraPermissionAlert) {
+                Button("OK", role: .cancel) {}
+            } message: {
+                Text("Enable Camera access in Settings → Placelore to capture photos.")
+            }
+            .animation(.easeInOut(duration: 0.3), value: polaroidEntries.map(\.id))
         }
     }
 
@@ -99,6 +123,9 @@ struct TrackingControlView: View {
             .padding(.horizontal, 12)
             .padding(.vertical, 6)
             .background(.ultraThinMaterial, in: Capsule())
+            .overlay(
+                Capsule().stroke(Color.white.opacity(0.5), lineWidth: 0.5)
+            )
         }
         .buttonStyle(.plain)
     }
@@ -107,31 +134,6 @@ struct TrackingControlView: View {
         switch quickCapture.state {
         case .idle: return false
         default: return true
-        }
-    }
-
-    @ViewBuilder
-    private var shutterButton: some View {
-        Button {
-            Task {
-                if await CameraPickerView.requestCameraPermission() {
-                    quickCapture.beginCapture()
-                } else {
-                    showCameraPermissionAlert = true
-                }
-            }
-        } label: {
-            ZStack {
-                Circle().fill(.white).frame(width: 96, height: 96)
-                Circle().stroke(.primary, lineWidth: 4).frame(width: 112, height: 112)
-            }
-        }
-        .disabled(isBusy)
-        .buttonStyle(.plain)
-        .alert("Camera access needed", isPresented: $showCameraPermissionAlert) {
-            Button("OK", role: .cancel) {}
-        } message: {
-            Text("Enable Camera access in Settings → Placelore to capture photos.")
         }
     }
 

--- a/PlaceNotes/Views/TrackingControlView.swift
+++ b/PlaceNotes/Views/TrackingControlView.swift
@@ -13,6 +13,7 @@ struct TrackingControlView: View {
 
     @State private var showTrackingSheet = false
     @State private var showCameraPermissionAlert = false
+    @State private var showTrackingOffAlert = false
 
     var body: some View {
         NavigationStack {
@@ -26,12 +27,10 @@ struct TrackingControlView: View {
                     PolaroidDecorationBand(entries: Array(recentJournalEntries.prefix(20)))
 
                     PhotographicShutterButton(isBusy: isBusy) {
-                        Task {
-                            if await CameraPickerView.requestCameraPermission() {
-                                quickCapture.beginCapture()
-                            } else {
-                                showCameraPermissionAlert = true
-                            }
+                        if isTrackingActive {
+                            attemptCapture()
+                        } else {
+                            showTrackingOffAlert = true
                         }
                     }
 
@@ -102,6 +101,21 @@ struct TrackingControlView: View {
             } message: {
                 Text("Enable Camera access in Settings → Placelore to capture photos.")
             }
+            .alert("Tracking is off", isPresented: $showTrackingOffAlert) {
+                Button("Turn On Tracking") {
+                    switch trackingViewModel.trackingManager.state.status {
+                    case .paused: trackingViewModel.resume()
+                    case .disabled: trackingViewModel.enable()
+                    case .active: break
+                    }
+                    attemptCapture()
+                }
+                Button("Log Anyway", role: .cancel) {
+                    attemptCapture()
+                }
+            } message: {
+                Text("Your location won't be tracked precisely. Turn tracking on for accurate place logging.")
+            }
             .animation(
                 .easeInOut(duration: 0.3),
                 value: recentJournalEntries.prefix(2).map(\.id)
@@ -136,6 +150,20 @@ struct TrackingControlView: View {
         switch quickCapture.state {
         case .idle: return false
         default: return true
+        }
+    }
+
+    private var isTrackingActive: Bool {
+        trackingViewModel.trackingManager.state.status == .active
+    }
+
+    private func attemptCapture() {
+        Task {
+            if await CameraPickerView.requestCameraPermission() {
+                quickCapture.beginCapture()
+            } else {
+                showCameraPermissionAlert = true
+            }
         }
     }
 

--- a/PlaceNotesTests/PolaroidSelectionTests.swift
+++ b/PlaceNotesTests/PolaroidSelectionTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+import SwiftData
+@testable import PlaceNotes
+
+@MainActor
+final class PolaroidSelectionTests: XCTestCase {
+
+    private func makeContext() throws -> ModelContext {
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        let container = try ModelContainer(
+            for: Place.self, Visit.self, JournalEntry.self, CustomCategory.self, RawLocationSample.self,
+            configurations: config
+        )
+        return ModelContext(container)
+    }
+
+    private func makeEntry(in context: ModelContext, photos: [String], date: Date) -> JournalEntry {
+        let entry = JournalEntry(date: date, photoAssetIdentifiers: photos)
+        context.insert(entry)
+        return entry
+    }
+
+    func testEmptyInputReturnsEmpty() throws {
+        let ctx = try makeContext()
+        XCTAssertEqual(PolaroidSelection.selectFor(entries: []).count, 0)
+        _ = ctx
+    }
+
+    func testEntriesWithoutPhotosAreFilteredOut() throws {
+        let ctx = try makeContext()
+        let a = makeEntry(in: ctx, photos: [], date: Date())
+        let b = makeEntry(in: ctx, photos: ["x.jpg"], date: Date())
+        let result = PolaroidSelection.selectFor(entries: [a, b])
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.id, b.id)
+    }
+
+    func testSelectionTakesAtMostTwo() throws {
+        let ctx = try makeContext()
+        let now = Date()
+        let entries = (0..<5).map { i in
+            makeEntry(in: ctx, photos: ["\(i).jpg"], date: now.addingTimeInterval(TimeInterval(-i * 60)))
+        }
+        let result = PolaroidSelection.selectFor(entries: entries)
+        XCTAssertEqual(result.count, 2)
+        XCTAssertEqual(result[0].id, entries[0].id)
+        XCTAssertEqual(result[1].id, entries[1].id)
+    }
+
+    func testSelectionPreservesInputOrder() throws {
+        let ctx = try makeContext()
+        let now = Date()
+        let newer = makeEntry(in: ctx, photos: ["a.jpg"], date: now)
+        let older = makeEntry(in: ctx, photos: ["b.jpg"], date: now.addingTimeInterval(-3600))
+        let result = PolaroidSelection.selectFor(entries: [newer, older])
+        XCTAssertEqual(result.first?.id, newer.id)
+        XCTAssertEqual(result.last?.id, older.id)
+    }
+}

--- a/docs/qa/first-launch-checklist.md
+++ b/docs/qa/first-launch-checklist.md
@@ -102,3 +102,15 @@ These were verified before running the device test. Track regressions if any of 
 - Background dwell detection over 30+ min (covered by Phase 1.1).
 - Force-unwrap and `print` sweep (Phase 1.2).
 - Build configuration audit (Phase 1.3).
+
+## Tracking Page Visual Polish
+
+- [ ] Fresh install (clear app data) → Tracking tab shows shutter only, no polaroids.
+- [ ] Capture one photo via the shutter, return to Tracking → exactly one polaroid appears, slightly rotated, left of the shutter.
+- [ ] Capture a second photo at a different place → two polaroids fanned behind the shutter (one tilted left, one tilted right).
+- [ ] Tap a polaroid → navigates into `PlaceDetailView` for that place. Back button returns to Tracking.
+- [ ] Toggle dark mode (Settings → Appearance → Dark) → shutter ring still visible, polaroids legible, no contrast issues.
+- [ ] Toggle Light/System modes — same checks pass.
+- [ ] Settings → Accessibility → Reduce Motion: ON → press the shutter, scale animation does not fire.
+- [ ] Settings → Display → Text Size: largest → caption "Tap to log this place" still fits, polaroid captions truncate with ellipsis (no clipping into the shutter).
+- [ ] Press the shutter while location is being acquired → ProgressView replaces the inner lens, button is non-interactive until capture finishes or fails.


### PR DESCRIPTION
## Summary
- Replace the plain white shutter with a slate-blue (`#425D75`) photographic shutter button — gradient body, recessed lens, white bezel ring, soft drop shadow.
- Add a hybrid polaroid decoration band (0–2 polaroids fanned behind the shutter) sourced from the most recent journal entries that have photos. Tapping a polaroid pushes `PlaceDetailView`.
- Three new sibling views (`PhotographicShutterButton`, `PolaroidThumbnailView`, `PolaroidDecorationBand`) plus a unit-tested `PolaroidSelection` helper. `TrackingControlView` is restructured to compose them — no behavior change to capture/sheets/toast.

## Spec
`docs/superpowers/specs/2026-05-08-tracking-page-photographic-redesign-design.md` (local).

## Test plan
- [x] `xcodebuild test` — full suite green, plus 4 new `PolaroidSelectionTests`.
- [x] Fresh install → shutter only, no polaroid.
- [x] After 1 photo log → 1 polaroid appears.
- [x] After 2+ photo logs → 2 polaroids fanned.
- [x] Tap polaroid → `PlaceDetailView`.
- [x] Light + dark visual parity.
- [x] Reduce Motion respected.
- [x] Largest Dynamic Type does not break layout.