### PR TITLE
ci: drop local tag verification in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Resolve tag
         id: tag
@@ -32,9 +30,6 @@ jobs:
           else
             echo "name=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
           fi
-
-      - name: Verify tag points at a commit
-        run: git rev-parse "${{ steps.tag.outputs.name }}^{commit}"
 
       - name: Create release
         env:


### PR DESCRIPTION
## Summary
- `actions/checkout@v4` does not fetch tags by default, so `git rev-parse "<tag>^{commit}"` fails with `unknown revision` on the runner (observed on `v0.0.0-test` smoke test).
- `gh release create --verify-tag` already validates the tag server-side, so the local verification step is redundant. Removing it.

## Test plan
- [ ] After merge, push a throwaway tag (e.g. `v0.0.0-test2`) and confirm the workflow creates a release; delete the test release + tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)