### PR TITLE
fix: disable camera flash by default in photo capture

### DIFF
--- a/PlaceNotes/Views/CameraPickerView.swift
+++ b/PlaceNotes/Views/CameraPickerView.swift
@@ -12,6 +12,7 @@ struct CameraPickerView: UIViewControllerRepresentable {
         let picker = UIImagePickerController()
         picker.sourceType = .camera
         picker.cameraDevice = .rear
+        picker.cameraFlashMode = .off
         picker.delegate = context.coordinator
         return picker
     }


### PR DESCRIPTION
UIImagePickerController defaults to .auto flash, which causes the LED
to fire in low light when capturing photo logs. Set cameraFlashMode
to .off so the torch never activates on its own.

https://claude.ai/code/session_011w7FNpA2Nx7mUiKmSNPhnx