### PR TITLE
Reject GPS teleport outliers from day trajectory

### DIFF
--- a/PlaceNotes/Services/TrajectoryBuilder.swift
+++ b/PlaceNotes/Services/TrajectoryBuilder.swift
@@ -91,6 +91,42 @@ enum TrajectoryBuilder {
         return zip(points, keep).compactMap { $0.1 ? $0.0 : nil }
     }
 
+    /// Drop physically-impossible GPS fixes ("teleports") from a
+    /// chronologically-sorted run of samples. A fix is rejected when its
+    /// implied speed from the last *kept* sample exceeds
+    /// `maxSpeedMetersPerSecond`. Anchoring on the last kept sample — rather
+    /// than the immediate predecessor — means a lone outlier is discarded
+    /// without also dropping the valid fix that follows it.
+    ///
+    /// The device's self-reported `horizontalAccuracy` can stay small on a
+    /// grossly wrong fix, so the accuracy gate upstream never catches these;
+    /// the inter-sample speed is the only reliable signal.
+    static func rejectOutliers(
+        _ samples: [RawLocationSample],
+        maxSpeedMetersPerSecond: Double
+    ) -> [RawLocationSample] {
+        guard let first = samples.first else { return [] }
+
+        var kept: [RawLocationSample] = [first]
+        var anchor = first
+
+        for i in 1..<samples.count {
+            let candidate = samples[i]
+            let dt = candidate.timestamp.timeIntervalSince(anchor.timestamp)
+            let anchorLoc = CLLocation(latitude: anchor.latitude, longitude: anchor.longitude)
+            let candidateLoc = CLLocation(latitude: candidate.latitude, longitude: candidate.longitude)
+            let distance = anchorLoc.distance(from: candidateLoc)
+            // dt <= 0 means duplicate/zero-interval timestamps; a co-located
+            // fix is fine, but any spatial jump in zero time is a teleport.
+            let impliedSpeed = dt > 0 ? distance / dt : (distance == 0 ? 0 : .infinity)
+            if impliedSpeed <= maxSpeedMetersPerSecond {
+                kept.append(candidate)
+                anchor = candidate
+            }
+        }
+        return kept
+    }
+
     static func computeStats(
         segments: [TrajectorySegment],
         rawSampleCount: Int,
@@ -124,10 +160,12 @@ enum TrajectoryBuilder {
         samples: [RawLocationSample],
         day: Date,
         epsilonMeters: Double = 5,
-        maxGapSeconds: TimeInterval = 600
+        maxGapSeconds: TimeInterval = 600,
+        maxSpeedMetersPerSecond: Double = 50
     ) -> [TrajectorySegment] {
         let dayStart = Calendar.current.startOfDay(for: day)
-        let raw = splitIntoSegments(samples, maxGapSeconds: maxGapSeconds)
+        let cleaned = rejectOutliers(samples, maxSpeedMetersPerSecond: maxSpeedMetersPerSecond)
+        let raw = splitIntoSegments(cleaned, maxGapSeconds: maxGapSeconds)
 
         return raw.compactMap { rawSegment in
             let points = convertToPoints(rawSegment, dayStart: dayStart)

--- a/PlaceNotes/Views/DayTrajectoryView.swift
+++ b/PlaceNotes/Views/DayTrajectoryView.swift
@@ -184,7 +184,7 @@ struct DayTrajectoryView: View {
             predicate: #Predicate {
                 $0.timestamp >= dayStart
                 && $0.timestamp < dayEnd
-                && $0.filterStatus != "rejected-accuracy"
+                && $0.filterStatus == "accepted"
             },
             sortBy: [SortDescriptor(\.timestamp)]
         )

--- a/PlaceNotes/Views/DayTrajectoryView.swift
+++ b/PlaceNotes/Views/DayTrajectoryView.swift
@@ -37,13 +37,10 @@ struct DayTrajectoryView: View {
                 TrajectoryPolyline(segments: segments, colorMode: .time)
 
                 if showAllSamples {
-                    ForEach(rawSamples, id: \.id) { sample in
+                    ForEach(segments.flatMap(\.points), id: \.timestamp) { point in
                         Annotation(
                             "",
-                            coordinate: CLLocationCoordinate2D(
-                                latitude: sample.latitude,
-                                longitude: sample.longitude
-                            )
+                            coordinate: point.coordinate
                         ) {
                             Circle()
                                 .fill(Color.blue.opacity(0.7))

--- a/PlaceNotesTests/TrajectoryBuilderTests.swift
+++ b/PlaceNotesTests/TrajectoryBuilderTests.swift
@@ -87,6 +87,75 @@ final class TrajectoryBuilderTests: XCTestCase {
         XCTAssertEqual(segments[2].count, 2)
     }
 
+    // MARK: - rejectOutliers (teleport guard)
+
+    func testRejectOutliersEmptyReturnsEmpty() {
+        let result = TrajectoryBuilder.rejectOutliers([], maxSpeedMetersPerSecond: 50)
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testRejectOutliersSingleSampleKept() {
+        let s = [sample(offsetSeconds: 0)]
+        let result = TrajectoryBuilder.rejectOutliers(s, maxSpeedMetersPerSecond: 50)
+        XCTAssertEqual(result.count, 1)
+    }
+
+    func testRejectOutliersSlowWalkAllKept() {
+        // ~0.0001 deg lat ≈ 11 m per 30 s ≈ 0.37 m/s — well under the bound.
+        let s = (0..<5).map { i in
+            sample(offsetSeconds: Double(i) * 30, lat: 37.78 + Double(i) * 0.0001, lon: -122.41)
+        }
+        let result = TrajectoryBuilder.rejectOutliers(s, maxSpeedMetersPerSecond: 50)
+        XCTAssertEqual(result.count, 5)
+    }
+
+    func testRejectOutliersDropsTeleportAndKeepsNeighbor() {
+        // Two valid co-located fixes 120 s apart, with a ~24 km jump in between
+        // (offset 60 s → implied speed far above 50 m/s).
+        let s = [
+            sample(offsetSeconds: 0, lat: 37.78, lon: -122.41),
+            sample(offsetSeconds: 60, lat: 38.00, lon: -122.41),  // teleport
+            sample(offsetSeconds: 120, lat: 37.78, lon: -122.41)
+        ]
+        let result = TrajectoryBuilder.rejectOutliers(s, maxSpeedMetersPerSecond: 50)
+        XCTAssertEqual(result.count, 2)
+        XCTAssertEqual(result[0].latitude, 37.78, accuracy: 1e-9)
+        // Anchor stayed at the first fix, so the post-teleport fix is kept.
+        XCTAssertEqual(result[1].latitude, 37.78, accuracy: 1e-9)
+        XCTAssertEqual(result[1].timestamp, s[2].timestamp)
+    }
+
+    func testRejectOutliersDropsRunOfTeleports() {
+        let s = [
+            sample(offsetSeconds: 0, lat: 37.78, lon: -122.41),
+            sample(offsetSeconds: 30, lat: 38.50, lon: -122.41),  // teleport
+            sample(offsetSeconds: 60, lat: 38.60, lon: -122.41),  // teleport vs anchor
+            sample(offsetSeconds: 90, lat: 37.78, lon: -122.41)
+        ]
+        let result = TrajectoryBuilder.rejectOutliers(s, maxSpeedMetersPerSecond: 50)
+        XCTAssertEqual(result.count, 2)
+        XCTAssertEqual(result[0].timestamp, s[0].timestamp)
+        XCTAssertEqual(result[1].timestamp, s[3].timestamp)
+    }
+
+    func testRejectOutliersZeroIntervalSpatialJumpRejected() {
+        let s = [
+            sample(offsetSeconds: 0, lat: 37.78, lon: -122.41),
+            sample(offsetSeconds: 0, lat: 38.00, lon: -122.41)  // same instant, far away
+        ]
+        let result = TrajectoryBuilder.rejectOutliers(s, maxSpeedMetersPerSecond: 50)
+        XCTAssertEqual(result.count, 1)
+    }
+
+    func testRejectOutliersPlausibleDrivingKept() {
+        // ~0.0001 deg lat ≈ 11 m per 0.3 s ≈ 37 m/s (highway) — under 50.
+        let s = (0..<4).map { i in
+            sample(offsetSeconds: Double(i) * 0.3, lat: 37.78 + Double(i) * 0.0001, lon: -122.41)
+        }
+        let result = TrajectoryBuilder.rejectOutliers(s, maxSpeedMetersPerSecond: 50)
+        XCTAssertEqual(result.count, 4)
+    }
+
     // MARK: - simplify (Douglas–Peucker)
 
     private func point(lat: Double, lon: Double) -> TrajectoryPoint {


### PR DESCRIPTION
Add a pre-pass to TrajectoryBuilder.build that drops physically-impossible
fixes whose implied speed from the last kept sample exceeds 50 m/s. Grossly
wrong fixes can still report a small horizontalAccuracy, so the upstream
accuracy gate never catches them; the inter-sample speed is the only reliable
signal. This removes the radiating "spoke" lines and corrects the inflated
distance total. Render the debug sample dots from the cleaned trajectory so
outlier points disappear there too.

https://claude.ai/code/session_0116rQ5h48MTckNv4UPNJxRQ