### PR TITLE
fix: gate tracking on real auth + retry quick-capture fix at shutter

### DIFF
--- a/PlaceNotes/PlaceNotesApp.swift
+++ b/PlaceNotes/PlaceNotesApp.swift
@@ -131,7 +131,8 @@ struct PlaceNotesApp: App {
     private func makeQuickCaptureViewModel() -> QuickCaptureViewModel {
         QuickCaptureViewModel(
             oneShot: LocationOneShot(),
-            context: modelContainer.mainContext
+            context: modelContainer.mainContext,
+            locationManager: locationManager
         )
     }
 

--- a/PlaceNotes/Services/LocationManager.swift
+++ b/PlaceNotes/Services/LocationManager.swift
@@ -50,6 +50,10 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
     @Published var currentVisit: Visit?
     @Published var userLocation: CLLocationCoordinate2D?
 
+    /// Last raw fix delivered by Core Location (coordinate, accuracy, timestamp).
+    /// Used by photo capture as a fallback when a fresh one-shot fails.
+    @Published var lastFix: CLLocation?
+
     var onVisitRecorded: ((Visit) -> Void)?
 
     // MARK: - Dwell detection
@@ -308,6 +312,7 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
         }
 
         userLocation = location.coordinate
+        lastFix = location
 
         if let last = lastObservedSample,
            last.lat == location.coordinate.latitude,

