### PR TITLE
fix(settings): read app version from Bundle

### DIFF
--- a/PlaceNotes/Views/SettingsView.swift
+++ b/PlaceNotes/Views/SettingsView.swift
@@ -65,6 +65,10 @@ struct SettingsView: View {
     @State private var exportData: Data = Data()
     @State private var showExporter = false
 
+    private var appVersion: String {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "—"
+    }
+
     var body: some View {
         NavigationStack {
             Form {
@@ -194,7 +198,7 @@ struct SettingsView: View {
                 }
 
                 Section("About") {
-                    LabeledContent("Version", value: "1.0.0")
+                    LabeledContent("Version", value: appVersion)
                 }
 
                 #if DEBUG


### PR DESCRIPTION
## Summary
- About row in Settings showed `1.0.0` even after bumping `MARKETING_VERSION` to `1.0.1` in `project.yml`. The string was hardcoded.
- Replace the literal with `Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString")`, which already resolves `$(MARKETING_VERSION)` via `Info.plist`. About now tracks the build setting automatically on future bumps.

## Test plan
- [x] Open Settings → About → Version reads `1.0.1`
- [ ] Bump `MARKETING_VERSION` in `project.yml`, regenerate project, rebuild → About reflects new value without code change

🤖 Generated with [Claude Code](https://claude.com/claude-code)