### PR TITLE
fix(map): include photo-logged places on map

### DIFF
--- a/PlaceNotes/Views/FrequentPlacesMapView.swift
+++ b/PlaceNotes/Views/FrequentPlacesMapView.swift
@@ -112,13 +112,28 @@ struct FrequentPlacesMapView: View {
         places.map { "\($0.id)|\($0.displayName)|\($0.emoji)" }
     }
 
+    /// Builds a combined ranking list: frequent places from the viewModel plus
+    /// any place with a journal entry that didn't clear the frequency threshold
+    /// (e.g. photo quick-captures, which create a 60-second synthetic visit).
+    /// Without this, photo-logged places never appear on the map and the user
+    /// can't open their detail sheet to set a nickname.
+    private func mapRankings() -> [PlaceRanking] {
+        var rankings = Array(viewModel.monthlyPlaces.prefix(50))
+        let included = Set(rankings.map { $0.place.id })
+        let extras = places
+            .filter { !$0.journalEntries.isEmpty && !included.contains($0.id) }
+            .map { PlaceRanking(place: $0, qualifiedStays: 0, totalMinutes: 0) }
+        rankings.append(contentsOf: extras)
+        return rankings
+    }
+
     /// Rebuilds annotations only when region or data changes — not on every render.
     private func rebuildAnnotations() {
         guard !isRebuildingAnnotations else { return }
         isRebuildingAnnotations = true
         defer { isRebuildingAnnotations = false }
 
-        let rankings = Array(viewModel.monthlyPlaces.prefix(50))
+        let rankings = mapRankings()
         let newAnnotations: [any MapAnnotationItem]
         if let region = visibleRegion {
             let clusterRadius = region.span.latitudeDelta * 0.08
@@ -254,13 +269,15 @@ struct PlaceAnnotationView: View {
                     )
             }
 
-            Text("\(ranking.qualifiedStays)")
-                .font(.caption2.bold())
-                .foregroundStyle(.white)
-                .padding(.horizontal, 6)
-                .padding(.vertical, 2)
-                .background(flameIntensity == .none ? Color.accentColor : flameIntensity.glowColor)
-                .clipShape(Capsule())
+            if ranking.qualifiedStays > 0 {
+                Text("\(ranking.qualifiedStays)")
+                    .font(.caption2.bold())
+                    .foregroundStyle(.white)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(flameIntensity == .none ? Color.accentColor : flameIntensity.glowColor)
+                    .clipShape(Capsule())
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Map tab previously sourced annotations only from `viewModel.monthlyPlaces`, which is filtered through `ReportGenerator.frequentPlaces` (requires `durationMinutes >= minStayMinutes`, default 30). Photo quick-captures create a 60-second synthetic `Visit` (`QuickCaptureService.quickVisitDuration`), so those places never cleared the threshold and never appeared on the map — leaving the user no way to open the detail sheet and assign a nickname.
- New `mapRankings()` unions the frequent rankings with any `Place` that has a `JournalEntry` but didn't clear the threshold, surfacing photo-logged places with `qualifiedStays = 0`.
- `PlaceAnnotationView` hides the qualified-stay count badge when `qualifiedStays == 0` so photo-only places don't render a "0" pill.

## Why
User reported: photo-logged a place, it didn't appear on the Map, so they couldn't tap the pin to rename it.

## Test plan
- [x] `xcodebuild -project PlaceNotes.xcodeproj -scheme PlaceNotes -destination 'platform=iOS Simulator,name=iPhone 17' -configuration Debug build` → BUILD SUCCEEDED
- [ ] Manual: photo quick-capture at a fresh location, verify pin appears on Map within a tab switch.
- [ ] Manual: tap pin → detail sheet → Rename → save nickname → verify name updates on the pin label.
- [ ] Manual: confirm frequent places still show flame intensity + visit count badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)