### PR TITLE
fix(map): break auto-fit feedback loop that froze the Map tab

### DIFF
--- a/PlaceNotes/Views/FrequentPlacesMapView.swift
+++ b/PlaceNotes/Views/FrequentPlacesMapView.swift
@@ -10,10 +10,10 @@ struct FrequentPlacesMapView: View {
     @EnvironmentObject private var trackingViewModel: TrackingViewModel
     @State private var selectedPlace: Place?
     @State private var cameraPosition: MapCameraPosition = .automatic
+    @State private var hasInitializedCamera = false
     @State private var visibleRegion: MKCoordinateRegion?
     @State private var cachedAnnotations: [any MapAnnotationItem] = []
     @State private var showTrackingAlert = false
-    @State private var isRebuildingAnnotations = false
     @Environment(\.scenePhase) private var scenePhase
 
     var body: some View {
@@ -43,9 +43,17 @@ struct FrequentPlacesMapView: View {
                 }
                 .onMapCameraChange(frequency: .onEnd) { context in
                     let newRegion = context.region
-                    // Skip rebuild if the region hasn't changed meaningfully — this
-                    // breaks the feedback loop where annotation updates nudge the
-                    // camera, which triggers another rebuild, and so on.
+
+                    // Lock in a concrete region the first time MapKit reports one
+                    // so `.automatic` stops re-fitting whenever the annotation set
+                    // changes. Without this, every rebuild shifts the auto-fit,
+                    // which shifts the cluster radius, which shifts the annotation
+                    // set — a feedback loop that pegs the main thread on tab entry.
+                    if !hasInitializedCamera {
+                        hasInitializedCamera = true
+                        cameraPosition = .region(newRegion)
+                    }
+
                     if let old = visibleRegion {
                         let spanTolerance = max(old.span.latitudeDelta * 0.02, 0.0001)
                         let latSame = abs(old.span.latitudeDelta - newRegion.span.latitudeDelta) < spanTolerance
@@ -85,7 +93,7 @@ struct FrequentPlacesMapView: View {
             }
             .navigationTitle("Map")
             .navigationBarTitleDisplayMode(.inline)
-            .onAppear {
+            .task {
                 viewModel.refresh(places: places)
                 rebuildAnnotations()
             }
@@ -129,10 +137,6 @@ struct FrequentPlacesMapView: View {
 
     /// Rebuilds annotations only when region or data changes — not on every render.
     private func rebuildAnnotations() {
-        guard !isRebuildingAnnotations else { return }
-        isRebuildingAnnotations = true
-        defer { isRebuildingAnnotations = false }
-
         let rankings = mapRankings()
         let newAnnotations: [any MapAnnotationItem]
         if let region = visibleRegion {


### PR DESCRIPTION
`FrequentPlacesMapView` started with `cameraPosition = .automatic` and
never moved off it. Each time `rebuildAnnotations` produced a new set
(e.g. clustering kicking in once `visibleRegion` was set), MapKit
re-fit the camera to the new content, `onMapCameraChange` fired with a
new span, the cluster radius shifted, IDs changed again, MapKit re-fit
again, and so on. With enough places the loop pegged the main thread on
tab entry — the previous tab's pixels stayed on screen and killing the
app didn't help because the same persisted place set re-triggered the
loop on relaunch. `DayTrajectoryView` shows the same `Map` working fine
because it sets `cameraPosition = .region(...)` after its initial load.

- On the first `onMapCameraChange`, switch `cameraPosition` from
  `.automatic` to `.region(newRegion)` so MapKit stops re-fitting on
  every annotation change.
- Drop the `isRebuildingAnnotations` guard — `rebuildAnnotations` is
  synchronous, so `defer` resets the flag before any other call could
  see it; it only added two extra `@State` mutations per call.
- Move the initial `viewModel.refresh` + `rebuildAnnotations` from
  `onAppear` to `task` so the heavy first build doesn't block the
  synchronous tab-switch render path.