### PR TITLE
Prevent duplicate dwell visit recording and improve duplicate detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,10 +40,21 @@ jobs:
         run: xcodegen generate
 
       - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+        run: |
+          set -euo pipefail
+          # Pick the highest-versioned Xcode_*.app installed on the runner.
+          # iOS 26 / Liquid Glass APIs (GlassEffectContainer, .buttonStyle(.glass),
+          # .glassEffect) only exist in Xcode 26+ SDKs — older Xcodes can see
+          # the iOS 26 simulator runtime via simctl but can't compile against it.
+          LATEST=$(ls -d /Applications/Xcode_*.app 2>/dev/null | sort -V | tail -1)
+          XCODE_APP="${LATEST:-/Applications/Xcode.app}"
+          echo "Selecting $XCODE_APP"
+          sudo xcode-select -s "$XCODE_APP/Contents/Developer"
+          xcodebuild -version
 
       - name: Build and run tests
         run: |
+          set -eo pipefail
           # Find the first available iPhone simulator
           SIMULATOR=$(xcrun simctl list devices available -j | python3 -c "
           import json, sys
@@ -62,7 +73,7 @@ jobs:
             -destination "platform=iOS Simulator,name=$SIMULATOR,OS=latest" \
             -resultBundlePath TestResults.xcresult \
             CODE_SIGNING_ALLOWED=NO \
-            | xcpretty --color || true
+            | xcpretty --color
 
       - name: Upload test results
         if: always()

--- a/PlaceNotes/Services/LocationManager.swift
+++ b/PlaceNotes/Services/LocationManager.swift
@@ -62,6 +62,11 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
     private var dwellSamples: [LocationSample] = []
     private var dwellStartDate: Date?
     private var lastRecordedDwellLocation: CLLocation?
+    /// `dwellStartDate` value at the moment a visit was recorded for the current
+    /// continuous dwell. Prevents repeated `recordDwellVisit` calls as new
+    /// samples / timer ticks fire after the threshold first trips. Cleared
+    /// whenever a fresh dwell begins (in `finalizeDwell`).
+    private var recordedDwellStartDate: Date?
     private var dwellTimer: Timer?
     private let settings: AppSettings
 
@@ -202,6 +207,10 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
                     return
                 }
             }
+            if recordedDwellStartDate == start {
+                logger.debug("Dwell timer tick — already recorded for this dwell, skipping")
+                return
+            }
             logger.notice("Dwell threshold reached via timer (\(Int(elapsed))s >= \(Int(threshold))s) — recording visit")
             let cluster = buildCluster(from: dwellSamples, startDate: start)
             recordDwellVisit(cluster: cluster, context: modelContext)
@@ -280,7 +289,7 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
                 addressOnly: useAddressFallback
             )
 
-            if isDuplicate(place: place, arrival: arrival) {
+            if isDuplicate(place: place, arrival: arrival, context: modelContext) {
                 logger.info("Skipping duplicate CLVisit for \(place.name)")
                 return
             }
@@ -401,7 +410,8 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
                 }
 
                 if let start = dwellStartDate,
