### PR TITLE
Place detail charts (#114)

### DIFF
--- a/PlaceNotes/Services/PlaceInsight.swift
+++ b/PlaceNotes/Services/PlaceInsight.swift
@@ -1,0 +1,159 @@
+import Foundation
+
+enum PlaceInsight {
+
+    struct Insight: Equatable {
+        let emoji: String
+        let text: String
+    }
+
+    private enum Band: String {
+        case morning, afternoon, evening, lateNight
+
+        var label: String {
+            switch self {
+            case .morning:   return "mornings"
+            case .afternoon: return "afternoons"
+            case .evening:   return "evenings"
+            case .lateNight: return "late nights"
+            }
+        }
+
+        var sunriseEmoji: String {
+            switch self {
+            case .morning:   return "🌅"
+            case .afternoon: return "☀️"
+            case .evening:   return "🌃"
+            case .lateNight: return "🌙"
+            }
+        }
+
+        static func from(hour: Int) -> Band {
+            switch hour {
+            case 5...11:  return .morning
+            case 12...16: return .afternoon
+            case 17...21: return .evening
+            default:      return .lateNight
+            }
+        }
+    }
+
+    static func summarize(visits: [Visit],
+                          now: Date = .now,
+                          calendar: Calendar = .current) -> Insight? {
+        guard visits.count >= 5 else { return nil }
+
+        if let weekdayInsight = weekdaySplitInsight(visits: visits, calendar: calendar) {
+            return weekdayInsight
+        }
+        if let hourInsight = peakHourInsight(visits: visits, calendar: calendar) {
+            return hourInsight
+        }
+        if let trend = trendInsight(visits: visits, now: now, calendar: calendar) {
+            return trend
+        }
+        return nil
+    }
+
+    private static func weekdaySplitInsight(visits: [Visit], calendar: Calendar) -> Insight? {
+        guard spanDays(visits: visits, calendar: calendar) >= 14 else { return nil }
+
+        let weekendCount = visits.filter { isWeekend($0.arrivalDate, calendar: calendar) }.count
+        let weekdayCount = visits.count - weekendCount
+        let total = Double(visits.count)
+        let weekendShare = Double(weekendCount) / total
+        let weekdayShare = Double(weekdayCount) / total
+
+        let dominantIsWeekend: Bool
+        if weekdayShare >= 0.70 {
+            dominantIsWeekend = false
+        } else if weekendShare >= 0.70 {
+            dominantIsWeekend = true
+        } else {
+            return nil
+        }
+
+        let matching = visits.filter {
+            isWeekend($0.arrivalDate, calendar: calendar) == dominantIsWeekend
+        }
+        let band = dominantBand(in: matching, calendar: calendar)
+        let scope = dominantIsWeekend ? "weekend" : "weekday"
+        return Insight(
+            emoji: band.sunriseEmoji,
+            text: "Mostly \(scope) \(band.label) here"
+        )
+    }
+
+    private static func peakHourInsight(visits: [Visit], calendar: Calendar) -> Insight? {
+        let buckets = VisitStats.hourBuckets(for: visits, calendar: calendar)
+        guard let peak = buckets.max(by: { $0.count < $1.count }), peak.count > 0 else {
+            return nil
+        }
+        let share = Double(peak.count) / Double(visits.count)
+        guard share >= 0.25 else { return nil }
+        return Insight(
+            emoji: "⏰",
+            text: "Most visits land around \(hourLabel(peak.id))"
+        )
+    }
+
+    private static func trendInsight(visits: [Visit], now: Date, calendar: Calendar) -> Insight? {
+        guard spanDays(visits: visits, calendar: calendar) >= 120 else { return nil }
+        guard let currentMonthStart = startOfMonth(now, calendar: calendar) else { return nil }
+        guard let recentStart = calendar.date(byAdding: .month, value: -3, to: currentMonthStart),
+              let priorStart  = calendar.date(byAdding: .month, value: -6, to: currentMonthStart) else {
+            return nil
+        }
+
+        let recent = visits.filter { $0.arrivalDate >= recentStart && $0.arrivalDate < currentMonthStart }.count
+        let prior  = visits.filter { $0.arrivalDate >= priorStart  && $0.arrivalDate < recentStart      }.count
+
+        guard prior > 0 else {
+            return recent >= 3 ? Insight(emoji: "📈", text: "You've been visiting more lately") : nil
+        }
+
+        let change = Double(recent - prior) / Double(prior)
+        if change >= 0.50 {
+            return Insight(emoji: "📈", text: "You've been visiting more lately")
+        }
+        if change <= -0.50 {
+            return Insight(emoji: "📉", text: "Visits have slowed recently")
+        }
+        return nil
+    }
+
+    private static func isWeekend(_ date: Date, calendar: Calendar) -> Bool {
+        let w = calendar.component(.weekday, from: date)
+        return w == 1 || w == 7
+    }
+
+    private static func dominantBand(in visits: [Visit], calendar: Calendar) -> Band {
+        var counts: [Band: Int] = [:]
+        for v in visits {
+            let hour = calendar.component(.hour, from: v.arrivalDate)
+            counts[Band.from(hour: hour), default: 0] += 1
+        }
+        return counts.max(by: { $0.value < $1.value })?.key ?? .morning
+    }
+
+    private static func spanDays(visits: [Visit], calendar: Calendar) -> Int {
+        guard let first = visits.map(\.arrivalDate).min(),
+              let last  = visits.map(\.arrivalDate).max() else { return 0 }
+        let comps = calendar.dateComponents([.day], from: first, to: last)
+        return comps.day ?? 0
+    }
+
+    private static func startOfMonth(_ date: Date, calendar: Calendar) -> Date? {
+        let comps = calendar.dateComponents([.year, .month], from: date)
+        return calendar.date(from: comps)
+    }
+
+    private static func hourLabel(_ hour: Int) -> String {
+        switch hour {
+        case 0:        return "midnight"
+        case 12:       return "noon"
+        case 1...11:   return "\(hour)am"
+        default:       return "\(hour - 12)pm"
+        }
+    }
+}

--- a/PlaceNotes/Services/VisitStats.swift
+++ b/PlaceNotes/Services/VisitStats.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+enum VisitStats {
+
+    struct MonthBucket: Identifiable, Equatable {
+        let id: Date
+        let label: String
+        let count: Int
+    }
+
+    struct HourBucket: Identifiable, Equatable {
+        let id: Int
+        let count: Int
+    }
+
+    struct WeekdayBucket: Identifiable, Equatable {
+        let id: Int
+        let label: String
+        let count: Int
+    }
+
+    static func monthBuckets(for visits: [Visit],
+                             endingAt now: Date = .now,
+                             calendar: Calendar = .current) -> [MonthBucket] {
+        let monthStarts = lastNMonthStarts(12, endingAt: now, calendar: calendar)
+        let formatter = DateFormatter()
+        formatter.calendar = calendar
+        formatter.locale = calendar.locale ?? .current
+        formatter.timeZone = calendar.timeZone
+        formatter.dateFormat = "MMM"
+
+        let countsByMonth = Dictionary(grouping: visits) { v in
+            startOfMonth(v.arrivalDate, calendar: calendar)
+        }.mapValues { $0.count }
+
+        return monthStarts.map { start in
+            MonthBucket(
+                id: start,
+                label: formatter.string(from: start),
+                count: countsByMonth[start] ?? 0
+            )
+        }
+    }
+
+    static func hourBuckets(for visits: [Visit],
+                            calendar: Calendar = .current) -> [HourBucket] {
+        var counts = Array(repeating: 0, count: 24)
+        for v in visits {
+            let h = calendar.component(.hour, from: v.arrivalDate)
+            counts[h] += 1
+        }
+        return (0..<24).map { HourBucket(id: $0, count: counts[$0]) }
+    }
+
+    static func weekdayBuckets(for visits: [Visit],
+                               calendar: Calendar = .current) -> [WeekdayBucket] {
+        var counts = Array(repeating: 0, count: 8)
+        for v in visits {
+            let w = calendar.component(.weekday, from: v.arrivalDate)
+            counts[w] += 1
+        }
+        let symbols = calendar.shortWeekdaySymbols
+        let order = orderedWeekdays(firstWeekday: calendar.firstWeekday)
+        return order.map { w in
+            WeekdayBucket(id: w, label: symbols[w - 1], count: counts[w])
+        }
+    }
+
+    private static func startOfMonth(_ date: Date, calendar: Calendar) -> Date {
+        let comps = calendar.dateComponents([.year, .month], from: date)
+        return calendar.date(from: comps) ?? date
+    }
+
+    private static func lastNMonthStarts(_ n: Int,
+                                         endingAt now: Date,
+                                         calendar: Calendar) -> [Date] {
+        let current = startOfMonth(now, calendar: calendar)
+        return (0..<n).reversed().compactMap { offset in
+            calendar.date(byAdding: .month, value: -offset, to: current)
+        }
+    }
+
+    private static func orderedWeekdays(firstWeekday: Int) -> [Int] {
+        (0..<7).map { offset in ((firstWeekday - 1 + offset) % 7) + 1 }
+    }
+}

--- a/PlaceNotes/Views/PlaceDetailView.swift
+++ b/PlaceNotes/Views/PlaceDetailView.swift
@@ -20,21 +20,21 @@ struct PlaceDetailView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 20) {
-                // Place header
                 placeHeader
 
-                // Stats row
                 statsRow
 
                 Divider()
 
-                // Photos overview
+                PlaceStatsCharts(place: place)
+
                 if !allPhotoFilenames.isEmpty {
-                    photosSection
                     Divider()
+                    photosSection
                 }
 
-                // Journal entries
+                Divider()
+
                 journalSection
             }
             .padding()
