### PR TITLE
Refactor quick capture UI to root level and simplify tracking view

### DIFF
--- a/PlaceNotes/Views/ContentView.swift
+++ b/PlaceNotes/Views/ContentView.swift
@@ -34,6 +34,44 @@ struct ContentView: View {
                 }
         }
         .tint(.accentColor)
+        .fullScreenCover(isPresented: $quickCapture.showCamera) {
+            CameraPickerView(
+                onCaptured: { image, exif in
+                    quickCapture.showCamera = false
+                    quickCapture.photoCaptured(image: image, exifLocation: exif)
+                },
+                onCancelled: {
+                    quickCapture.showCamera = false
+                    quickCapture.cancelCapture()
+                }
+            )
+            .ignoresSafeArea()
+        }
+        .sheet(isPresented: Binding(
+            get: { quickCapture.state == .manualPickNeeded },
+            set: { newValue in
+                if !newValue, quickCapture.state == .manualPickNeeded {
+                    quickCapture.cancelCapture()
+                }
+            }
+        )) {
+            ManualPlacePickerView(
+                onPicked: { place in
+                    if let id = quickCapture.pendingPhotoAssetId {
+                        quickCapture.manualPlaceSelected(place, photoAssetId: id)
+                    }
+                },
+                onCancelled: { quickCapture.cancelCapture() }
+            )
+        }
+        .alert("Capture failed", isPresented: Binding(
+            get: { if case .error = quickCapture.state { return true } else { return false } },
+            set: { if !$0 { quickCapture.cancelCapture() } }
+        )) {
+            Button("OK") { quickCapture.cancelCapture() }
+        } message: {
+            if case let .error(msg) = quickCapture.state { Text(msg) }
+        }
         .overlay(alignment: .top) {
             if quickCapture.isWorkingInBackground {
                 BackgroundWorkPill(state: quickCapture.state)
@@ -41,7 +79,20 @@ struct ContentView: View {
                     .transition(.move(edge: .top).combined(with: .opacity))
             }
         }
+        .overlay(alignment: .bottom) {
+            if case let .done(payload) = quickCapture.state {
+                QuickCaptureToast(
+                    payload: payload,
+                    onUndo: { quickCapture.undoNewVisit(payload) },
+                    onSplit: { quickCapture.splitFromMerge(payload) },
+                    onDismiss: { quickCapture.cancelCapture() }
+                )
+                .padding(.bottom, 70)
+                .transition(.move(edge: .bottom).combined(with: .opacity))
+            }
+        }
         .animation(.easeInOut(duration: 0.2), value: quickCapture.isWorkingInBackground)
+        .animation(.easeInOut(duration: 0.2), value: quickCapture.state)
     }
 }
 

