### PR TITLE
[codex] Add logbook trip clusters

### DIFF
--- a/PlaceNotes/Models/AppSettings.swift
+++ b/PlaceNotes/Models/AppSettings.swift
@@ -44,6 +44,36 @@ final class AppSettings: ObservableObject {
         didSet { UserDefaults.standard.set(rawLocationRetentionDays, forKey: "rawLocationRetentionDays") }
     }
 
+    @Published var tripMinDays: Int {
+        didSet { UserDefaults.standard.set(tripMinDays, forKey: "tripMinDays") }
+    }
+
+    @Published var tripMinDistanceKm: Double {
+        didSet { UserDefaults.standard.set(tripMinDistanceKm, forKey: "tripMinDistanceKm") }
+    }
+
+    @Published var cachedTripHomeLatitude: Double? {
+        didSet { Self.setOptional(cachedTripHomeLatitude, forKey: "cachedTripHomeLatitude") }
+    }
+
+    @Published var cachedTripHomeLongitude: Double? {
+        didSet { Self.setOptional(cachedTripHomeLongitude, forKey: "cachedTripHomeLongitude") }
+    }
+
+    var cachedTripHomeCentroid: TripDetector.HomeCentroid? {
+        get {
+            guard let latitude = cachedTripHomeLatitude,
+                  let longitude = cachedTripHomeLongitude else {
+                return nil
+            }
+            return TripDetector.HomeCentroid(latitude: latitude, longitude: longitude)
+        }
+        set {
+            cachedTripHomeLatitude = newValue?.latitude
+            cachedTripHomeLongitude = newValue?.longitude
+        }
+    }
+
     @Published var trackingState: TrackingState {
         didSet {
             if let data = try? JSONEncoder().encode(trackingState) {
@@ -62,6 +92,15 @@ final class AppSettings: ObservableObject {
         let savedRetention = UserDefaults.standard.integer(forKey: "rawLocationRetentionDays")
         self.rawLocationRetentionDays = savedRetention > 0 ? savedRetention : 30
 
+        let savedTripMinDays = UserDefaults.standard.integer(forKey: "tripMinDays")
+        self.tripMinDays = savedTripMinDays > 0 ? savedTripMinDays : 2
+
+        let savedTripMinDistance = UserDefaults.standard.double(forKey: "tripMinDistanceKm")
+        self.tripMinDistanceKm = savedTripMinDistance > 0 ? savedTripMinDistance : 50
+
+        self.cachedTripHomeLatitude = Self.optionalDouble(forKey: "cachedTripHomeLatitude")
+        self.cachedTripHomeLongitude = Self.optionalDouble(forKey: "cachedTripHomeLongitude")
+
         if let raw = UserDefaults.standard.string(forKey: "appearanceMode"),
            let mode = AppearanceMode(rawValue: raw) {
             self.appearanceMode = mode
@@ -74,6 +113,18 @@ final class AppSettings: ObservableObject {
             self.trackingState = state
         } else {
             self.trackingState = .default
+        }
+    }
+
+    private static func optionalDouble(forKey key: String) -> Double? {
+        UserDefaults.standard.object(forKey: key) as? Double
+    }
+
+    private static func setOptional(_ value: Double?, forKey key: String) {
+        if let value {
+            UserDefaults.standard.set(value, forKey: key)
+        } else {
+            UserDefaults.standard.removeObject(forKey: key)
         }
     }
 }

--- a/PlaceNotes/Services/MockLocationProvider.swift
+++ b/PlaceNotes/Services/MockLocationProvider.swift
@@ -52,14 +52,22 @@ final class MockLocationProvider {
             purgeIfNeeded(context: context)
         }
 
-        guard !hasSeededData else { return }
-
         let descriptor = FetchDescriptor<Place>()
         let existingCount = (try? context.fetchCount(descriptor)) ?? 0
-        guard existingCount == 0 else { return }
-
         let calendar = Calendar.current
         let now = Date()
+
+        if existingCount > 0 {
+            guard !hasDetectedTripFixtures(context: context) else { return }
+
+            seedDetectedTrips(now: now, calendar: calendar, context: context)
+            try? context.save()
+            UserDefaults.standard.set(true, forKey: seededKey)
+            UserDefaults.standard.set(seedVersion, forKey: seedVersionKey)
+            logger.info("Added debug mock trip fixtures (v\(seedVersion))")
+            return
+        }
+
         let tripDayOffsets: Set<Int> = [7, 8, 9, 24, 25, 26, 27]
 
         for mockPlace in samplePlaces {
@@ -128,7 +136,39 @@ final class MockLocationProvider {
 
     @MainActor
     private static func seedDetectedTrips(now: Date, calendar: Calendar, context: ModelContext) {
-        let home = Place(
+        let descriptor = FetchDescriptor<Place>()
+        let existingPlaces = (try? context.fetch(descriptor)) ?? []
+        var existingPlacesByName: [String: Place] = [:]
+        for existingPlace in existingPlaces {
+            existingPlacesByName[existingPlace.name] = existingPlacesByName[existingPlace.name] ?? existingPlace
+        }
+
+        func place(
+            name: String,
+            latitude: Double,
+            longitude: Double,
+            category: String,
+            city: String,
+            state: String
+        ) -> Place {
+            if let existingPlace = existingPlacesByName[name] {
+                return existingPlace
+            }
+
+            let newPlace = Place(
+                name: name,
+                latitude: latitude,
+                longitude: longitude,
+                category: category,
+                city: city,
+                state: state
+            )
+            context.insert(newPlace)
+            existingPlacesByName[name] = newPlace
+            return newPlace
+        }
+
+        let home = place(
             name: "Home",
             latitude: 37.7649,
             longitude: -122.4194,
@@ -136,7 +176,7 @@ final class MockLocationProvider {
             city: "San Francisco",
             state: "CA"
         )
-        let stumptown = Place(
+        let stumptown = place(
             name: "Stumptown Coffee Roasters",
             latitude: 45.5228,
             longitude: -122.6819,
@@ -144,7 +184,7 @@ final class MockLocationProvider {
             city: "Portland",
             state: "OR"
         )
-        let powells = Place(
+        let powells = place(
             name: "Powell's City of Books",
             latitude: 45.5231,
             longitude: -122.6813,
@@ -152,7 +192,7 @@ final class MockLocationProvider {
             city: "Portland",
             state: "OR"
         )
-        let pokPok = Place(
+        let pokPok = place(
             name: "Pok Pok",
             latitude: 45.5049,
             longitude: -122.6321,
@@ -160,7 +200,7 @@ final class MockLocationProvider {
             city: "Portland",
             state: "OR"
         )
-        let hotel = Place(
+        let hotel = place(
             name: "The State Hotel",
             latitude: 47.6097,
             longitude: -122.3405,
@@ -168,7 +208,7 @@ final class MockLocationProvider {
             city: "Seattle",
             state: "WA"
         )
-        let pikePlace = Place(
+        let pikePlace = place(
             name: "Pike Place Market",
             latitude: 47.6094,
             longitude: -122.3417,
@@ -176,7 +216,7 @@ final class MockLocationProvider {
             city: "Seattle",
             state: "WA"
         )
-        let museum = Place(
+        let museum = place(
             name: "Seattle Art Museum",
             latitude: 47.6073,
             longitude: -122.3381,
@@ -184,10 +224,6 @@ final class MockLocationProvider {
             city: "Seattle",
             state: "WA"
         )
-
-        for place in [home, stumptown, powells, pokPok, hotel, pikePlace, museum] {
-            context.insert(place)
-        }
 
         // Enough recent overnight home visits to make the inferred home centroid deterministic.
         for offset in [1, 2, 3, 4, 5, 10, 12, 14, 18, 21, 30, 45] {
@@ -270,6 +306,17 @@ final class MockLocationProvider {
     ]
 
     private static let mockPlaceNames: Set<String> = Set(samplePlaces.map(\.name)).union(mockTripPlaceNames)
+
+    @MainActor
+    private static func hasDetectedTripFixtures(context: ModelContext) -> Bool {
+        let descriptor = FetchDescriptor<Place>()
+        guard let places = try? context.fetch(descriptor) else { return false }
+
+        let tripPlaces = places.filter { mockTripPlaceNames.contains($0.name) }
+        let tripPlaceNames = Set(tripPlaces.map(\.name))
+        let tripFixtureVisitCount = tripPlaces.reduce(0) { $0 + $1.visits.count }
+        return mockTripPlaceNames.isSubset(of: tripPlaceNames) && tripFixtureVisitCount >= 20
+    }
 
     /// Removes all mock-seeded data from the database.
     /// Call this in release builds to clean up leftover debug data.

--- a/PlaceNotes/Services/MockLocationProvider.swift
+++ b/PlaceNotes/Services/MockLocationProvider.swift
@@ -10,7 +10,7 @@ final class MockLocationProvider {
 
     private static let seededKey = "mockDataSeeded_debug"
     /// Bump this version to force a re-seed (e.g. after adding new mock fields).
-    private static let seedVersion = 3
+    private static let seedVersion = 4
     private static let seedVersionKey = "mockDataSeedVersion"
 
     /// Whether mock data has been seeded into the current debug database.
@@ -60,6 +60,7 @@ final class MockLocationProvider {
 
         let calendar = Calendar.current
         let now = Date()
+        let tripDayOffsets: Set<Int> = [7, 8, 9, 24, 25, 26, 27]
 
         for mockPlace in samplePlaces {
             let place = Place(
@@ -76,6 +77,7 @@ final class MockLocationProvider {
             let visitCount = Int.random(in: 5...20)
             for _ in 0..<visitCount {
                 let daysAgo = Int.random(in: 0...89)
+                guard !tripDayOffsets.contains(daysAgo) else { continue }
                 let hour = Int.random(in: 6...22)
                 let minute = Int.random(in: 0...59)
                 let durationMinutes = Int.random(in: 5...180)
@@ -116,15 +118,158 @@ final class MockLocationProvider {
             }
         }
 
+        seedDetectedTrips(now: now, calendar: calendar, context: context)
+
         try? context.save()
         UserDefaults.standard.set(true, forKey: seededKey)
         UserDefaults.standard.set(seedVersion, forKey: seedVersionKey)
-        logger.info("Seeded \(samplePlaces.count) places with sample visits (v\(seedVersion))")
+        logger.info("Seeded debug mock places with sample visits and trips (v\(seedVersion))")
+    }
+
+    @MainActor
+    private static func seedDetectedTrips(now: Date, calendar: Calendar, context: ModelContext) {
+        let home = Place(
+            name: "Home",
+            latitude: 37.7649,
+            longitude: -122.4194,
+            category: "Home",
+            city: "San Francisco",
+            state: "CA"
+        )
+        let stumptown = Place(
+            name: "Stumptown Coffee Roasters",
+            latitude: 45.5228,
+            longitude: -122.6819,
+            category: "Cafe",
+            city: "Portland",
+            state: "OR"
+        )
+        let powells = Place(
+            name: "Powell's City of Books",
+            latitude: 45.5231,
+            longitude: -122.6813,
+            category: "Bookstore",
+            city: "Portland",
+            state: "OR"
+        )
+        let pokPok = Place(
+            name: "Pok Pok",
+            latitude: 45.5049,
+            longitude: -122.6321,
+            category: "Restaurant",
+            city: "Portland",
+            state: "OR"
+        )
+        let hotel = Place(
+            name: "The State Hotel",
+            latitude: 47.6097,
+            longitude: -122.3405,
+            category: "Hotel",
+            city: "Seattle",
+            state: "WA"
+        )
+        let pikePlace = Place(
+            name: "Pike Place Market",
+            latitude: 47.6094,
+            longitude: -122.3417,
+            category: "Market",
+            city: "Seattle",
+            state: "WA"
+        )
+        let museum = Place(
+            name: "Seattle Art Museum",
+            latitude: 47.6073,
+            longitude: -122.3381,
+            category: "Museum",
+            city: "Seattle",
+            state: "WA"
+        )
+
+        for place in [home, stumptown, powells, pokPok, hotel, pikePlace, museum] {
+            context.insert(place)
+        }
+
+        // Enough recent overnight home visits to make the inferred home centroid deterministic.
+        for offset in [1, 2, 3, 4, 5, 10, 12, 14, 18, 21, 30, 45] {
+            addVisit(
+                place: home,
+                dayOffset: offset,
+                startHour: 23,
+                startMinute: 0,
+                durationMinutes: 7 * 60,
+                noteTitle: nil,
+                photoCount: 0,
+                now: now,
+                calendar: calendar,
+                context: context
+            )
+        }
+
+        // Portland: 3 contiguous away days, all >50 km from home.
+        addVisit(place: stumptown, dayOffset: 9, startHour: 9, startMinute: 15, durationMinutes: 45, noteTitle: "Morning coffee", photoCount: 1, now: now, calendar: calendar, context: context)
+        addVisit(place: powells, dayOffset: 9, startHour: 11, startMinute: 0, durationMinutes: 100, noteTitle: "Lost in the stacks", photoCount: 2, now: now, calendar: calendar, context: context)
+        addVisit(place: pokPok, dayOffset: 8, startHour: 18, startMinute: 30, durationMinutes: 95, noteTitle: "Dinner with wings", photoCount: 1, now: now, calendar: calendar, context: context)
+        addVisit(place: stumptown, dayOffset: 7, startHour: 10, startMinute: 20, durationMinutes: 35, noteTitle: nil, photoCount: 0, now: now, calendar: calendar, context: context)
+
+        // Seattle: 4 contiguous away days, useful for checking multiple trip cards.
+        addVisit(place: hotel, dayOffset: 27, startHour: 22, startMinute: 10, durationMinutes: 9 * 60, noteTitle: "Checked in late", photoCount: 1, now: now, calendar: calendar, context: context)
+        addVisit(place: pikePlace, dayOffset: 26, startHour: 9, startMinute: 45, durationMinutes: 120, noteTitle: "Market morning", photoCount: 2, now: now, calendar: calendar, context: context)
+        addVisit(place: museum, dayOffset: 25, startHour: 13, startMinute: 0, durationMinutes: 150, noteTitle: "Afternoon galleries", photoCount: 1, now: now, calendar: calendar, context: context)
+        addVisit(place: pikePlace, dayOffset: 24, startHour: 8, startMinute: 30, durationMinutes: 75, noteTitle: nil, photoCount: 0, now: now, calendar: calendar, context: context)
+    }
+
+    @MainActor
+    private static func addVisit(
+        place: Place,
+        dayOffset: Int,
+        startHour: Int,
+        startMinute: Int,
+        durationMinutes: Int,
+        noteTitle: String?,
+        photoCount: Int,
+        now: Date,
+        calendar: Calendar,
+        context: ModelContext
+    ) {
+        let day = calendar.date(byAdding: .day, value: -dayOffset, to: calendar.startOfDay(for: now)) ?? now
+        guard let arrival = calendar.date(bySettingHour: startHour, minute: startMinute, second: 0, of: day) else {
+            return
+        }
+        let visit = Visit(
+            arrivalDate: arrival,
+            departureDate: arrival.addingTimeInterval(TimeInterval(durationMinutes * 60)),
+            place: place
+        )
+        visit.confidence = .high
+        visit.medianAccuracyMeters = 12
+        context.insert(visit)
+
+        guard noteTitle != nil || photoCount > 0 else { return }
+        let photoIDs = (0..<photoCount).map { "debug-trip-\(visit.id.uuidString)-\($0)" }
+        let entry = JournalEntry(
+            title: noteTitle ?? "",
+            body: noteTitle.map { "Mock trip note: \($0)." } ?? "",
+            date: arrival.addingTimeInterval(10 * 60),
+            photoAssetIdentifiers: photoIDs
+        )
+        entry.place = place
+        entry.visit = visit
+        context.insert(entry)
     }
 
     /// Known mock place names used to detect legacy seeded data
     /// that was inserted before the `mockDataSeeded` flag existed.
-    private static let mockPlaceNames: Set<String> = Set(samplePlaces.map(\.name))
+    private static let mockTripPlaceNames: Set<String> = [
+        "Home",
+        "Stumptown Coffee Roasters",
+        "Powell's City of Books",
+        "Pok Pok",
+        "The State Hotel",
+        "Pike Place Market",
+        "Seattle Art Museum"
+    ]
+
+    private static let mockPlaceNames: Set<String> = Set(samplePlaces.map(\.name)).union(mockTripPlaceNames)
 
     /// Removes all mock-seeded data from the database.
     /// Call this in release builds to clean up leftover debug data.

--- a/PlaceNotes/Services/TripDetector.swift
+++ b/PlaceNotes/Services/TripDetector.swift
@@ -1,0 +1,179 @@
+import Foundation
+import CoreLocation
+
+struct Trip: Identifiable {
+    let id: String
+    let startDate: Date
+    let endDate: Date
+    let dayCount: Int
+    let distanceFromHomeKm: Double
+    let visits: [Visit]
+
+    var uniquePlaces: [Place] {
+        var seen = Set<UUID>()
+        var places: [Place] = []
+        for visit in visits {
+            guard let place = visit.place, !seen.contains(place.id) else { continue }
+            seen.insert(place.id)
+            places.append(place)
+        }
+        return places
+    }
+
+    var noteCount: Int {
+        visits.reduce(0) { $0 + $1.journalEntries.count }
+    }
+
+    var photoCount: Int {
+        visits.reduce(0) { total, visit in
+            total + visit.journalEntries.reduce(0) { $0 + $1.photoAssetIdentifiers.count }
+        }
+    }
+}
+
+/// Pure helpers for deriving travel spans from recorded visits.
+enum TripDetector {
+    struct HomeCentroid: Codable, Equatable {
+        let latitude: Double
+        let longitude: Double
+
+        var location: CLLocation {
+            CLLocation(latitude: latitude, longitude: longitude)
+        }
+    }
+
+    static func homeCentroid(
+        from visits: [Visit],
+        now: Date = Date(),
+        calendar: Calendar = .current,
+        lookbackDays: Int = 60
+    ) -> HomeCentroid? {
+        let cutoff = calendar.date(byAdding: .day, value: -lookbackDays, to: now) ?? .distantPast
+        var countsByPlaceID: [UUID: (place: Place, count: Int)] = [:]
+
+        for visit in visits {
+            guard visit.arrivalDate >= cutoff,
+                  visit.arrivalDate <= now,
+                  isNightVisit(visit, calendar: calendar),
+                  let place = visit.place else {
+                continue
+            }
+            var bucket = countsByPlaceID[place.id] ?? (place, 0)
+            bucket.count += 1
+            countsByPlaceID[place.id] = bucket
+        }
+
+        guard let home = countsByPlaceID.values.max(by: { lhs, rhs in
+            if lhs.count != rhs.count { return lhs.count < rhs.count }
+            return lhs.place.displayName > rhs.place.displayName
+        })?.place else {
+            return nil
+        }
+
+        return HomeCentroid(latitude: home.latitude, longitude: home.longitude)
+    }
+
+    static func detectTrips(
+        from visits: [Visit],
+        homeCentroid: HomeCentroid,
+        minDays: Int = 2,
+        minDistanceKm: Double = 50,
+        calendar: Calendar = .current
+    ) -> [Trip] {
+        let sortedVisits = visits
+            .filter { $0.place != nil }
+            .sorted { $0.arrivalDate < $1.arrivalDate }
+
+        guard !sortedVisits.isEmpty else { return [] }
+
+        var visitsByDay: [Date: [Visit]] = [:]
+        for visit in sortedVisits {
+            let day = calendar.startOfDay(for: visit.arrivalDate)
+            visitsByDay[day, default: []].append(visit)
+        }
+
+        let days = visitsByDay.keys.sorted()
+        var trips: [Trip] = []
+        var currentRun: [Date] = []
+
+        func finishRun() {
+            guard currentRun.count >= max(1, minDays) else {
+                currentRun.removeAll()
+                return
+            }
+            let runVisits = currentRun
+                .flatMap { visitsByDay[$0] ?? [] }
+                .sorted { $0.arrivalDate < $1.arrivalDate }
+            guard !runVisits.isEmpty else {
+                currentRun.removeAll()
+                return
+            }
+            trips.append(makeTrip(
+                from: runVisits,
+                dayCount: currentRun.count,
+                homeCentroid: homeCentroid
+            ))
+            currentRun.removeAll()
+        }
+
+        for day in days {
+            let dayVisits = visitsByDay[day] ?? []
+            let isAwayDay = !dayVisits.isEmpty && dayVisits.allSatisfy {
+                distanceFromHomeKm(for: $0, homeCentroid: homeCentroid) > minDistanceKm
+            }
+
+            guard isAwayDay else {
+                finishRun()
+                continue
+            }
+
+            if let previousDay = currentRun.last,
+               let expectedDay = calendar.date(byAdding: .day, value: 1, to: previousDay),
+               !calendar.isDate(day, inSameDayAs: expectedDay) {
+                finishRun()
+            }
+            currentRun.append(day)
+        }
+        finishRun()
+
+        return trips.sorted { $0.startDate > $1.startDate }
+    }
+
+    private static func isNightVisit(_ visit: Visit, calendar: Calendar) -> Bool {
+        let hour = calendar.component(.hour, from: visit.arrivalDate)
+        return hour >= 22 || hour < 6
+    }
+
+    private static func distanceFromHomeKm(for visit: Visit, homeCentroid: HomeCentroid) -> Double {
+        guard let place = visit.place else { return 0 }
+        let location = CLLocation(latitude: place.latitude, longitude: place.longitude)
+        return location.distance(from: homeCentroid.location) / 1_000
+    }
+
+    private static func makeTrip(
+        from visits: [Visit],
+        dayCount: Int,
+        homeCentroid: HomeCentroid
+    ) -> Trip {
+        let startDate = visits.first?.arrivalDate ?? .distantPast
+        let endDate = visits
+            .map { $0.departureDate ?? $0.arrivalDate }
+            .max() ?? startDate
+        let distances = visits.map { distanceFromHomeKm(for: $0, homeCentroid: homeCentroid) }
+        let averageDistance = distances.isEmpty ? 0 : distances.reduce(0, +) / Double(distances.count)
+        let id = [
+            "\(Int(startDate.timeIntervalSince1970))",
+            "\(Int(endDate.timeIntervalSince1970))",
+            "\(visits.count)"
+        ].joined(separator: "-")
+
+        return Trip(
+            id: id,
+            startDate: startDate,
+            endDate: endDate,
+            dayCount: dayCount,
+            distanceFromHomeKm: averageDistance,
+            visits: visits
+        )
+    }
+}

--- a/PlaceNotes/Views/LogbookView.swift
+++ b/PlaceNotes/Views/LogbookView.swift
@@ -11,39 +11,77 @@ struct LogbookView: View {
     @State private var showDeleteConfirmation = false
     @State private var refreshID = UUID()
     @State private var trajectoryDay: Date?
+    @State private var tripHomeCentroid: TripDetector.HomeCentroid?
 
-    private var groupedVisits: [(year: Int, months: [(month: Int, visits: [Visit])])] {
+    private var logbookVisits: [Visit] {
         let minStay = settings.minStayMinutes
-        let allVisits = places
+        return places
             .flatMap { $0.visits }
             .filter { $0.isQuickCapture || !$0.journalEntries.isEmpty || $0.durationMinutes >= minStay }
             .sorted { $0.arrivalDate > $1.arrivalDate }
+    }
 
-        let calendar = Calendar.current
-        var yearMonthMap: [Int: [Int: [Visit]]] = [:]
+    private var timelineSections: [LogbookTimelineSection] {
+        let visits = logbookVisits
+        guard !visits.isEmpty else { return [] }
 
-        for visit in allVisits {
-            let year = calendar.component(.year, from: visit.arrivalDate)
-            let month = calendar.component(.month, from: visit.arrivalDate)
-            yearMonthMap[year, default: [:]][month, default: []].append(visit)
+        let home = tripHomeCentroid ?? settings.cachedTripHomeCentroid
+        let trips = home.map {
+            TripDetector.detectTrips(
+                from: visits,
+                homeCentroid: $0,
+                minDays: settings.tripMinDays,
+                minDistanceKm: settings.tripMinDistanceKm
+            )
+        } ?? []
+        let tripVisitIDs = Set(trips.flatMap { $0.visits.map(\.id) })
+        let localVisits = visits.filter { !tripVisitIDs.contains($0.id) }
+
+        var sections = trips.map { trip in
+            LogbookTimelineSection(
+                id: "trip-\(trip.id)",
+                title: "Trip · \(Self.tripDateRange(for: trip))",
+                icon: "airplane",
+                latestDate: trip.endDate,
+                kind: .trip(trip)
+            )
         }
 
-        return yearMonthMap
-            .sorted { $0.key > $1.key }
-            .map { year, months in
-                let sortedMonths = months
-                    .sorted { $0.key > $1.key }
-                    .map { month, visits in
-                        (month: month, visits: visits.sorted { $0.arrivalDate > $1.arrivalDate })
-                    }
-                return (year: year, months: sortedMonths)
-            }
+        let thisWeekInterval = Calendar.current.dateInterval(of: .weekOfYear, for: Date())
+        let thisWeek = localVisits.filter { visit in
+            thisWeekInterval?.contains(visit.arrivalDate) == true
+        }
+        let earlier = localVisits.filter { visit in
+            thisWeekInterval?.contains(visit.arrivalDate) != true
+        }
+
+        if !thisWeek.isEmpty {
+            sections.append(LogbookTimelineSection(
+                id: "local-this-week",
+                title: "This week",
+                icon: "calendar",
+                latestDate: thisWeek.first?.arrivalDate ?? .distantPast,
+                kind: .local(visits: thisWeek)
+            ))
+        }
+
+        if !earlier.isEmpty {
+            sections.append(LogbookTimelineSection(
+                id: "local-earlier",
+                title: "Earlier",
+                icon: "calendar",
+                latestDate: earlier.first?.arrivalDate ?? .distantPast,
+                kind: .local(visits: earlier)
+            ))
+        }
+
+        return sections.sorted { $0.latestDate > $1.latestDate }
     }
 
     var body: some View {
         NavigationStack {
             Group {
-                if groupedVisits.isEmpty {
+                if logbookVisits.isEmpty {
                     ContentUnavailableView(
                         "No Visits Yet",
                         systemImage: "book.closed",
@@ -51,36 +89,58 @@ struct LogbookView: View {
                     )
                 } else {
                     List {
-                        ForEach(groupedVisits, id: \.year) { yearGroup in
+                        ForEach(timelineSections) { section in
                             Section {
-                                ForEach(yearGroup.months, id: \.month) { monthGroup in
-                                    MonthSection(
-                                        year: yearGroup.year,
-                                        month: monthGroup.month,
-                                        visits: monthGroup.visits,
-                                        onPickAlternative: { visit in
-                                            visitForAlternatives = visit
-                                        },
-                                        onDelete: { visit in
-                                            visitToDelete = visit
-                                            showDeleteConfirmation = true
-                                        },
-                                        onShowTrajectory: { arrival in
-                                            trajectoryDay = Calendar.current.startOfDay(for: arrival)
+                                switch section.kind {
+                                case .trip(let trip):
+                                    TripHeroCard(trip: trip)
+                                        .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
+
+                                case .local(let visits):
+                                    ForEach(Array(visits.enumerated()), id: \.element.id) { index, visit in
+                                        if let place = visit.place {
+                                            NavigationLink {
+                                                PlaceDetailView(place: place)
+                                            } label: {
+                                                LocalVisitCompactRow(
+                                                    visit: visit,
+                                                    place: place,
+                                                    nextSameDayArrival: nextSameDayArrival(for: index, in: visits)
+                                                ) {
+                                                    visitForAlternatives = visit
+                                                }
+                                            }
+                                            .buttonStyle(.plain)
+                                            .swipeActions(edge: .leading, allowsFullSwipe: false) {
+                                                Button {
+                                                    trajectoryDay = Calendar.current.startOfDay(for: visit.arrivalDate)
+                                                } label: {
+                                                    Label("Map", systemImage: "map")
+                                                }
+                                                .tint(.blue)
+                                            }
+                                            .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                                                Button {
+                                                    visitToDelete = visit
+                                                    showDeleteConfirmation = true
+                                                } label: {
+                                                    Label("Delete", systemImage: "trash")
+                                                }
+                                                .tint(.red)
+                                            }
                                         }
-                                    )
+                                    }
                                 }
                             } header: {
-                                Text(String(yearGroup.year))
-                                    .font(.title2.bold())
-                                    .foregroundStyle(.primary)
-                                    .textCase(nil)
+                                LogbookSectionHeader(icon: section.icon, title: section.title)
                             }
                         }
                     }
                     .listStyle(.insetGrouped)
                     .id(refreshID)
+                    .onAppear(perform: refreshTripHomeCentroid)
                     .refreshable {
+                        refreshTripHomeCentroid()
                         refreshID = UUID()
                     }
                 }
@@ -114,6 +174,226 @@ struct LogbookView: View {
                 Text("This visit will be permanently deleted.")
             }
         }
+    }
+
+    private func refreshTripHomeCentroid() {
+        let allVisits = places.flatMap { $0.visits }
+        if let centroid = TripDetector.homeCentroid(from: allVisits) {
+            settings.cachedTripHomeCentroid = centroid
+            tripHomeCentroid = centroid
+        } else {
+            tripHomeCentroid = settings.cachedTripHomeCentroid
+        }
+    }
+
+    private func nextSameDayArrival(for index: Int, in visits: [Visit]) -> Date? {
+        guard index > 0 else { return nil }
+        let next = visits[index - 1]
+        let current = visits[index]
+        return Calendar.current.isDate(next.arrivalDate, inSameDayAs: current.arrivalDate) ? next.arrivalDate : nil
+    }
+
+    private static func tripDateRange(for trip: Trip) -> String {
+        let calendar = Calendar.current
+        let start = trip.startDate
+        let end = trip.endDate
+        let formatter = DateFormatter()
+
+        if calendar.component(.year, from: start) == calendar.component(.year, from: end) {
+            formatter.dateFormat = "MMM d"
+            let startText = formatter.string(from: start)
+            formatter.dateFormat = calendar.component(.month, from: start) == calendar.component(.month, from: end) ? "d" : "MMM d"
+            return "\(startText) - \(formatter.string(from: end))"
+        }
+
+        formatter.dateFormat = "MMM d, yyyy"
+        return "\(formatter.string(from: start)) - \(formatter.string(from: end))"
+    }
+}
+
+private struct LogbookTimelineSection: Identifiable {
+    let id: String
+    let title: String
+    let icon: String
+    let latestDate: Date
+    let kind: LogbookTimelineSectionKind
+}
+
+private enum LogbookTimelineSectionKind {
+    case trip(Trip)
+    case local(visits: [Visit])
+}
+
+private struct LogbookSectionHeader: View {
+    let icon: String
+    let title: String
+
+    var body: some View {
+        Label(title, systemImage: icon)
+            .font(.headline)
+            .foregroundStyle(.primary)
+            .textCase(nil)
+    }
+}
+
+private struct TripHeroCard: View {
+    let trip: Trip
+
+    private var title: String {
+        if let city = trip.uniquePlaces.compactMap(\.city).first {
+            return "Trip to \(city)"
+        }
+        return trip.uniquePlaces.first?.displayName ?? "Trip"
+    }
+
+    private var subtitle: String {
+        let days = trip.dayCount == 1 ? "1 day" : "\(trip.dayCount) days"
+        return "\(days) · \(Int(trip.distanceFromHomeKm.rounded())) km from home"
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(alignment: .top, spacing: 12) {
+                Image(systemName: "airplane.circle.fill")
+                    .font(.system(size: 32))
+                    .foregroundStyle(Color.accentColor)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(title)
+                        .font(.title3.weight(.semibold))
+                    Text(subtitle)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+            }
+
+            PlacePillRow(places: trip.uniquePlaces)
+
+            HStack(spacing: 10) {
+                TripStat(value: "\(trip.uniquePlaces.count)", label: "Places", icon: "mappin.and.ellipse")
+                TripStat(value: "\(trip.noteCount)", label: "Notes", icon: "note.text")
+                TripStat(value: "\(trip.photoCount)", label: "Photos", icon: "camera")
+            }
+        }
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(Color.accentColor.opacity(0.10))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(Color.accentColor.opacity(0.20), lineWidth: 1)
+        )
+        .padding(.vertical, 2)
+    }
+}
+
+private struct PlacePillRow: View {
+    let places: [Place]
+
+    var body: some View {
+        let visiblePlaces = Array(places.prefix(3))
+        HStack(spacing: 8) {
+            ForEach(visiblePlaces, id: \.id) { place in
+                HStack(spacing: 4) {
+                    Text(place.emoji)
+                    Text(place.displayName)
+                        .lineLimit(1)
+                }
+                .font(.caption.weight(.medium))
+                .padding(.horizontal, 9)
+                .padding(.vertical, 5)
+                .background(Capsule().fill(Color(.secondarySystemGroupedBackground)))
+            }
+
+            if places.count > visiblePlaces.count {
+                Text("+\(places.count - visiblePlaces.count) more")
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 9)
+                    .padding(.vertical, 5)
+                    .background(Capsule().fill(Color(.secondarySystemGroupedBackground)))
+            }
+        }
+    }
+}
+
+private struct TripStat: View {
+    let value: String
+    let label: String
+    let icon: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Image(systemName: icon)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.headline)
+            Text(label)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+private struct LocalVisitCompactRow: View {
+    let visit: Visit
+    let place: Place
+    let nextSameDayArrival: Date?
+    var onPickAlternative: (() -> Void)?
+
+    private var relativeTimestamp: String {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter.localizedString(for: visit.arrivalDate, relativeTo: Date())
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 12) {
+                Text(place.emoji)
+                    .font(.title3)
+                    .frame(width: 28)
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(place.displayName)
+                        .font(.body.weight(.medium))
+                        .lineLimit(1)
+                    Text(relativeTimestamp)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                Text(visit.effectiveDurationString(cappedAt: nextSameDayArrival))
+                    .font(.caption.bold())
+                    .foregroundStyle(Color.accentColor)
+            }
+
+            if !visit.alternativePlaces.isEmpty {
+                Button {
+                    onPickAlternative?()
+                } label: {
+                    if visit.placeConfirmed {
+                        Label("Place confirmed", systemImage: "checkmark.circle")
+                            .font(.caption2)
+                            .foregroundStyle(.tertiary)
+                    } else {
+                        Label("Not the right place?", systemImage: "arrow.triangle.swap")
+                            .font(.caption2)
+                            .foregroundStyle(.orange)
+                    }
+                }
+                .buttonStyle(.plain)
+                .padding(.leading, 40)
+            }
+        }
+        .padding(.vertical, 4)
     }
 }
 
@@ -292,216 +572,3 @@ private struct AlternativePlacePicker: View {
         dismiss()
     }
 }
-
-private struct MonthSection: View {
-    let year: Int
-    let month: Int
-    let visits: [Visit]
-    var onPickAlternative: ((Visit) -> Void)?
-    var onDelete: ((Visit) -> Void)?
-    var onShowTrajectory: ((Date) -> Void)?
-
-    private var monthName: String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "MMMM"
-        var components = DateComponents()
-        components.month = month
-        let date = Calendar.current.date(from: components) ?? Date()
-        return formatter.string(from: date)
-    }
-
-    private var uniquePlaceCount: Int {
-        Set(visits.compactMap { $0.place?.id }).count
-    }
-
-    private var totalMinutes: Int {
-        visits.reduce(0) { $0 + $1.durationMinutes }
-    }
-
-    var body: some View {
-        DisclosureGroup {
-            ForEach(Array(visits.enumerated()), id: \.element.id) { index, visit in
-                if let place = visit.place {
-                    let nextSameDay: Date? = {
-                        guard index > 0 else { return nil }
-                        let next = visits[index - 1]
-                        return Calendar.current.isDate(next.arrivalDate, inSameDayAs: visit.arrivalDate) ? next.arrivalDate : nil
-                    }()
-                    NavigationLink {
-                        PlaceDetailView(place: place)
-                    } label: {
-                        LogbookVisitRow(visit: visit, place: place, nextSameDayArrival: nextSameDay) {
-                            onPickAlternative?(visit)
-                        }
-                    }
-                    .buttonStyle(.plain)
-                    .swipeActions(edge: .leading, allowsFullSwipe: false) {
-                        Button {
-                            onShowTrajectory?(visit.arrivalDate)
-                        } label: {
-                            Label("Map", systemImage: "map")
-                        }
-                        .tint(.blue)
-                    }
-                    .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-                        Button {
-                            onDelete?(visit)
-                        } label: {
-                            Label("Delete", systemImage: "trash")
-                        }
-                        .tint(.red)
-                    }
-                }
-            }
-        } label: {
-            HStack {
-                Text(monthName)
-                    .font(.headline)
-                Spacer()
-                VStack(alignment: .trailing, spacing: 2) {
-                    Text("\(visits.count) visits")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                    Text("\(uniquePlaceCount) places")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-            }
-        }
-    }
-}
-
-private struct LogbookVisitRow: View {
-    let visit: Visit
-    let place: Place
-    let nextSameDayArrival: Date?
-    var onPickAlternative: (() -> Void)?
-
-    private var dateString: String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "MMM d, h:mm a"
-        return formatter.string(from: visit.arrivalDate)
-    }
-
-    private var hasPhoto: Bool {
-        let start = visit.arrivalDate.addingTimeInterval(-5 * 60)
-        let end = (visit.departureDate ?? visit.arrivalDate).addingTimeInterval(5 * 60)
-        return place.journalEntries.contains { entry in
-            !entry.photoAssetIdentifiers.isEmpty &&
-            entry.date >= start &&
-            entry.date <= end
-        }
-    }
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            HStack(spacing: 12) {
-                if place.customEmoji != nil {
-                    Text(place.emoji)
-                        .font(.title3)
-                        .frame(width: 28)
-                } else {
-                    Image(systemName: PlaceCategorizer.icon(for: place.category))
-                        .font(.title3)
-                        .foregroundStyle(Color.accentColor)
-                        .frame(width: 28)
-                }
-
-                VStack(alignment: .leading, spacing: 3) {
-                    HStack(spacing: 6) {
-                        Text(place.displayName)
-                            .font(.body.weight(.medium))
-                        if hasPhoto {
-                            Image(systemName: "camera.fill")
-                                .font(.caption2)
-                                .foregroundStyle(.secondary)
-                        }
-                    }
-
-                    HStack(spacing: 8) {
-                        if let category = place.category, !category.isEmpty {
-                            Text(category)
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        }
-                        if let city = place.city {
-                            Text(city)
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        }
-                    }
-                }
-
-                Spacer()
-
-                VStack(alignment: .trailing, spacing: 3) {
-                    Text(dateString)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                    Text(visit.effectiveDurationString(cappedAt: nextSameDayArrival))
-                        .font(.caption.bold())
-                        .foregroundStyle(Color.accentColor)
-                    #if DEBUG
-                    ConfidenceBadge(confidence: visit.confidence, accuracy: visit.medianAccuracyMeters)
-                    #endif
-                }
-            }
-
-            if !visit.alternativePlaces.isEmpty {
-                Button {
-                    onPickAlternative?()
-                } label: {
-                    if visit.placeConfirmed {
-                        Label("Place confirmed", systemImage: "checkmark.circle")
-                            .font(.caption2)
-                            .foregroundStyle(.tertiary)
-                    } else {
-                        Label("Not the right place?", systemImage: "arrow.triangle.swap")
-                            .font(.caption2)
-                            .foregroundStyle(.orange)
-                    }
-                }
-                .buttonStyle(.plain)
-                .padding(.leading, 40)
-            }
-        }
-        .padding(.vertical, 2)
-    }
-}
-
-// MARK: - Debug Confidence Badge
-
-#if DEBUG
-private struct ConfidenceBadge: View {
-    let confidence: PlaceConfidence
-    let accuracy: Double?
-
-    private var color: Color {
-        switch confidence {
-        case .high: return .green
-        case .medium: return .orange
-        case .low: return .red
-        }
-    }
-
-    private var icon: String {
-        switch confidence {
-        case .high: return "checkmark.seal.fill"
-        case .medium: return "questionmark.diamond.fill"
-        case .low: return "exclamationmark.triangle.fill"
-        }
-    }
-
-    var body: some View {
-        HStack(spacing: 3) {
-            Image(systemName: icon)
-            Text(confidence.rawValue)
-            if let acc = accuracy {
-                Text("(\(Int(acc))m)")
-            }
-        }
-        .font(.caption2)
-        .foregroundStyle(color)
-    }
-}
-#endif

--- a/PlaceNotes/Views/SettingsView.swift
+++ b/PlaceNotes/Views/SettingsView.swift
@@ -96,6 +96,27 @@ struct SettingsView: View {
                 }
 
                 Section {
+                    Stepper(value: $settings.tripMinDays, in: 2...14) {
+                        LabeledContent("Minimum Length", value: "\(settings.tripMinDays) days")
+                    }
+
+                    Stepper(value: $settings.tripMinDistanceKm, in: 10...500, step: 10) {
+                        LabeledContent("Distance From Home", value: "\(Int(settings.tripMinDistanceKm)) km")
+                    }
+
+                    if let home = settings.cachedTripHomeCentroid {
+                        LabeledContent(
+                            "Cached Home",
+                            value: "\(home.latitude.formatted(.number.precision(.fractionLength(4)))), \(home.longitude.formatted(.number.precision(.fractionLength(4))))"
+                        )
+                    }
+                } header: {
+                    Text("Trip Clustering")
+                } footer: {
+                    Text("Trips are derived from visits that span multiple days away from your inferred overnight home location.")
+                }
+
+                Section {
                     ForEach(Array(settings.milestoneVisitCounts), id: \.self) { count in
                         HStack {
                             Image(systemName: "bell.fill")

--- a/PlaceNotesTests/TripDetectorTests.swift
+++ b/PlaceNotesTests/TripDetectorTests.swift
@@ -1,0 +1,175 @@
+import XCTest
+import SwiftData
+@testable import PlaceNotes
+
+@MainActor
+final class TripDetectorTests: XCTestCase {
+    private var calendar: Calendar!
+
+    override func setUp() {
+        super.setUp()
+        calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+    }
+
+    func testHomeCentroidUsesMostVisitedNightPlaceInLookbackWindow() {
+        let context = try! makeContext()
+        let now = date(year: 2026, month: 5, day: 20, hour: 12)
+        let home = place("Home", lat: 37.7749, lon: -122.4194, in: context)
+        let hotel = place("Hotel", lat: 34.0522, lon: -118.2437, in: context)
+        let visits = [
+            visit(home, year: 2026, month: 5, day: 15, hour: 23, in: context),
+            visit(home, year: 2026, month: 5, day: 16, hour: 1, in: context),
+            visit(hotel, year: 2026, month: 5, day: 17, hour: 23, in: context),
+            visit(home, year: 2026, month: 2, day: 1, hour: 23, in: context)
+        ]
+
+        let centroid = TripDetector.homeCentroid(
+            from: visits,
+            now: now,
+            calendar: calendar,
+            lookbackDays: 60
+        )
+
+        XCTAssertEqual(centroid?.latitude, home.latitude)
+        XCTAssertEqual(centroid?.longitude, home.longitude)
+    }
+
+    func testHomeCentroidIgnoresDaytimeVisits() {
+        let context = try! makeContext()
+        let now = date(year: 2026, month: 5, day: 20, hour: 12)
+        let home = place("Home", lat: 37.7749, lon: -122.4194, in: context)
+        let office = place("Office", lat: 37.7890, lon: -122.4010, in: context)
+        let visits = [
+            visit(office, year: 2026, month: 5, day: 15, hour: 10, in: context),
+            visit(office, year: 2026, month: 5, day: 16, hour: 11, in: context),
+            visit(home, year: 2026, month: 5, day: 17, hour: 23, in: context)
+        ]
+
+        let centroid = TripDetector.homeCentroid(
+            from: visits,
+            now: now,
+            calendar: calendar,
+            lookbackDays: 60
+        )
+
+        XCTAssertEqual(centroid?.latitude, home.latitude)
+        XCTAssertEqual(centroid?.longitude, home.longitude)
+    }
+
+    func testDetectTripsGroupsConsecutiveAwayDays() {
+        let context = try! makeContext()
+        let home = place("Home", lat: 37.7749, lon: -122.4194, in: context)
+        let cafe = place("Stumptown", lat: 45.5228, lon: -122.6819, city: "Portland", in: context)
+        let dinner = place("Pok Pok", lat: 45.5049, lon: -122.6321, city: "Portland", in: context)
+        let visits = [
+            visit(home, year: 2026, month: 5, day: 7, hour: 22, in: context),
+            visit(cafe, year: 2026, month: 5, day: 8, hour: 9, in: context),
+            visit(dinner, year: 2026, month: 5, day: 9, hour: 19, in: context),
+            visit(cafe, year: 2026, month: 5, day: 10, hour: 10, in: context)
+        ]
+
+        let trips = TripDetector.detectTrips(
+            from: visits,
+            homeCentroid: TripDetector.HomeCentroid(latitude: home.latitude, longitude: home.longitude),
+            minDays: 2,
+            minDistanceKm: 50,
+            calendar: calendar
+        )
+
+        XCTAssertEqual(trips.count, 1)
+        XCTAssertEqual(trips[0].dayCount, 3)
+        XCTAssertEqual(trips[0].visits.map { $0.place?.displayName }, ["Stumptown", "Pok Pok", "Stumptown"])
+        XCTAssertGreaterThan(trips[0].distanceFromHomeKm, 800)
+    }
+
+    func testDetectTripsBreaksWhenAnyVisitOnDayIsLocal() {
+        let context = try! makeContext()
+        let home = place("Home", lat: 37.7749, lon: -122.4194, in: context)
+        let away = place("Away", lat: 34.0522, lon: -118.2437, in: context)
+        let visits = [
+            visit(away, year: 2026, month: 5, day: 8, hour: 9, in: context),
+            visit(home, year: 2026, month: 5, day: 9, hour: 22, in: context),
+            visit(away, year: 2026, month: 5, day: 10, hour: 9, in: context)
+        ]
+
+        let trips = TripDetector.detectTrips(
+            from: visits,
+            homeCentroid: TripDetector.HomeCentroid(latitude: home.latitude, longitude: home.longitude),
+            minDays: 2,
+            minDistanceKm: 50,
+            calendar: calendar
+        )
+
+        XCTAssertTrue(trips.isEmpty)
+    }
+
+    func testDetectTripsRequiresMinimumCalendarDays() {
+        let context = try! makeContext()
+        let home = place("Home", lat: 37.7749, lon: -122.4194, in: context)
+        let away = place("Away", lat: 34.0522, lon: -118.2437, in: context)
+        let visits = [
+            visit(away, year: 2026, month: 5, day: 8, hour: 9, in: context),
+            visit(away, year: 2026, month: 5, day: 8, hour: 19, in: context)
+        ]
+
+        let trips = TripDetector.detectTrips(
+            from: visits,
+            homeCentroid: TripDetector.HomeCentroid(latitude: home.latitude, longitude: home.longitude),
+            minDays: 2,
+            minDistanceKm: 50,
+            calendar: calendar
+        )
+
+        XCTAssertTrue(trips.isEmpty)
+    }
+
+    private func makeContext() throws -> ModelContext {
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        let container = try ModelContainer(
+            for: Place.self, Visit.self, JournalEntry.self, CustomCategory.self, RawLocationSample.self,
+            configurations: config
+        )
+        return ModelContext(container)
+    }
+
+    private func place(
+        _ name: String,
+        lat: Double,
+        lon: Double,
+        city: String? = nil,
+        in context: ModelContext
+    ) -> Place {
+        let place = Place(name: name, latitude: lat, longitude: lon, city: city)
+        context.insert(place)
+        return place
+    }
+
+    private func visit(
+        _ place: Place,
+        year: Int,
+        month: Int,
+        day: Int,
+        hour: Int,
+        in context: ModelContext
+    ) -> Visit {
+        let arrival = date(year: year, month: month, day: day, hour: hour)
+        let visit = Visit(
+            arrivalDate: arrival,
+            departureDate: arrival.addingTimeInterval(60 * 60),
+            place: place
+        )
+        context.insert(visit)
+        return visit
+    }
+
+    private func date(year: Int, month: Int, day: Int, hour: Int) -> Date {
+        calendar.date(from: DateComponents(
+            timeZone: calendar.timeZone,
+            year: year,
+            month: month,
+            day: day,
+            hour: hour
+        ))!
+    }
+}


### PR DESCRIPTION
## Summary
- add pure TripDetector support for inferred home centroid and multi-day away visit spans
- add configurable trip thresholds and cached home coordinates to app settings
- rework Logbook into trip hero sections plus local This week/Earlier compact rows
- add focused TripDetector unit tests
- seed DEBUG builds with deterministic Portland and Seattle trip clusters for simulator review

## Trip detection logic
- Trips are derived entirely from existing Visit data; Trip is an in-memory value type and is not persisted as a SwiftData model.
- On logbook appear/refresh, the app recomputes the home centroid from all visits and stores the latest inferred coordinate in AppSettings as a cache.
- Home centroid inference looks at the last 60 days of visits, keeps only overnight visits whose arrival hour is 22:00 through 05:59 local time, then chooses the most-visited Place in that filtered set. The selected place's latitude/longitude becomes the home centroid.
- Trip detection takes the visible logbook visits, the cached/inferred home centroid, tripMinDays, and tripMinDistanceKm. Defaults are 2 days and 50 km.
- Visits are grouped by local calendar day. A day counts as an away day only when every visit with a place on that day is farther than tripMinDistanceKm from the home centroid. Any local visit on that calendar day breaks the away run.
- Consecutive away days are accumulated into a run. A run becomes a Trip only when it spans at least tripMinDays calendar days. One-day away clusters remain local visits.
- Trip start/end dates come from the first arrival and latest departure/arrival in the run. Distance-from-home shown on the card is the average distance of the trip visits from the home centroid.
- After trips are detected, Logbook partitions out visits whose IDs are part of any Trip. Remaining visits render under local sections: This week when the arrival falls inside the current calendar week interval, otherwise Earlier.

## Debug seed data
- DEBUG mock data now reseeds at version 4. Existing v3 simulator seed data is purged and replaced on launch.
- The seed includes repeated overnight Home visits so the inferred home centroid is deterministic.
- Random local mock visits avoid the deterministic trip dates so they do not break the away-day runs.
- Seeded examples include a 3-day Portland trip and a 4-day Seattle trip, with a few mock notes/photo identifiers so card stats are visible.

## Validation
- xcodegen generate
- xcodebuild test -scheme PlaceNotes-Debug -destination 'id=40247635-F520-43F4-8BBF-A9180970C369' -only-testing:PlaceNotesTests/TripDetectorTests

## Notes
- Full test suite currently has unrelated existing SwiftData instability/failures around duplicate registration plus QuickCaptureServiceTests.testDeletingVisitCascadeDeletesLinkedJournalEntry and VisitTests.testDurationWithoutDepartureUsesNow.