### PR TITLE
Move totalVisits calculation to PlaceRanking model

### DIFF
--- a/PlaceNotes/Services/ReportGenerator.swift
+++ b/PlaceNotes/Services/ReportGenerator.swift
@@ -6,6 +6,10 @@ struct PlaceRanking: Identifiable {
     let place: Place
     let qualifiedStays: Int
     let totalMinutes: Int
+
+    /// All recorded visits, regardless of duration or recency — the count the
+    /// place detail card, header, and charts display.
+    var totalVisits: Int { place.visits.count }
 }
 
 struct MonthlyReport: Identifiable {

--- a/PlaceNotes/Views/FrequentPlacesMapView.swift
+++ b/PlaceNotes/Views/FrequentPlacesMapView.swift
@@ -234,10 +234,6 @@ struct ClusterItem: MapAnnotationItem {
         let memberIDs = rankings.map { $0.place.id.uuidString }.sorted().joined(separator: "+")
         return "cluster-\(memberIDs)"
     }
-
-    var totalVisits: Int {
-        rankings.reduce(0) { $0 + $1.qualifiedStays }
-    }
 }
 
 // MARK: - Annotation Views
@@ -247,7 +243,7 @@ struct PlaceAnnotationView: View {
     @State private var pulse = false
 
     private var flameIntensity: FlameIntensity {
-        FlameIntensity(visitCount: ranking.qualifiedStays)
+        FlameIntensity(visitCount: ranking.totalVisits)
     }
 
     private var borderGradient: LinearGradient {
@@ -307,19 +303,19 @@ struct PlaceAnnotationView: View {
             Text(ranking.place.emoji)
                 .font(.system(size: 18))
 
-            if ranking.qualifiedStays > 0 {
+            if ranking.totalVisits > 0 {
                 Circle()
                     .fill(.black.opacity(0.3))
                     .frame(width: 4, height: 4)
 
-                Text("\(ranking.qualifiedStays)")
+                Text("\(ranking.totalVisits)")
                     .font(.system(size: 15, weight: .bold))
                     .foregroundStyle(.primary)
             }
         }
         .padding(.vertical, 8)
         .padding(.leading, 10)
-        .padding(.trailing, ranking.qualifiedStays > 0 ? 14 : 10)
+        .padding(.trailing, ranking.totalVisits > 0 ? 14 : 10)
         .background(
             Capsule()
                 .fill(.ultraThinMaterial)


### PR DESCRIPTION
## Summary

Consolidates the `totalVisits` calculation into the `PlaceRanking` model as a computed property, removing duplicate logic from `ClusterItem` and ensuring a single source of truth for visit counts across the app.

## Changes

- **Removed `totalVisits` from `ClusterItem`**: The computed property that summed `qualifiedStays` across cluster members is no longer needed.
- **Added `totalVisits` to `PlaceRanking`**: New computed property that returns `place.visits.count`, representing all recorded visits regardless of duration or recency.
- **Updated `PlaceAnnotationView`**: Changed all references from `ranking.qualifiedStays` to `ranking.totalVisits` for consistency with the detail card, header, and charts display logic.

## Implementation Details

The `totalVisits` property on `PlaceRanking` is now the canonical source for visit counts displayed in the UI. This aligns with the existing pattern where `qualifiedStays` represents a filtered subset (based on duration/recency criteria), while `totalVisits` reflects the complete visit history stored in `place.visits`.

This change ensures that the flame intensity indicator and visit count badge in the annotation view use the same metric as the rest of the app's reporting and detail views.

https://claude.ai/code/session_01W8g6buPyuHs4AE7N9duDNT