### PR TITLE
ci: verify dispatched tag exists before bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,17 @@ jobs:
             echo "prerelease=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Verify tag exists (dispatch only)
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.tag.outputs.name }}"
+          if ! gh api "repos/$GITHUB_REPOSITORY/git/refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG does not exist in $GITHUB_REPOSITORY. Push the tag before dispatching." >&2
+            exit 1
+          fi
+
       - name: Checkout main
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary
- Adds a `Verify tag exists (dispatch only)` step that calls `gh api repos/$GITHUB_REPOSITORY/git/refs/tags/<tag>` before checkout/bump.
- Closes the half-state where dispatching with a typo'd non-prerelease tag would push a `MARKETING_VERSION` bump to `main` for a tag that never existed.
- `push: tags` trigger unaffected — the tag is guaranteed to exist when GitHub fires the event.

## Test plan
- [ ] Dispatch with a bogus tag (e.g. `v9.9.9`) — workflow should fail at the verify step, before checkout/bump.
- [ ] Dispatch with a real existing tag — workflow proceeds as before.
- [ ] Push a real `v*` tag — workflow proceeds (verify step is skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)