--- a/PlaceNotes/Services/QuickCaptureService.swift
+++ b/PlaceNotes/Services/QuickCaptureService.swift
@@ -21,17 +21,36 @@ enum QuickCaptureService {
     /// matching radius, a "nearest" lookup could mis-attribute across neighbors.
     static let liveFixAccuracyThreshold: CLLocationDistance = 50
 
-    /// Resolves the coordinate for a quick capture per D1 priority:
+    /// Max age (seconds) for a cached `LocationManager.userLocation` fallback
+    /// to count as "recent enough" to attribute a photo to.
+    static let cachedFixMaxAge: TimeInterval = 120
+
+    /// Resolves the coordinate for a quick capture in priority order:
     /// 1. live fix if accuracy ≤ 50m
-    /// 2. EXIF location from the saved PHAsset
-    /// 3. nil (caller opens ManualPlacePickerView)
-    static func resolveCoordinate(liveFix: CLLocation?, exifLocation: CLLocation?) -> CLLocation? {
+    /// 2. EXIF location from the photo metadata
+    /// 3. recent passive-tracking fix (≤ 120s old, ≤ 50m accuracy)
+    /// 4. nil (caller opens ManualPlacePickerView)
+    static func resolveCoordinate(
+        liveFix: CLLocation?,
+        exifLocation: CLLocation?,
+        cachedFix: CLLocation? = nil,
+        now: Date = Date()
+    ) -> CLLocation? {
         if let live = liveFix,
            live.horizontalAccuracy >= 0,
            live.horizontalAccuracy <= liveFixAccuracyThreshold {
             return live
         }
-        return exifLocation
+        if let exif = exifLocation {
+            return exif
+        }
+        if let cached = cachedFix,
+           cached.horizontalAccuracy >= 0,
+           cached.horizontalAccuracy <= liveFixAccuracyThreshold,
+           now.timeIntervalSince(cached.timestamp) <= cachedFixMaxAge {
+            return cached
+        }
+        return nil
     }
 }
 

--- a/PlaceNotes/Services/TrackingManager.swift
+++ b/PlaceNotes/Services/TrackingManager.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Combine
+import CoreLocation
 import os
 
 private let logger = Logger(subsystem: "dev.placelore.app", category: "TrackingManager")
@@ -12,31 +13,47 @@ final class TrackingManager: ObservableObject {
 
     @Published var state: TrackingState
 
+    /// True when the most recent enable/resume attempt was blocked because the
+    /// user has denied or restricted location access. UI can surface this to
+    /// guide the user to Settings.
+    @Published var isPermissionDenied: Bool = false
+
+    /// True while the user has requested tracking but the system authorization
+    /// prompt is still in flight (status == .notDetermined). When auth flips
+    /// to authorized we promote to `.active`; if it flips to denied we abandon.
+    private var pendingEnable: Bool = false
+
     init(locationManager: LocationManager, settings: AppSettings = .shared) {
         self.locationManager = locationManager
         self.settings = settings
         self.state = settings.trackingState
-        logger.info("TrackingManager initialized, state: \(self.state.status.rawValue)")
+        logger.info("TrackingManager initialized, state: \(self.state.status.rawValue), auth: \(locationManager.authorizationStatus.rawValue)")
 
+        observeAuthorizationChanges()
         checkPauseExpiry()
     }
 
     func enableTracking() {
         logger.notice(">>> Enable tracking requested <<<")
-        locationManager.requestAuthorization()
-
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
-            guard let self else { return }
-            self.state.status = .active
-            self.state.pauseResumeDate = nil
-            self.locationManager.startMonitoring()
-            self.persist()
-            logger.notice("Tracking enabled and monitoring started")
+        switch locationManager.authorizationStatus {
+        case .authorizedAlways, .authorizedWhenInUse:
+            applyEnabled()
+        case .notDetermined:
+            pendingEnable = true
+            locationManager.requestAuthorization()
+            logger.info("Auth not determined — awaiting user decision")
+        case .denied, .restricted:
+            isPermissionDenied = true
+            logger.warning("Cannot enable tracking — permission \(self.locationManager.authorizationStatus.rawValue)")
+        @unknown default:
+            isPermissionDenied = true
+            logger.warning("Cannot enable tracking — unknown authorization value")
         }
     }
 
     func disableTracking() {
         logger.notice(">>> Disable tracking requested <<<")
+        pendingEnable = false
         state.status = .disabled
         state.pauseResumeDate = nil
         locationManager.stopMonitoring()
@@ -47,6 +64,7 @@ final class TrackingManager: ObservableObject {
 
     func pauseTracking(for duration: PauseDuration) {
         logger.notice(">>> Pause tracking for \(duration.label) <<<")
+        pendingEnable = false
         state.status = .paused
         state.pauseResumeDate = Date().addingTimeInterval(duration.interval)
         locationManager.stopMonitoring()
@@ -56,15 +74,81 @@ final class TrackingManager: ObservableObject {
 
     func resumeTracking() {
         logger.notice(">>> Resume tracking <<<")
+        switch locationManager.authorizationStatus {
+        case .authorizedAlways, .authorizedWhenInUse:
+            applyEnabled()
+        case .notDetermined:
+            pendingEnable = true
+            locationManager.requestAuthorization()
+        case .denied, .restricted:
+            isPermissionDenied = true
+            state.status = .disabled
+            state.pauseResumeDate = nil
+            pauseTimer?.invalidate()
+            persist()
+            logger.warning("Resume blocked — permission denied; state reset to disabled")
+        @unknown default:
+            isPermissionDenied = true
+            state.status = .disabled
+            state.pauseResumeDate = nil
+            pauseTimer?.invalidate()
+            persist()
+        }
+    }
+
+    // MARK: - Private
+
+    private func applyEnabled() {
+        pendingEnable = false
+        isPermissionDenied = false
         state.status = .active
         state.pauseResumeDate = nil
         pauseTimer?.invalidate()
         locationManager.startMonitoring()
         persist()
-        logger.notice("Tracking resumed")
+        logger.notice("Tracking enabled and monitoring started")
     }
 
-    // MARK: - Private
+    private var isAuthorized: Bool {
+        let status = locationManager.authorizationStatus
+        return status == .authorizedAlways || status == .authorizedWhenInUse
+    }
+
+    private func observeAuthorizationChanges() {
+        locationManager.$authorizationStatus
+            .dropFirst()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] status in
+                self?.handleAuthorizationChange(status)
+            }
+            .store(in: &cancellables)
+    }
+
+    private func handleAuthorizationChange(_ status: CLAuthorizationStatus) {
+        logger.notice("TrackingManager observed auth change: \(status.rawValue)")
+        switch status {
+        case .authorizedAlways, .authorizedWhenInUse:
+            isPermissionDenied = false
+            if pendingEnable || state.status == .active {
+                applyEnabled()
+            }
+        case .denied, .restricted:
+            isPermissionDenied = true
+            pendingEnable = false
+            if state.status != .disabled {
+                state.status = .disabled
+                state.pauseResumeDate = nil
+                locationManager.stopMonitoring()
+                pauseTimer?.invalidate()
+                persist()
+                logger.warning("Tracking demoted to disabled — authorization revoked")
+            }
+        case .notDetermined:
+            break
+        @unknown default:
+            break
+        }
+    }
 
     private func schedulePauseResume(after interval: TimeInterval) {
         pauseTimer?.invalidate()
@@ -86,8 +170,20 @@ final class TrackingManager: ObservableObject {
                 locationManager.stopMonitoring()
             }
         } else if state.status == .active {
-            logger.info("State is active on launch — starting monitoring")
-            locationManager.startMonitoring()
+            if isAuthorized {
+                logger.info("State is active on launch — starting monitoring")
+                locationManager.startMonitoring()
+            } else if locationManager.authorizationStatus == .notDetermined {
+                logger.info("State is active on launch but auth not determined — awaiting prompt")
+                pendingEnable = true
+                locationManager.requestAuthorization()
+            } else {
+                logger.warning("State is active on launch but auth denied/restricted — demoting to disabled")
+                isPermissionDenied = true
+                state.status = .disabled
+                state.pauseResumeDate = nil
+                persist()
+            }
         } else {
             logger.info("State is disabled on launch — not starting monitoring")
         }

--- a/PlaceNotes/ViewModels/QuickCaptureViewModel.swift
+++ b/PlaceNotes/ViewModels/QuickCaptureViewModel.swift
@@ -32,9 +32,6 @@ final class QuickCaptureViewModel: ObservableObject {
     @Published var showCamera: Bool = false
     @Published private(set) var pendingPhotoAssetId: String?
 
-    /// True while photo save or place resolution is running. Used to show a
-    /// persistent banner so the user sees something is in flight after they
-    /// switch tabs away from the camera screen.
     var isWorkingInBackground: Bool {
         switch state {
         case .savingPhoto, .resolvingPlace: return true
@@ -42,14 +39,30 @@ final class QuickCaptureViewModel: ObservableObject {
         }
     }
 
+    /// Time budget for the background warm-up fetch kicked off when the camera opens.
+    /// Most users compose for >5s; keep this generous so a warm-up fix usually lands
+    /// before the shutter, but the shutter-time retry is the real safety net.
+    static let warmupTimeout: TimeInterval = 15
+
+    /// Time budget for the retry fetch issued at shutter time when warm-up failed.
+    /// Tuned to be long enough for a cold GPS fix but short enough that the user
+    /// doesn't see the saving spinner for an eternity.
+    static let shutterTimeout: TimeInterval = 10
+
     private let oneShot: LocationOneShotProviding
     private let context: ModelContext
+    private weak var locationManager: LocationManager?
     private var pendingLiveFix: CLLocation?
     private var locationFetchTask: Task<Void, Never>?
 
-    init(oneShot: LocationOneShotProviding, context: ModelContext) {
+    init(
+        oneShot: LocationOneShotProviding,
+        context: ModelContext,
+        locationManager: LocationManager? = nil
+    ) {
         self.oneShot = oneShot
         self.context = context
+        self.locationManager = locationManager
     }
 
     // MARK: - Flow
@@ -58,11 +71,12 @@ final class QuickCaptureViewModel: ObservableObject {
         guard state == .idle else { return }
         state = .acquiringLocation
         showCamera = true
+        pendingLiveFix = nil
         locationFetchTask?.cancel()
         oneShot.cancel()
         locationFetchTask = Task { [weak self] in
             guard let self else { return }
-            let loc = await self.oneShot.fetchOnce(timeout: 5)
+            let loc = await self.oneShot.fetchOnce(timeout: Self.warmupTimeout)
             if Task.isCancelled { return }
             await MainActor.run { self.pendingLiveFix = loc }
         }
@@ -138,8 +152,19 @@ final class QuickCaptureViewModel: ObservableObject {
     // MARK: - Private
 
     private func continueAfterPhoto(photoAssetId: String, exifLocation: CLLocation?) async {
-        let coord = QuickCaptureService.resolveCoordinate(liveFix: pendingLiveFix, exifLocation: exifLocation)
+        if pendingLiveFix == nil {
+            logger.info("Warm-up fix missing at shutter — retrying with \(Self.shutterTimeout)s budget")
+            let retry = await oneShot.fetchOnce(timeout: Self.shutterTimeout)
+            if let retry { pendingLiveFix = retry }
+        }
+        let cachedFix = locationManager?.lastFix
+        let coord = QuickCaptureService.resolveCoordinate(
+            liveFix: pendingLiveFix,
+            exifLocation: exifLocation,
+            cachedFix: cachedFix
+        )
         guard let coord else {
+            logger.info("No coordinate available — falling back to manual picker")
             await MainActor.run {
                 self.pendingPhotoAssetId = photoAssetId
                 self.state = .manualPickNeeded

--- a/PlaceNotes/Views/TrackingControlView.swift
+++ b/PlaceNotes/Views/TrackingControlView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import SwiftData
+import UIKit
 
 struct TrackingControlView: View {
     @EnvironmentObject var trackingViewModel: TrackingViewModel
@@ -100,6 +101,26 @@ struct TrackingControlView: View {
                 Button("OK", role: .cancel) {}
             } message: {
                 Text("Enable Camera access in Settings → Placelore to capture photos.")
+            }
+            .alert("Location access needed", isPresented: Binding(
+                get: { trackingViewModel.trackingManager.isPermissionDenied },
+                set: { newValue in
+                    if !newValue {
+                        trackingViewModel.trackingManager.isPermissionDenied = false
+                    }
+                }
+            )) {
+                Button("Open Settings") {
+                    trackingViewModel.trackingManager.isPermissionDenied = false
+                    if let url = URL(string: UIApplication.openSettingsURLString) {
+                        UIApplication.shared.open(url)
+                    }
+                }
+                Button("Cancel", role: .cancel) {
+                    trackingViewModel.trackingManager.isPermissionDenied = false
+                }
+            } message: {
+                Text("Placelore can't track your location until you allow access in Settings → Placelore → Location.")
             }
             .alert("Tracking is off", isPresented: $showTrackingOffAlert) {
                 Button("Turn On Tracking") {

--- a/PlaceNotesTests/QuickCaptureServiceTests.swift
+++ b/PlaceNotesTests/QuickCaptureServiceTests.swift
@@ -53,6 +53,47 @@ final class QuickCaptureServiceTests: XCTestCase {
         XCTAssertEqual(pick?.coordinate.latitude, 3)
     }
 
+    func testCachedFixUsedWhenLiveAndExifAreUnavailable() {
+        let cached = loc(lat: 5, lon: 6, accuracy: 30, age: 10)
+        let pick = QuickCaptureService.resolveCoordinate(
+            liveFix: nil,
+            exifLocation: nil,
+            cachedFix: cached
+        )
+        XCTAssertEqual(pick?.coordinate.latitude, 5)
+    }
+
+    func testCachedFixIgnoredWhenStale() {
+        let cached = loc(lat: 5, lon: 6, accuracy: 30, age: QuickCaptureService.cachedFixMaxAge + 60)
+        let pick = QuickCaptureService.resolveCoordinate(
+            liveFix: nil,
+            exifLocation: nil,
+            cachedFix: cached
+        )
+        XCTAssertNil(pick)
+    }
+
+    func testCachedFixIgnoredWhenTooCoarse() {
+        let cached = loc(lat: 5, lon: 6, accuracy: 200, age: 5)
+        let pick = QuickCaptureService.resolveCoordinate(
+            liveFix: nil,
+            exifLocation: nil,
+            cachedFix: cached
+        )
+        XCTAssertNil(pick)
+    }
+
+    func testExifPreferredOverCachedFix() {
+        let exif = loc(lat: 3, lon: 4, accuracy: 20)
+        let cached = loc(lat: 5, lon: 6, accuracy: 20, age: 5)
+        let pick = QuickCaptureService.resolveCoordinate(
+            liveFix: nil,
+            exifLocation: exif,
+            cachedFix: cached
+        )
+        XCTAssertEqual(pick?.coordinate.latitude, 3)
+    }
+
     // MARK: - Merge decision (D5)
 
     func testMergesWithActiveVisitAtSamePlace() throws {


### PR DESCRIPTION
The tracking chip could show 'active' even when location permission was
denied because enableTracking() flipped state.status after a fixed 1s
asyncAfter, regardless of the user's permission decision. And on top of
that, photo capture often hit the manual picker with "No matching
places" because the live-fix one-shot timed out 5s after the camera
opened — long before the user actually pressed the shutter — so even
with permission granted, no coordinate reached PlaceResolver.

TrackingManager: drive transitions from CLAuthorizationStatus instead
of a timer. enableTracking / resumeTracking only promote to .active
when authorized; if .notDetermined, hold pendingEnable until the auth
callback resolves; if denied/restricted, surface isPermissionDenied
for the UI to route to Settings. Observe LocationManager's auth
publisher so a later grant promotes, and a revoke demotes to .disabled.
checkPauseExpiry guards startMonitoring on isAuthorized.

QuickCaptureViewModel: extend the warm-up budget to 15s and, if no fix
landed by shutter time, retry fetchOnce for up to 10s. Pass the
passively-tracked LocationManager.lastFix into resolveCoordinate as a
final fallback (≤120s old, ≤50m accuracy). Reset pendingLiveFix at the
start of beginCapture so stale state can't leak between captures.

LocationManager: publish lastFix (full CLLocation with timestamp and
accuracy) alongside the existing userLocation coordinate so consumers
can age-check the cached fallback.

TrackingControlView: surface the new isPermissionDenied flag with an
'Open Settings' alert so a denied-permission tap isn't a silent no-op.