@@ -83,6 +83,12 @@ struct PlaceDetailView: View {
                 Text(place.displayName)
                     .font(.title2.bold())
 
+                if let subtitle = visitsSinceSubtitle {
+                    Text(subtitle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
                 if place.nickname != nil {
                     Text(place.name)
                         .font(.caption)
@@ -105,12 +111,20 @@ struct PlaceDetailView: View {
         }
     }
 
+    private var visitsSinceSubtitle: String? {
+        guard !place.visits.isEmpty,
+              let firstVisit = place.visits.map(\.arrivalDate).min() else { return nil }
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMM yyyy"
+        let count = place.visits.count
+        let plural = count == 1 ? "visit" : "visits"
+        return "\(count) \(plural) · since \(formatter.string(from: firstVisit))"
+    }
+
     // MARK: - Stats
 
     private var statsRow: some View {
         HStack(spacing: 0) {
-            statItem(value: "\(place.visits.count)", label: "Visits")
-            Spacer()
             statItem(value: formatDuration(place.totalTrackedMinutes), label: "Total Time")
             Spacer()
             statItem(value: "\(place.journalEntries.count)", label: "Entries")

--- a/PlaceNotes/Views/PlaceStatsCharts.swift
+++ b/PlaceNotes/Views/PlaceStatsCharts.swift
@@ -1,0 +1,123 @@
+import SwiftUI
+import Charts
+
+struct PlaceStatsCharts: View {
+    let place: Place
+
+    private var visits: [Visit] { place.visits }
+    private var monthData: [VisitStats.MonthBucket] { VisitStats.monthBuckets(for: visits) }
+    private var hourData: [VisitStats.HourBucket] { VisitStats.hourBuckets(for: visits) }
+    private var weekdayData: [VisitStats.WeekdayBucket] { VisitStats.weekdayBuckets(for: visits) }
+    private var insight: PlaceInsight.Insight? { PlaceInsight.summarize(visits: visits) }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            chartCard(title: "Visits per month") { monthChart }
+            chartCard(title: "Time of day") { hourChart }
+            if let insight {
+                insightBanner(insight)
+            }
+            chartCard(title: "Day of week") { weekdayChart }
+        }
+    }
+
+    @ViewBuilder
+    private func chartCard<Content: View>(
+        title: String,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.secondary)
+            content()
+                .frame(height: 140)
+        }
+        .padding()
+        .background(Color(.systemGray6))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    private func insightBanner(_ insight: PlaceInsight.Insight) -> some View {
+        HStack(alignment: .top, spacing: 10) {
+            Rectangle()
+                .fill(Color.yellow)
+                .frame(width: 3)
+            HStack(spacing: 6) {
+                Text(insight.emoji)
+                Text(insight.text)
+                    .font(.footnote)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.vertical, 8)
+        .padding(.trailing, 12)
+        .background(Color.yellow.opacity(0.15))
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+    }
+
+    private var monthChart: some View {
+        Chart(monthData) { bucket in
+            BarMark(
+                x: .value("Month", bucket.label),
+                y: .value("Visits", bucket.count)
+            )
+            .foregroundStyle(Color.accentColor)
+        }
+        .chartXAxis {
+            AxisMarks(values: .automatic(desiredCount: 6)) { _ in
+                AxisValueLabel()
+                AxisTick()
+            }
+        }
+        .chartYAxis {
+            AxisMarks(position: .leading)
+        }
+    }
+
+    private var hourChart: some View {
+        Chart(hourData) { bucket in
+            BarMark(
+                x: .value("Hour", bucket.id),
+                y: .value("Visits", bucket.count)
+            )
+            .foregroundStyle(Color.accentColor)
+        }
+        .chartXAxis {
+            AxisMarks(values: [0, 6, 12, 18]) { value in
+                AxisValueLabel {
+                    if let hour = value.as(Int.self) {
+                        Text(hourLabel(hour))
+                    }
+                }
+                AxisTick()
+            }
+        }
+        .chartYAxis {
+            AxisMarks(position: .leading)
+        }
+    }
+
+    private var weekdayChart: some View {
+        Chart(weekdayData) { bucket in
+            BarMark(
+                x: .value("Day", bucket.label),
+                y: .value("Visits", bucket.count)
+            )
+            .foregroundStyle(Color.accentColor)
+        }
+        .chartYAxis {
+            AxisMarks(position: .leading)
+        }
+    }
+
+    private func hourLabel(_ hour: Int) -> String {
+        switch hour {
+        case 0:  return "12a"
+        case 6:  return "6a"
+        case 12: return "12p"
+        case 18: return "6p"
+        default: return "\(hour)"
+        }
+    }
+}

--- a/PlaceNotesTests/PlaceInsightTests.swift
+++ b/PlaceNotesTests/PlaceInsightTests.swift
@@ -1,0 +1,141 @@
+import XCTest
+@testable import PlaceNotes
+
+final class PlaceInsightTests: XCTestCase {
+
+    private func utcCalendar() -> Calendar {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        cal.firstWeekday = 1
+        return cal
+    }
+
+    private func date(year: Int, month: Int, day: Int, hour: Int, calendar: Calendar) -> Date {
+        let comps = DateComponents(
+            calendar: calendar,
+            timeZone: calendar.timeZone,
+            year: year, month: month, day: day, hour: hour
+        )
+        return calendar.date(from: comps)!
+    }
+
+    private func visit(year: Int, month: Int, day: Int, hour: Int, calendar: Calendar) -> Visit {
+        Visit(arrivalDate: date(year: year, month: month, day: day, hour: hour, calendar: calendar))
+    }
+
+    func test_summarize_under5Visits_returnsNil() {
+        let cal = utcCalendar()
+        let visits = (1...4).map { day in
+            visit(year: 2026, month: 5, day: day, hour: 9, calendar: cal)
+        }
+        let now = date(year: 2026, month: 5, day: 20, hour: 12, calendar: cal)
+        XCTAssertNil(PlaceInsight.summarize(visits: visits, now: now, calendar: cal))
+    }
+
+    func test_summarize_allWeekdayMornings_returnsWeekdayMorningInsight() {
+        let cal = utcCalendar()
+        let weekdayDates: [(Int, Int)] = [
+            (3, 2), (3, 3), (3, 4), (3, 5), (3, 6),
+            (3, 9), (3, 10), (3, 11), (3, 12), (3, 16),
+        ]
+        let visits = weekdayDates.map { (m, d) in
+            visit(year: 2026, month: m, day: d, hour: 9, calendar: cal)
+        }
+        let now = date(year: 2026, month: 3, day: 20, hour: 12, calendar: cal)
+        let result = PlaceInsight.summarize(visits: visits, now: now, calendar: cal)
+        XCTAssertNotNil(result)
+        XCTAssertTrue(result!.text.lowercased().contains("weekday"))
+        XCTAssertTrue(result!.text.lowercased().contains("morning"))
+    }
+
+    func test_summarize_allWeekendEvenings_returnsWeekendEveningInsight() {
+        let cal = utcCalendar()
+        let weekendDates: [(Int, Int)] = [
+            (2, 7), (2, 8), (2, 14), (2, 15), (2, 21),
+            (2, 22), (2, 28), (3, 1), (3, 7), (3, 8),
+        ]
+        let visits = weekendDates.map { (m, d) in
+            visit(year: 2026, month: m, day: d, hour: 19, calendar: cal)
+        }
+        let now = date(year: 2026, month: 3, day: 20, hour: 12, calendar: cal)
+        let result = PlaceInsight.summarize(visits: visits, now: now, calendar: cal)
+        XCTAssertNotNil(result)
+        XCTAssertTrue(result!.text.lowercased().contains("weekend"))
+        XCTAssertTrue(result!.text.lowercased().contains("evening"))
+    }
+
+    func test_summarize_visitsSpanUnder14Days_skipsWeekdaySplit() {
+        let cal = utcCalendar()
+        let visits = (2...11).map { day in
+            visit(year: 2026, month: 3, day: day, hour: 9, calendar: cal)
+        }
+        let now = date(year: 2026, month: 3, day: 20, hour: 12, calendar: cal)
+        let result = PlaceInsight.summarize(visits: visits, now: now, calendar: cal)
+        XCTAssertNotNil(result)
+        XCTAssertFalse(result!.text.lowercased().contains("weekday"))
+    }
+
+    func test_summarize_evenSplit_returnsPeakHour() {
+        let cal = utcCalendar()
+        var visits: [Visit] = []
+        let mixed: [(Int, Int)] = [
+            (3, 2), (3, 3), (3, 9), (3, 10),
+            (3, 7), (3, 8), (3, 14), (3, 15),
+        ]
+        visits += mixed.map { (m, d) in
+            visit(year: 2026, month: m, day: d, hour: 15, calendar: cal)
+        }
+        visits.append(visit(year: 2026, month: 3, day: 16, hour: 8, calendar: cal))
+        visits.append(visit(year: 2026, month: 3, day: 17, hour: 20, calendar: cal))
+
+        let now = date(year: 2026, month: 3, day: 20, hour: 12, calendar: cal)
+        let result = PlaceInsight.summarize(visits: visits, now: now, calendar: cal)
+        XCTAssertNotNil(result)
+        XCTAssertTrue(result!.text.lowercased().contains("3pm")
+                      || result!.text.lowercased().contains("15"))
+    }
+
+    func test_summarize_peakHourBelow25Percent_skipsPeakRule() {
+        let cal = utcCalendar()
+        let visits: [Visit] = (0..<12).map { i in
+            let day = 2 + i
+            return visit(year: 2026, month: 3, day: day, hour: i + 6, calendar: cal)
+        }
+        let now = date(year: 2026, month: 3, day: 20, hour: 12, calendar: cal)
+        XCTAssertNil(PlaceInsight.summarize(visits: visits, now: now, calendar: cal))
+    }
+
+    func test_summarize_risingTrend_returnsRising() {
+        let cal = utcCalendar()
+        var visits: [Visit] = [
+            visit(year: 2025, month: 12, day: 1, hour: 9, calendar: cal),
+            visit(year: 2026, month: 1, day: 15, hour: 14, calendar: cal),
+        ]
+        let recent: [(Int, Int, Int)] = [
+            (3, 1, 7), (3, 8, 8), (3, 15, 11),
+            (4, 2, 13), (4, 9, 16), (4, 16, 18),
+            (5, 3, 20), (5, 10, 6), (5, 11, 22), (5, 17, 10),
+        ]
+        visits += recent.map { (m, d, h) in
+            visit(year: 2026, month: m, day: d, hour: h, calendar: cal)
+        }
+        let now = date(year: 2026, month: 5, day: 20, hour: 12, calendar: cal)
+        let result = PlaceInsight.summarize(visits: visits, now: now, calendar: cal)
+        XCTAssertNotNil(result)
+        let lower = result!.text.lowercased()
+        XCTAssertTrue(lower.contains("more") || lower.contains("rising") || lower.contains("lately"))
+    }
+
+    func test_summarize_visitsSpanUnder4Months_skipsTrend() {
+        let cal = utcCalendar()
+        let visits: [Visit] = (1...12).map { day in
+            visit(year: 2026, month: 5, day: day, hour: 6 + day, calendar: cal)
+        }
+        let now = date(year: 2026, month: 5, day: 20, hour: 12, calendar: cal)
+        let result = PlaceInsight.summarize(visits: visits, now: now, calendar: cal)
+        if let r = result {
+            XCTAssertFalse(r.text.lowercased().contains("lately"))
+            XCTAssertFalse(r.text.lowercased().contains("slowed"))
+        }
+    }
+}

--- a/PlaceNotesTests/VisitStatsTests.swift
+++ b/PlaceNotesTests/VisitStatsTests.swift
@@ -1,0 +1,112 @@
+import XCTest
+@testable import PlaceNotes
+
+final class VisitStatsTests: XCTestCase {
+
+    private func utcCalendar() -> Calendar {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        cal.firstWeekday = 1
+        return cal
+    }
+
+    private func date(_ iso: String, calendar: Calendar) -> Date {
+        let f = ISO8601DateFormatter()
+        f.timeZone = calendar.timeZone
+        return f.date(from: iso)!
+    }
+
+    private func visit(_ iso: String, calendar: Calendar) -> Visit {
+        Visit(arrivalDate: date(iso, calendar: calendar))
+    }
+
+    func test_monthBuckets_emptyVisits_returns12ZeroBuckets() {
+        let cal = utcCalendar()
+        let now = date("2026-05-17T12:00:00Z", calendar: cal)
+        let buckets = VisitStats.monthBuckets(for: [], endingAt: now, calendar: cal)
+        XCTAssertEqual(buckets.count, 12)
+        XCTAssertEqual(buckets.map(\.count), Array(repeating: 0, count: 12))
+    }
+
+    func test_monthBuckets_groupsByCalendarMonth() {
+        let cal = utcCalendar()
+        let now = date("2026-05-17T12:00:00Z", calendar: cal)
+        let visits = [
+            visit("2026-05-01T08:00:00Z", calendar: cal),
+            visit("2026-05-15T08:00:00Z", calendar: cal),
+            visit("2026-04-20T08:00:00Z", calendar: cal),
+        ]
+        let buckets = VisitStats.monthBuckets(for: visits, endingAt: now, calendar: cal)
+        XCTAssertEqual(buckets.count, 12)
+        XCTAssertEqual(buckets.last?.count, 2)
+        XCTAssertEqual(buckets[buckets.count - 2].count, 1)
+    }
+
+    func test_monthBuckets_fixedNowAnchor_endsAtCorrectMonth() {
+        let cal = utcCalendar()
+        let now = date("2026-05-17T12:00:00Z", calendar: cal)
+        let buckets = VisitStats.monthBuckets(for: [], endingAt: now, calendar: cal)
+        let lastId = buckets.last!.id
+        let comps = cal.dateComponents([.year, .month], from: lastId)
+        XCTAssertEqual(comps.year, 2026)
+        XCTAssertEqual(comps.month, 5)
+    }
+
+    func test_monthBuckets_visitsOlderThan12MonthsAreIgnored() {
+        let cal = utcCalendar()
+        let now = date("2026-05-17T12:00:00Z", calendar: cal)
+        let visits = [
+            visit("2024-01-01T08:00:00Z", calendar: cal),
+            visit("2026-05-01T08:00:00Z", calendar: cal),
+        ]
+        let buckets = VisitStats.monthBuckets(for: visits, endingAt: now, calendar: cal)
+        XCTAssertEqual(buckets.reduce(0) { $0 + $1.count }, 1)
+    }
+
+    func test_hourBuckets_returns24ZeroFilledBuckets() {
+        let cal = utcCalendar()
+        let buckets = VisitStats.hourBuckets(for: [], calendar: cal)
+        XCTAssertEqual(buckets.count, 24)
+        XCTAssertEqual(buckets.map(\.id), Array(0..<24))
+        XCTAssertEqual(buckets.map(\.count), Array(repeating: 0, count: 24))
+    }
+
+    func test_hourBuckets_visitAtMidnight_landsInBucket0() {
+        let cal = utcCalendar()
+        let v = visit("2026-05-15T00:30:00Z", calendar: cal)
+        let buckets = VisitStats.hourBuckets(for: [v], calendar: cal)
+        XCTAssertEqual(buckets[0].count, 1)
+        XCTAssertEqual(buckets[1].count, 0)
+    }
+
+    func test_hourBuckets_dstSpringForward_usesLocalHour() {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "America/Los_Angeles")!
+        let comps = DateComponents(
+            calendar: cal,
+            timeZone: cal.timeZone,
+            year: 2026, month: 3, day: 8, hour: 3, minute: 0
+        )
+        let arrival = cal.date(from: comps)!
+        let v = Visit(arrivalDate: arrival)
+        let buckets = VisitStats.hourBuckets(for: [v], calendar: cal)
+        XCTAssertEqual(buckets[3].count, 1)
+    }
+
+    func test_weekdayBuckets_returns7BucketsOrderedByFirstWeekday() {
+        var cal = utcCalendar()
+        cal.firstWeekday = 2
+        let buckets = VisitStats.weekdayBuckets(for: [], calendar: cal)
+        XCTAssertEqual(buckets.count, 7)
+        XCTAssertEqual(buckets.first?.id, 2)
+        XCTAssertEqual(buckets.last?.id, 1)
+    }
+
+    func test_weekdayBuckets_countsByWeekday() {
+        let cal = utcCalendar()
+        let v = visit("2026-05-17T12:00:00Z", calendar: cal)
+        let buckets = VisitStats.weekdayBuckets(for: [v], calendar: cal)
+        let sunday = buckets.first { $0.id == 1 }!
+        XCTAssertEqual(sunday.count, 1)
+    }
+}


### PR DESCRIPTION
## Summary
- Add three Swift Charts to `PlaceDetailView`: Visits per month, Time of day, Day of week.
- Add auto-insight banner between charts 2 and 3 — weekday/weekend split, peak hour, or recent-trend rules (first match wins). Hidden when `visits.count < 5`.
- Add `N visits · since MMM YYYY` subtitle under the place title.
- Shrink stats card from 3 items to 2 (Total Time, Entries) — Visits moves into the subtitle.

New pure-function namespaces `VisitStats` and `PlaceInsight` hold all bucketing/rule logic and are fully unit-tested (`VisitStatsTests`, `PlaceInsightTests`).

Closes #114.

## Test plan
- [x] `xcodebuild test -scheme PlaceNotes-Debug` — 197 tests, 0 failures
- [x] Open high-traffic place → all 3 charts + insight banner render
- [x] Open low-data place (< 5 visits) → charts render sparse, no banner
- [x] Subtitle shows correct count + month
- [x] No regression in photos / journal sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)