### PR TITLE
fix(currently-at-card): hide stale card after user walks away

### DIFF
--- a/PlaceNotes/Services/LocationManager.swift
+++ b/PlaceNotes/Services/LocationManager.swift
@@ -110,6 +110,16 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
     /// Distance (meters) the user must move before we consider them "left".
     private let dwellRadiusMeters: Double = 80
 
+    /// Distance (meters) from a place at which an open visit is force-closed
+    /// even if the dwell-finalize path missed the departure. Wider than the
+    /// dwell radius so transient GPS jumps don't prematurely end a stay.
+    private let orphanVisitCloseRadiusMeters: Double = 250
+
+    /// Maximum horizontal accuracy (meters) to trust a fix for closing an
+    /// orphan open visit. Looser than the dwell-collection filter so a fix
+    /// that's clearly far away can still trigger a close.
+    private let maxAccuracyForOrphanClose: CLLocationAccuracy = 100
+
     /// Maximum horizontal accuracy to accept a sample (meters).
     /// Samples noisier than this are dropped.
     private let maxAcceptableAccuracy: CLLocationAccuracy = 65
@@ -358,6 +368,12 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
             modelContext.insert(visit)
             try? modelContext.save()
 
+            closeOlderOpenVisits(
+                excludingPlaceID: place.id,
+                departureDate: arrival,
+                context: modelContext
+            )
+
             currentVisit = visit
             onVisitRecorded?(visit)
             logger.notice("Recorded CLVisit at \(place.name) (confidence: \(confidence.rawValue), accuracy: \(Int(accuracy))m)")
@@ -394,6 +410,8 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
             location.horizontalAccuracy,
             location.timestamp
         )
+
+        closeStaleOpenVisits(currentLocation: location, context: modelContext)
 
         // Step 1: Filter noisy / stale samples
         let isAccurate = location.horizontalAccuracy >= 0 && location.horizontalAccuracy <= maxAcceptableAccuracy
@@ -621,10 +639,90 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
             context.insert(visit)
             try? context.save()
 
+            closeOlderOpenVisits(
+                excludingPlaceID: place.id,
+                departureDate: cluster.startDate,
+                context: context
+            )
+
             currentVisit = visit
             onVisitRecorded?(visit)
             let stayMinutes = Int(elapsed / 60)
             logger.notice("VISIT RECORDED: \(place.name) (confidence: \(confidence.rawValue), accuracy: \(Int(cluster.medianAccuracy))m, spread: \(Int(cluster.spreadMeters))m, stayed \(stayMinutes) min)")
