### PR TITLE
fix(tracking): suppress duplicate visit when same place is already open

### DIFF
--- a/PlaceNotes/Services/LocationManager.swift
+++ b/PlaceNotes/Services/LocationManager.swift
@@ -771,6 +771,17 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
     /// `Place` row.
     @MainActor
     private func isDuplicate(place: Place, arrival: Date, context: ModelContext) -> Bool {
+        let placeID = place.id
+        let openDescriptor = FetchDescriptor<Visit>(
+            predicate: #Predicate<Visit> { $0.departureDate == nil }
+        )
+        if let openVisits = try? context.fetch(openDescriptor) {
+            for visit in openVisits where visit.place?.id == placeID && visit.arrivalDate < arrival {
+                logger.debug("Duplicate detected — open visit at \(place.name) since \(visit.arrivalDate)")
+                return true
+            }
+        }
+
         let timeWindow: TimeInterval = 600
         let spatialThresholdMeters: Double = 150
         let windowStart = arrival.addingTimeInterval(-timeWindow)


### PR DESCRIPTION
If GPS jitter pushed the dwell centroid >80m from the recorded place,
finalizeDwell would skip closing the open visit. A new dwell at the same
spot would then record a second visit at the same Place 5+ min later —
isDuplicate's 10-min window missed it and closeOlderOpenVisits skips
same-place visits by design.

Treat any existing open visit at the same Place as a duplicate so the
continuation collapses back into the original stay.