### PR TITLE
ci: skip CI when only docs/non-code files change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,22 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'design/**'
+      - '.github/workflows/release.yml'
+      - 'LICENSE'
+      - '.gitignore'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'design/**'
+      - '.github/workflows/release.yml'
+      - 'LICENSE'
+      - '.gitignore'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary
- Adds `paths-ignore` to the `push` and `pull_request` triggers in `.github/workflows/ci.yml`.
- Ignored paths: `**.md`, `docs/**`, `design/**`, `.github/workflows/release.yml`, `LICENSE`, `.gitignore`.
- Saves macOS runner minutes on doc-only and metadata-only PRs.
- `workflow_dispatch` left untouched, so CI can still be triggered manually for any commit.

## Test plan
- [ ] Open a docs-only PR after merge; confirm CI does not run.
- [ ] Open a Swift-source PR; confirm CI still runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)