+        }
+    }
+
+    /// Close any prior open visit whose place is different from the
+    /// newly-recorded one and whose arrival predates it. Maintains the
+    /// "user is at one place at a time" invariant when the regular
+    /// dwell-finalize path missed a departure.
+    @MainActor
+    private func closeOlderOpenVisits(
+        excludingPlaceID: UUID,
+        departureDate: Date,
+        context: ModelContext
+    ) {
+        let cutoff = departureDate
+        let descriptor = FetchDescriptor<Visit>(
+            predicate: #Predicate<Visit> {
+                $0.departureDate == nil && $0.arrivalDate < cutoff
+            }
+        )
+        guard let openVisits = try? context.fetch(descriptor) else { return }
+
+        var closedAny = false
+        for visit in openVisits {
+            guard let place = visit.place, place.id != excludingPlaceID else { continue }
+            visit.departureDate = departureDate
+            closedAny = true
+            logger.notice("Closed prior open visit at \(place.name) — superseded by new visit at \(departureDate)")
+        }
+        if closedAny {
+            try? context.save()
+        }
+    }
+
+    /// Safety net: close any open visit whose place is now far from the user's
+    /// current location. The dwell-finalize path can miss this when iOS pauses
+    /// or throttles location updates during a long stay and the dwell buffer
+    /// loses coherence by the time movement resumes.
+    private func closeStaleOpenVisits(currentLocation: CLLocation, context: ModelContext) {
+        let placeLat = currentLocation.coordinate.latitude
+        let placeLon = currentLocation.coordinate.longitude
+        let accuracy = currentLocation.horizontalAccuracy
+        let departureDate = currentLocation.timestamp
+        let closeRadius = orphanVisitCloseRadiusMeters
+        let maxAccuracy = maxAccuracyForOrphanClose
+
+        Task { @MainActor in
+            let descriptor = FetchDescriptor<Visit>(
+                predicate: #Predicate { $0.departureDate == nil }
+            )
+            guard let openVisits = try? context.fetch(descriptor), !openVisits.isEmpty else { return }
+
+            var closedAny = false
+            for visit in openVisits {
+                guard let place = visit.place else { continue }
+                let hasLeft = StayDetector.hasUserLeftPlace(
+                    placeLatitude: place.latitude,
+                    placeLongitude: place.longitude,
+                    currentLatitude: placeLat,
+                    currentLongitude: placeLon,
+                    currentAccuracy: accuracy,
+                    maxAcceptableAccuracy: maxAccuracy,
+                    thresholdMeters: closeRadius
+                )
+                guard hasLeft, departureDate > visit.arrivalDate else { continue }
+                visit.departureDate = departureDate
+                closedAny = true
+                let distance = CLLocation(latitude: place.latitude, longitude: place.longitude)
+                    .distance(from: CLLocation(latitude: placeLat, longitude: placeLon))
+                logger.notice("Closed stale open visit at \(place.name) — user is \(Int(distance))m away")
+            }
+
+            if closedAny {
+                try? context.save()
+            }
         }
     }
 

--- a/PlaceNotes/Services/StayDetector.swift
+++ b/PlaceNotes/Services/StayDetector.swift
@@ -140,4 +140,25 @@ enum StayDetector {
             return eventLoc.distance(from: centerLoc) > dwellRadiusMeters
         }
     }
+
+    // MARK: - Orphan Visit Detection
+
+    /// Whether the user has clearly moved away from a place far enough that an
+    /// open visit there should be closed even if the dwell-finalize path missed
+    /// it. Requires a trustworthy fix (accuracy in `(0, maxAcceptableAccuracy]`)
+    /// so noisy GPS jumps don't prematurely end a stay.
+    static func hasUserLeftPlace(
+        placeLatitude: Double,
+        placeLongitude: Double,
+        currentLatitude: Double,
+        currentLongitude: Double,
+        currentAccuracy: CLLocationAccuracy,
+        maxAcceptableAccuracy: CLLocationAccuracy,
+        thresholdMeters: Double
+    ) -> Bool {
+        guard currentAccuracy >= 0, currentAccuracy <= maxAcceptableAccuracy else { return false }
+        let placeLoc = CLLocation(latitude: placeLatitude, longitude: placeLongitude)
+        let currentLoc = CLLocation(latitude: currentLatitude, longitude: currentLongitude)
+        return currentLoc.distance(from: placeLoc) > thresholdMeters
+    }
 }

