### PR TITLE
Simplify location sampling: remove synthetic floor timer

### DIFF
--- a/PlaceNotes/Services/LocationManager.swift
+++ b/PlaceNotes/Services/LocationManager.swift
@@ -72,26 +72,9 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
 
     /// In-memory buffer of raw samples awaiting batch insert into SwiftData.
     /// Flushed when the buffer fills, on the dwell-timer tick, or on stop.
+    /// Kept small so app termination loses at most a handful of samples.
     private var pendingRawSamples: [PendingRawSample] = []
-    private let rawSampleBatchSize = 50
-
-    /// Last sample's identity used to suppress iOS re-deliveries of an unchanged fix.
-    private var lastObservedSample: (lat: Double, lon: Double, accuracy: Double, timestamp: Date)?
-
-    /// Wall-clock time at which we last queued ANY raw sample (real or synthesized).
-    /// Drives the time-floor regulator: if the gap exceeds `sampleFloorIntervalSeconds`,
-    /// a synthesized sample is emitted using the last known fix.
-    private var lastSampleSavedAt: Date?
-
-    /// Repeating timer that enforces the time floor on raw-sample cadence.
-    private var sampleFloorTimer: Timer?
-
-    /// Time-floor target: persist at least one `RawLocationSample` every N seconds
-    /// even when the user is stationary and iOS has no new fix to deliver.
-    private let sampleFloorIntervalSeconds: TimeInterval = 10
-
-    /// Window within which an identical-coord/accuracy sample is treated as a redelivery.
-    private let duplicateSampleWindow: TimeInterval = 30
+    private let rawSampleBatchSize = 10
 
     /// CLVisit arrival/departure events seen during this tracking session,
     /// retained so a long gap in `didUpdateLocations` can be cross-checked
@@ -143,13 +126,10 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
         super.init()
         clManager.delegate = self
         clManager.allowsBackgroundLocationUpdates = true
-        // Keep the stream alive while tracking so the sample-floor timer can
-        // synthesize stationary samples on a regular cadence. iOS auto-pause
-        // would otherwise drop updates entirely during long stays.
         clManager.pausesLocationUpdatesAutomatically = false
         clManager.activityType = .other
         clManager.desiredAccuracy = kCLLocationAccuracyBest
-        clManager.distanceFilter = 10
+        clManager.distanceFilter = 5
         authorizationStatus = clManager.authorizationStatus
         logger.info("LocationManager initialized, auth status: \(self.authorizationStatus.rawValue), minStay: \(settings.minStayMinutes)min")
     }
@@ -171,8 +151,7 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
         clManager.startMonitoringSignificantLocationChanges()
         clManager.startUpdatingLocation()
         startDwellTimer()
-        startSampleFloorTimer()
-        logger.notice("Monitoring started: visits + significant changes + location updates + dwell timer + sample floor timer")
+        logger.notice("Monitoring started: visits + significant changes + location updates + dwell timer")
     }
 
     func stopMonitoring() {
@@ -182,12 +161,8 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
         clManager.stopUpdatingLocation()
         dwellTimer?.invalidate()
         dwellTimer = nil
-        sampleFloorTimer?.invalidate()
-        sampleFloorTimer = nil
         flushRawSamples()
         finalizeDwell()
-        lastObservedSample = nil
-        lastSampleSavedAt = nil
         observedVisitEvents.removeAll()
         logger.notice("All monitoring stopped")
     }
@@ -206,44 +181,6 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
             self?.checkDwellStatus()
         }
         logger.debug("Dwell timer started (30s interval)")
