### PR TITLE
chore: split scheme into PlaceNotes-Debug and PlaceNotes-Release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           echo "Using simulator: $SIMULATOR"
           xcodebuild test \
             -project PlaceNotes.xcodeproj \
-            -scheme PlaceNotes \
+            -scheme PlaceNotes-Debug \
             -destination "platform=iOS Simulator,name=$SIMULATOR,OS=latest" \
             -resultBundlePath TestResults.xcresult \
             CODE_SIGNING_ALLOWED=NO \

--- a/project.yml
+++ b/project.yml
@@ -19,16 +19,36 @@ settings:
       VALIDATE_PRODUCT: YES
 
 schemes:
-  PlaceNotes:
+  PlaceNotes-Debug:
     build:
       targets:
         PlaceNotes: all
         PlaceNotesTests: [test]
     test:
+      config: Debug
       targets:
         - PlaceNotesTests
     run:
       config: Debug
+    profile:
+      config: Debug
+    analyze:
+      config: Debug
+    archive:
+      config: Debug
+
+  PlaceNotes-Release:
+    build:
+      targets:
+        PlaceNotes: all
+    run:
+      config: Release
+    profile:
+      config: Release
+    analyze:
+      config: Release
+    archive:
+      config: Release
 
 targets:
   PlaceNotes:


### PR DESCRIPTION
## Summary
- Replace the single `PlaceNotes` scheme in `project.yml` with two explicit schemes regenerated by XcodeGen:
  - `PlaceNotes-Debug` — build + test, runs Debug. For day-to-day dev and CI.
  - `PlaceNotes-Release` — builds app target in Release for archive / profile / analyze. For App Store / TestFlight.
- Update `.github/workflows/ci.yml` to invoke `-scheme PlaceNotes-Debug`.

`.xcodeproj` stays gitignored. Anyone cloning runs `xcodegen generate` and gets both schemes auto-shared under `xcshareddata/xcschemes/`.

## Why
TestFlight/App Store archives need a dedicated Release-configured scheme. Splitting also makes the run/archive intent explicit instead of relying on the implicit default config.

## Test plan
- [x] `xcodegen generate` produces `PlaceNotes-Debug.xcscheme` + `PlaceNotes-Release.xcscheme`
- [x] `xcodebuild -scheme PlaceNotes-Debug -configuration Debug build` → BUILD SUCCEEDED
- [x] `xcodebuild -scheme PlaceNotes-Release -configuration Release build` → BUILD SUCCEEDED
- [ ] CI green on this PR using the new scheme name

🤖 Generated with [Claude Code](https://claude.com/claude-code)