### PR TITLE
fix(i18n): localize PlaceDetailView stats and chart titles

### DIFF
--- a/PlaceNotes/Localizable.xcstrings
+++ b/PlaceNotes/Localizable.xcstrings
@@ -538,6 +538,16 @@
         }
       }
     },
+    "Day of week" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "星期分布"
+          }
+        }
+      }
+    },
     "Debug" : {
       "localizations" : {
         "zh-Hans" : {
@@ -1593,6 +1603,16 @@
         }
       }
     },
+    "Time of day" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "时段分布"
+          }
+        }
+      }
+    },
     "Title" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -1972,6 +1992,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "按时段统计访问"
+          }
+        }
+      }
+    },
+    "Visits per month" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "每月访问"
           }
         }
       }

--- a/PlaceNotes/Views/PlaceDetailView.swift
+++ b/PlaceNotes/Views/PlaceDetailView.swift
@@ -134,7 +134,7 @@ struct PlaceDetailView: View {
         .clipShape(RoundedRectangle(cornerRadius: 12))
     }
 
-    private func statItem(value: String, label: String) -> some View {
+    private func statItem(value: String, label: LocalizedStringKey) -> some View {
         VStack(spacing: 4) {
             Text(value)
                 .font(.title3.bold())

--- a/PlaceNotes/Views/PlaceStatsCharts.swift
+++ b/PlaceNotes/Views/PlaceStatsCharts.swift
@@ -23,7 +23,7 @@ struct PlaceStatsCharts: View {
 
     @ViewBuilder
     private func chartCard<Content: View>(
-        title: String,
+        title: LocalizedStringKey,
         @ViewBuilder content: () -> Content
     ) -> some View {
         VStack(alignment: .leading, spacing: 8) {


### PR DESCRIPTION
## Summary
- `statItem(label:)` in `PlaceDetailView` and `chartCard(title:)` in `PlaceStatsCharts` took `String`, so `Text(label)` / `Text(title)` skipped `Localizable.xcstrings` lookup — "Total Time", "Entries", "Visits per month", "Time of day", "Day of week" stayed English under zh-Hans.
- Change both params to `LocalizedStringKey` so `Text` triggers table lookup.
- Add zh-Hans translations for the three chart titles (`Total Time` + `Entries` were already present).

## Test plan
- [x] `xcodebuild build -scheme PlaceNotes-Debug` succeeds
- [ ] Launch on zh-Hans simulator, open a Place detail screen, confirm Stats row + three chart titles render in Chinese

🤖 Generated with [Claude Code](https://claude.com/claude-code)