--- a/PlaceNotes/Views/CurrentlyAtCard.swift
+++ b/PlaceNotes/Views/CurrentlyAtCard.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import SwiftData
+import CoreLocation
 
 struct CurrentlyAtCard: View {
     @Query(
@@ -9,13 +10,19 @@ struct CurrentlyAtCard: View {
     ) private var openVisits: [Visit]
 
     @EnvironmentObject private var quickCapture: QuickCaptureViewModel
+    @EnvironmentObject private var locationManager: LocationManager
     @State private var showNoteEditor = false
 
     var body: some View {
         TimelineView(.periodic(from: .now, by: 60)) { context in
             let cutoff = context.date.addingTimeInterval(-48 * 3600)
             if let visit = openVisits.first(where: { $0.arrivalDate > cutoff }),
-               let place = visit.place {
+               let place = visit.place,
+               CurrentlyAtFormatter.isUserAtPlace(
+                   userLocation: locationManager.userLocation,
+                   placeLatitude: place.latitude,
+                   placeLongitude: place.longitude
+               ) {
                 cardBody(visit: visit, place: place, now: context.date)
             }
         }
@@ -116,6 +123,26 @@ private struct CardSurface: ViewModifier {
 }
 
 enum CurrentlyAtFormatter {
+    /// Maximum distance (meters) the user can be from a place before the
+    /// "You're at" card is hidden. Slightly larger than `LocationManager`'s
+    /// 80m dwell radius to absorb GPS noise without flickering.
+    static let presenceThresholdMeters: CLLocationDistance = 150
+
+    /// Whether the user is close enough to the place to still be considered
+    /// "at" it. Returns true when the user's location is unknown so the card
+    /// still renders before the first fix arrives.
+    static func isUserAtPlace(
+        userLocation: CLLocationCoordinate2D?,
+        placeLatitude: Double,
+        placeLongitude: Double,
+        thresholdMeters: CLLocationDistance = presenceThresholdMeters
+    ) -> Bool {
+        guard let userLocation else { return true }
+        let user = CLLocation(latitude: userLocation.latitude, longitude: userLocation.longitude)
+        let place = CLLocation(latitude: placeLatitude, longitude: placeLongitude)
+        return user.distance(from: place) <= thresholdMeters
+    }
+
     static func elapsed(arrivalDate: Date, now: Date) -> String {
         let total = max(0, Int(now.timeIntervalSince(arrivalDate)))
         if total < 60 {

--- a/PlaceNotesTests/CurrentlyAtCardFormattersTests.swift
+++ b/PlaceNotesTests/CurrentlyAtCardFormattersTests.swift
@@ -1,9 +1,88 @@
 import XCTest
+import CoreLocation
 @testable import PlaceNotes
 
 final class CurrentlyAtCardFormattersTests: XCTestCase {
 
     private let base = Date(timeIntervalSince1970: 1_700_000_000)
+
+    // Microsoft Building 109 / Overlake area
+    private let placeLat = 47.6446
+    private let placeLon = -122.1390
+
+    func testIsUserAtPlaceTrueWhenUserLocationUnknown() {
+        XCTAssertTrue(
+            CurrentlyAtFormatter.isUserAtPlace(
+                userLocation: nil,
+                placeLatitude: placeLat,
+                placeLongitude: placeLon
+            )
+        )
+    }
+
+    func testIsUserAtPlaceTrueWhenUserIsAtPlace() {
+        let user = CLLocationCoordinate2D(latitude: placeLat, longitude: placeLon)
+        XCTAssertTrue(
+            CurrentlyAtFormatter.isUserAtPlace(
+                userLocation: user,
+                placeLatitude: placeLat,
+                placeLongitude: placeLon
+            )
+        )
+    }
+
+    func testIsUserAtPlaceTrueWhenWithinThreshold() {
+        // ~50m north of the place — well within the 150m default threshold.
+        let user = CLLocationCoordinate2D(
+            latitude: placeLat + 0.00045,
+            longitude: placeLon
+        )
+        XCTAssertTrue(
+            CurrentlyAtFormatter.isUserAtPlace(
+                userLocation: user,
+                placeLatitude: placeLat,
+                placeLongitude: placeLon
+            )
+        )
+    }
+
+    func testIsUserAtPlaceFalseWhenBeyondThreshold() {
+        // ~500m east of the place — well outside the 150m default threshold.
+        let user = CLLocationCoordinate2D(
+            latitude: placeLat,
+            longitude: placeLon + 0.0067
+        )
+        XCTAssertFalse(
+            CurrentlyAtFormatter.isUserAtPlace(
+                userLocation: user,
+                placeLatitude: placeLat,
+                placeLongitude: placeLon
+            )
+        )
+    }
+
+    func testIsUserAtPlaceHonorsCustomThreshold() {
+        // ~200m north — outside 150m default but inside an explicit 300m override.
+        let user = CLLocationCoordinate2D(
+            latitude: placeLat + 0.0018,
+            longitude: placeLon
+        )
+        XCTAssertFalse(
+            CurrentlyAtFormatter.isUserAtPlace(
+                userLocation: user,
+                placeLatitude: placeLat,
+                placeLongitude: placeLon
+            )
+        )
+        XCTAssertTrue(
+            CurrentlyAtFormatter.isUserAtPlace(
+                userLocation: user,
+                placeLatitude: placeLat,
+                placeLongitude: placeLon,
+                thresholdMeters: 300
+            )
+        )
+    }
 
     func testElapsedUnderOneMinuteReadsJustArrived() {
         let now = base.addingTimeInterval(45)

--- a/PlaceNotesTests/StayDetectorTests.swift
+++ b/PlaceNotesTests/StayDetectorTests.swift
@@ -355,4 +355,73 @@ final class StayDetectorTests: XCTestCase {
         )
         XCTAssertFalse(result)
     }
+
+    // MARK: - hasUserLeftPlace
+
+    private let leftPlaceLat = 47.6446
+    private let leftPlaceLon = -122.1390
+
+    func testHasUserLeftPlaceFalseWhenSameSpot() {
+        XCTAssertFalse(StayDetector.hasUserLeftPlace(
+            placeLatitude: leftPlaceLat,
+            placeLongitude: leftPlaceLon,
+            currentLatitude: leftPlaceLat,
+            currentLongitude: leftPlaceLon,
+            currentAccuracy: 10,
+            maxAcceptableAccuracy: 100,
+            thresholdMeters: 250
+        ))
+    }
+
+    func testHasUserLeftPlaceFalseWhenWithinThreshold() {
+        // ~50m offset
+        XCTAssertFalse(StayDetector.hasUserLeftPlace(
+            placeLatitude: leftPlaceLat,
+            placeLongitude: leftPlaceLon,
+            currentLatitude: leftPlaceLat + 0.00045,
+            currentLongitude: leftPlaceLon,
+            currentAccuracy: 10,
+            maxAcceptableAccuracy: 100,
+            thresholdMeters: 250
+        ))
+    }
+
+    func testHasUserLeftPlaceTrueWhenBeyondThreshold() {
+        // ~500m offset
+        XCTAssertTrue(StayDetector.hasUserLeftPlace(
+            placeLatitude: leftPlaceLat,
+            placeLongitude: leftPlaceLon,
+            currentLatitude: leftPlaceLat,
+            currentLongitude: leftPlaceLon + 0.0067,
+            currentAccuracy: 15,
+            maxAcceptableAccuracy: 100,
+            thresholdMeters: 250
+        ))
+    }
+
+    func testHasUserLeftPlaceFalseWhenAccuracyTooPoor() {
+        // Far away, but accuracy is too noisy to trust.
+        XCTAssertFalse(StayDetector.hasUserLeftPlace(
+            placeLatitude: leftPlaceLat,
+            placeLongitude: leftPlaceLon,
+            currentLatitude: leftPlaceLat,
+            currentLongitude: leftPlaceLon + 0.0067,
+            currentAccuracy: 300,
+            maxAcceptableAccuracy: 100,
+            thresholdMeters: 250
+        ))
+    }
+
+    func testHasUserLeftPlaceFalseWhenAccuracyInvalid() {
+        // Negative accuracy means CoreLocation doesn't trust the fix.
+        XCTAssertFalse(StayDetector.hasUserLeftPlace(
+            placeLatitude: leftPlaceLat,
+            placeLongitude: leftPlaceLon,
+            currentLatitude: leftPlaceLat,
+            currentLongitude: leftPlaceLon + 0.0067,
+            currentAccuracy: -1,
+            maxAcceptableAccuracy: 100,
+            thresholdMeters: 250
+        ))
+    }
 }


### PR DESCRIPTION
The "You're at" card only filters by departureDate == nil, which can
linger if LocationManager.finalizeDwell fails to close the visit (long
stays, iOS background throttling, etc.). Check the user's current
location against the place coordinate so the card hides once they've
clearly left, even when the visit is still open in storage.