-                   Date().timeIntervalSince(start) >= dwellThresholdSeconds {
+                   Date().timeIntervalSince(start) >= dwellThresholdSeconds,
+                   recordedDwellStartDate != start {
                     logger.notice("Dwell threshold met via location update — recording visit")
                     let cluster = buildCluster(from: dwellSamples, startDate: start)
                     recordDwellVisit(cluster: cluster, context: modelContext)
@@ -522,6 +532,7 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
         }
 
         lastRecordedDwellLocation = clusterCenter
+        recordedDwellStartDate = cluster.startDate
 
         let confidence = computeConfidence(
             accuracy: cluster.medianAccuracy,
@@ -540,7 +551,7 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
                 addressOnly: useAddressFallback
             )
 
-            if isDuplicate(place: place, arrival: cluster.startDate) {
+            if isDuplicate(place: place, arrival: cluster.startDate, context: context) {
                 logger.info("Skipping duplicate dwell visit for \(place.name)")
                 return
             }
@@ -564,6 +575,7 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
               let modelContext else {
             dwellSamples = []
             dwellStartDate = nil
+            recordedDwellStartDate = nil
             return
         }
 
@@ -590,20 +602,43 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
         dwellSamples = []
         dwellStartDate = nil
         lastRecordedDwellLocation = nil
+        recordedDwellStartDate = nil
     }
 
     // MARK: - Duplicate Detection
 
+    /// True if a visit already exists within the time window AND geographically
+    /// close enough that the two are likely the same stay resolved to different
+    /// POIs (e.g. centroid drift inside a mall picking a coffee shop vs the
+    /// main entry). Checks ALL Places, not just `place.visits`, because the
+    /// failure mode is precisely that the duplicate lands on a different
+    /// `Place` row.
     @MainActor
-    private func isDuplicate(place: Place, arrival: Date) -> Bool {
-        let threshold: TimeInterval = 600
-        let isDup = place.visits.contains { visit in
-            abs(visit.arrivalDate.timeIntervalSince(arrival)) < threshold
+    private func isDuplicate(place: Place, arrival: Date, context: ModelContext) -> Bool {
+        let timeWindow: TimeInterval = 600
+        let spatialThresholdMeters: Double = 150
+        let windowStart = arrival.addingTimeInterval(-timeWindow)
+        let windowEnd = arrival.addingTimeInterval(timeWindow)
+        let descriptor = FetchDescriptor<Visit>(
+            predicate: #Predicate<Visit> {
+                $0.arrivalDate >= windowStart && $0.arrivalDate <= windowEnd
+            }
+        )
+        let candidates = (try? context.fetch(descriptor)) ?? []
+        let newPlaceLoc = CLLocation(latitude: place.latitude, longitude: place.longitude)
+        for visit in candidates {
+            guard let other = visit.place else { continue }
+            if other.id == place.id {
+                logger.debug("Duplicate detected at same place \(place.name) near \(arrival)")
+                return true
+            }
+            let otherLoc = CLLocation(latitude: other.latitude, longitude: other.longitude)
+            if newPlaceLoc.distance(from: otherLoc) < spatialThresholdMeters {
+                logger.debug("Duplicate detected — \(place.name) is \(Int(newPlaceLoc.distance(from: otherLoc)))m from existing visit at \(other.name)")
+                return true
+            }
         }
-        if isDup {
-            logger.debug("Duplicate detected for \(place.name) near \(arrival)")
-        }
-        return isDup
+        return false
     }
 
 }


### PR DESCRIPTION
## Summary

This PR fixes a bug where dwell visits could be recorded multiple times for the same continuous stay, and improves the duplicate detection logic to account for geographic proximity across different places.

## Key Changes

- **Added `recordedDwellStartDate` tracking**: A new private property that captures the `dwellStartDate` at the moment a visit is first recorded. This prevents repeated `recordDwellVisit` calls as subsequent timer ticks or location updates fire after the threshold is initially met. The value is cleared whenever a fresh dwell begins in `finalizeDwell()`.

- **Enhanced duplicate detection logic**: Refactored `isDuplicate(place:arrival:context:)` to:
  - Accept a `ModelContext` parameter to enable querying all visits in the time window (not just those on the current place)
  - Use `FetchDescriptor` to find all visits within a ±600 second time window
  - Check both same-place duplicates and geographically proximate visits (within 150 meters) on different places
  - This handles the case where centroid drift inside a large venue (e.g., a mall) picks different POIs but represents the same stay

- **Updated dwell recording checks**: Added `recordedDwellStartDate != start` guards in both the timer-based check (`checkDwellStatus`) and the location-update-based check to skip recording if already recorded for the current dwell.

- **Cleared state on dwell finalization**: Ensured `recordedDwellStartDate` is reset to `nil` in `finalizeDwell()` and `cancelDwell()` to maintain clean state transitions.

## Implementation Details

- The 150-meter spatial threshold and 600-second time window are tuned to catch duplicate visits at the same venue while avoiding false positives across distinct locations.
- All duplicate detection now happens on `@MainActor` as required by SwiftData.
- Logging messages distinguish between same-place duplicates and geographic duplicates for debugging.

https://claude.ai/code/session_01KFRk52C4va8PmwKqYYH5bA