### PR TITLE
ci: bump MARKETING_VERSION to match release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,17 +19,49 @@ jobs:
     name: Create GitHub Release
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
       - name: Resolve tag
         id: tag
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "name=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+            TAG="${{ inputs.tag }}"
           else
-            echo "name=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+            TAG="${GITHUB_REF#refs/tags/}"
           fi
+          VERSION="${TAG#v}"
+          echo "name=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          if [[ "$VERSION" == *-* ]]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sync MARKETING_VERSION to tag
+        if: steps.tag.outputs.prerelease == 'false'
+        run: |
+          VERSION="${{ steps.tag.outputs.version }}"
+          CURRENT=$(awk -F'"' '/MARKETING_VERSION:/ {print $2; exit}' project.yml)
+          if [ -z "$CURRENT" ]; then
+            echo "Could not find MARKETING_VERSION in project.yml" >&2
+            exit 1
+          fi
+          if [ "$CURRENT" = "$VERSION" ]; then
+            echo "MARKETING_VERSION already $VERSION; no bump needed."
+            exit 0
+          fi
+          echo "Bumping MARKETING_VERSION: $CURRENT -> $VERSION"
+          sed -i -E "s/(MARKETING_VERSION: )\"[^\"]*\"/\\1\"$VERSION\"/" project.yml
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add project.yml
+          git commit -m "chore: bump MARKETING_VERSION to $VERSION (${{ steps.tag.outputs.name }})"
+          git push origin main
 
       - name: Create release
         env:


### PR DESCRIPTION
## Summary
- Adds a `Sync MARKETING_VERSION to tag` step to `.github/workflows/release.yml`.
- On `v*` tag push (or manual dispatch), the workflow checks out `main`, parses the version from the tag, and if `project.yml`'s `MARKETING_VERSION` differs, edits it, commits as `github-actions[bot]`, and pushes to `main`.
- Skips for pre-release tags (anything with a `-` in the version, e.g. `v1.0.1-rc1`).
- Idempotent: no-op when the value already matches.

## Notes
- The bump commit lands on `main` *after* the tag, so the tagged commit itself still carries the pre-bump version. For the App Store build, archive from a commit where `project.yml` already matches the intended version (the workflow's bump then becomes a no-op, which is the safe state).
- If `main` has branch protection that blocks direct pushes, the workflow's push will fail. Either grant `github-actions[bot]` a bypass or switch to a PR-based flow.

## Test plan
- [ ] Manually dispatch the workflow with an existing tag whose version matches `MARKETING_VERSION` — confirm "no bump needed".
- [ ] Push a throwaway tag `v0.0.1-test` and confirm pre-release branch skips the bump.
- [ ] On the next real release (e.g. `v1.0.1`), confirm `project.yml` is updated on `main` and the GitHub Release is created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)