-    }
-
-    // MARK: - Sample Floor Timer
-
-    /// Tick at half the floor interval so the max gap between persisted samples
-    /// is bounded close to `sampleFloorIntervalSeconds` (and not 2x worst-case).
-    private func startSampleFloorTimer() {
-        sampleFloorTimer?.invalidate()
-        let tick = max(1.0, sampleFloorIntervalSeconds / 2)
-        sampleFloorTimer = Timer.scheduledTimer(withTimeInterval: tick, repeats: true) { [weak self] _ in
-            self?.emitFloorSampleIfNeeded()
-        }
-        logger.debug("Sample floor timer started (\(Int(tick))s tick, \(Int(self.sampleFloorIntervalSeconds))s floor)")
-    }
-
-    private func emitFloorSampleIfNeeded() {
-        guard let fix = lastFix else { return }
-        let now = Date()
-        if let last = lastSampleSavedAt, now.timeIntervalSince(last) < sampleFloorIntervalSeconds {
-            return
-        }
-
-        pendingRawSamples.append(PendingRawSample(
-            latitude: fix.coordinate.latitude,
-            longitude: fix.coordinate.longitude,
-            timestamp: now,
-            horizontalAccuracy: fix.horizontalAccuracy,
-            speed: fix.speed,
-            altitude: fix.altitude,
-            verticalAccuracy: fix.verticalAccuracy,
-            course: fix.course >= 0 ? fix.course : nil,
-            filterStatus: "synthesized-stationary"
-        ))
-        lastSampleSavedAt = now
-        if pendingRawSamples.count >= rawSampleBatchSize {
-            flushRawSamples()
-        }
-        logger.debug("Floor sample synthesized at (\(fix.coordinate.latitude), \(fix.coordinate.longitude))")
     }
 
     private func checkDwellStatus() {
@@ -396,21 +333,6 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
         userLocation = location.coordinate
         lastFix = location
 
-        if let last = lastObservedSample,
-           last.lat == location.coordinate.latitude,
-           last.lon == location.coordinate.longitude,
-           last.accuracy == location.horizontalAccuracy,
-           location.timestamp.timeIntervalSince(last.timestamp) < duplicateSampleWindow {
-            logger.debug("Duplicate sample suppressed (Δt=\(location.timestamp.timeIntervalSince(last.timestamp))s)")
-            return
-        }
-        lastObservedSample = (
-            location.coordinate.latitude,
-            location.coordinate.longitude,
-            location.horizontalAccuracy,
-            location.timestamp
-        )
-
         closeStaleOpenVisits(currentLocation: location, context: modelContext)
 
         // Step 1: Filter noisy / stale samples
@@ -445,7 +367,6 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
             course: location.course >= 0 ? location.course : nil,
             filterStatus: filterStatus
         ))
-        lastSampleSavedAt = Date()
         if pendingRawSamples.count >= rawSampleBatchSize {
             flushRawSamples()
         }


### PR DESCRIPTION
## Summary

Removes the sample-floor timer mechanism that was synthesizing stationary location samples at regular intervals. This simplifies the location collection pipeline by relying solely on iOS's native location updates and the dwell timer for sample persistence.

## Key Changes

- **Removed sample-floor timer logic**: Deleted `startSampleFloorTimer()`, `emitFloorSampleIfNeeded()`, and all related timer state (`sampleFloorTimer`, `sampleFloorIntervalSeconds`)
- **Removed duplicate-sample suppression**: Deleted the `lastObservedSample` tracking and deduplication window logic that was filtering re-deliveries within a 30-second window
- **Removed sample-timing state**: Deleted `lastSampleSavedAt` tracking that was used to enforce the time floor
- **Reduced batch size**: Changed `rawSampleBatchSize` from 50 to 10 to keep the in-memory buffer small (minimizes data loss on app termination)
- **Tightened distance filter**: Changed `distanceFilter` from 10 m to 5 m for finer-grained location tracking
- **Updated initialization comment**: Removed outdated comment about keeping the stream alive for the sample-floor timer
- **Simplified monitoring lifecycle**: Removed `startSampleFloorTimer()` call from `startMonitoring()` and cleanup from `stopMonitoring()`

## Implementation Details

The sample-floor timer was designed to emit synthesized samples during stationary periods to enforce a minimum cadence (one sample every 10 seconds). This change removes that synthetic injection, relying instead on:
- Native iOS location updates (filtered by the 5 m distance threshold)
- The existing 30-second dwell timer for periodic checks
- The batch flush mechanism when the buffer reaches 10 samples

This reduces complexity while maintaining adequate sampling for dwell detection and ST-DBSCAN analysis. The smaller batch size ensures minimal data loss if the app terminates unexpectedly.

https://claude.ai/code/session_012z2eLwT1bfjyDs3u6eYf2n