--- a/PlaceNotes/Views/LogbookView.swift
+++ b/PlaceNotes/Views/LogbookView.swift
@@ -16,7 +16,7 @@ struct LogbookView: View {
         let minStay = settings.minStayMinutes
         let allVisits = places
             .flatMap { $0.visits }
-            .filter { $0.isQuickCapture || $0.durationMinutes >= minStay }
+            .filter { $0.isQuickCapture || !$0.journalEntries.isEmpty || $0.durationMinutes >= minStay }
             .sorted { $0.arrivalDate > $1.arrivalDate }
 
         let calendar = Calendar.current

--- a/PlaceNotes/Views/TrackingControlView.swift
+++ b/PlaceNotes/Views/TrackingControlView.swift
@@ -18,87 +18,33 @@ struct TrackingControlView: View {
 
     var body: some View {
         NavigationStack {
-            ZStack {
-                VStack(spacing: 28) {
-                    trackingChip
-                        .padding(.top, 8)
+            VStack(spacing: 28) {
+                trackingChip
+                    .padding(.top, 8)
 
-                    CurrentlyAtCard()
+                CurrentlyAtCard()
 
-                    Spacer()
+                Spacer()
 
-                    PolaroidDecorationBand(entries: Array(recentJournalEntries.prefix(20)))
+                PolaroidDecorationBand(entries: Array(recentJournalEntries.prefix(20)))
 
-                    PhotographicShutterButton(isBusy: isBusy) {
-                        if isTrackingActive {
-                            attemptCapture()
-                        } else {
-                            showTrackingOffAlert = true
-                        }
+                PhotographicShutterButton(isBusy: isBusy) {
+                    if isTrackingActive {
+                        attemptCapture()
+                    } else {
+                        showTrackingOffAlert = true
                     }
-
-                    Text("Tap to log this place")
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-
-                    Spacer()
                 }
-                .padding()
 
-                if case let .done(payload) = quickCapture.state {
-                    VStack {
-                        Spacer()
-                        QuickCaptureToast(
-                            payload: payload,
-                            onUndo: { quickCapture.undoNewVisit(payload) },
-                            onSplit: { quickCapture.splitFromMerge(payload) },
-                            onDismiss: { quickCapture.cancelCapture() }
-                        )
-                        .padding(.bottom, 24)
-                    }
-                    .transition(.move(edge: .bottom).combined(with: .opacity))
-                }
+                Text("Tap to log this place")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+
+                Spacer()
             }
+            .padding()
             .navigationTitle("Placelore")
             .sheet(isPresented: $showTrackingSheet) { trackingSheet }
-            .fullScreenCover(isPresented: $quickCapture.showCamera) {
-                CameraPickerView(
-                    onCaptured: { image, exif in
-                        quickCapture.showCamera = false
-                        quickCapture.photoCaptured(image: image, exifLocation: exif)
-                    },
-                    onCancelled: {
-                        quickCapture.showCamera = false
-                        quickCapture.cancelCapture()
-                    }
-                )
-                .ignoresSafeArea()
-            }
-            .sheet(isPresented: Binding(
-                get: { quickCapture.state == .manualPickNeeded },
-                set: { newValue in
-                    if !newValue, quickCapture.state == .manualPickNeeded {
-                        quickCapture.cancelCapture()
-                    }
-                }
-            )) {
-                ManualPlacePickerView(
-                    onPicked: { place in
-                        if let id = quickCapture.pendingPhotoAssetId {
-                            quickCapture.manualPlaceSelected(place, photoAssetId: id)
-                        }
-                    },
-                    onCancelled: { quickCapture.cancelCapture() }
-                )
-            }
-            .alert("Capture failed", isPresented: Binding(
-                get: { if case .error = quickCapture.state { return true } else { return false } },
-                set: { if !$0 { quickCapture.cancelCapture() } }
-            )) {
-                Button("OK") { quickCapture.cancelCapture() }
-            } message: {
-                if case let .error(msg) = quickCapture.state { Text(msg) }
-            }
             .alert("Camera access needed", isPresented: $showCameraPermissionAlert) {
                 Button("OK", role: .cancel) {}
             } message: {


### PR DESCRIPTION
## Summary

This PR refactors the quick capture modal presentation logic from `TrackingControlView` to the root `ContentView`, simplifying the tracking view and centralizing capture state management at the app level. Additionally, the logbook filter is updated to include visits with journal entries.

## Key Changes

- **TrackingControlView**: Removed nested `ZStack` and all quick capture–related modifiers (camera picker, manual place picker, error alert, and success toast). Simplified the view hierarchy by flattening the `VStack` structure.

- **ContentView**: Added all quick capture presentation logic as modifiers:
  - `fullScreenCover` for camera picker
  - `sheet` for manual place picker
  - `alert` for capture errors
  - `overlay` for success toast (moved from inline to bottom overlay with adjusted padding)
  - Added animation for state changes

- **LogbookView**: Updated visit filter to include visits with journal entries (`!$0.journalEntries.isEmpty`) in addition to quick captures and minimum stay duration, ensuring visits with user notes are always visible in the logbook.

## Implementation Details

- The quick capture toast now uses a bottom overlay in `ContentView` instead of being conditionally rendered inside `TrackingControlView`, providing better visual hierarchy and consistency with the background work pill.
- Toast padding adjusted to 70pt to account for tab bar and safe area.
- State animation added to `ContentView` to smoothly transition the success toast.
- This change follows the principle of managing global app state at the root level while keeping child views focused on their primary UI responsibilities.

https://claude.ai/code/session_016XX9ZcHCBiock1iEsNRG5j