### PR TITLE
feat(capture): frame Dynamic Island as camera lens for photo logging

### DIFF
--- a/PlaceNotes/Services/CameraSession.swift
+++ b/PlaceNotes/Services/CameraSession.swift
@@ -1,0 +1,205 @@
+import AVFoundation
+import SwiftUI
+import UIKit
+import os
+
+private let logger = Logger(subsystem: "dev.placelore.app", category: "CameraSession")
+
+/// Owns the live `AVCaptureSession` behind the Dynamic Island camera screen.
+/// Configuration and start/stop run on a private serial queue; published
+/// state is mutated on the main actor for SwiftUI binding.
+@MainActor
+final class CameraSession: ObservableObject {
+
+    enum Flash: CaseIterable {
+        case off, on, auto
+
+        var avMode: AVCaptureDevice.FlashMode {
+            switch self {
+            case .off: return .off
+            case .on: return .on
+            case .auto: return .auto
+            }
+        }
+
+        var symbol: String {
+            switch self {
+            case .off: return "bolt.slash.fill"
+            case .on: return "bolt.fill"
+            case .auto: return "bolt.badge.a.fill"
+            }
+        }
+
+        var next: Flash {
+            switch self {
+            case .off: return .on
+            case .on: return .auto
+            case .auto: return .off
+            }
+        }
+    }
+
+    let session = AVCaptureSession()
+
+    @Published private(set) var isRunning = false
+    @Published var flash: Flash = .off
+    @Published private(set) var position: AVCaptureDevice.Position = .back
+
+    private let photoOutput = AVCapturePhotoOutput()
+    private let sessionQueue = DispatchQueue(label: "dev.placelore.camera-session")
+    private var currentInput: AVCaptureDeviceInput?
+    private var isConfigured = false
+
+    func start() {
+        sessionQueue.async { [weak self] in
+            guard let self else { return }
+            self.configureIfNeeded()
+            if !self.session.isRunning {
+                self.session.startRunning()
+            }
+            let running = self.session.isRunning
+            Task { @MainActor in self.isRunning = running }
+        }
+    }
+
+    func stop() {
+        sessionQueue.async { [weak self] in
+            guard let self else { return }
+            if self.session.isRunning {
+                self.session.stopRunning()
+            }
+            Task { @MainActor in self.isRunning = false }
+        }
+    }
+
+    func flip() {
+        let newPosition: AVCaptureDevice.Position = position == .back ? .front : .back
+        position = newPosition
+        sessionQueue.async { [weak self] in
+            guard let self else { return }
+            self.session.beginConfiguration()
+            self.addVideoInput(position: newPosition)
+            self.session.commitConfiguration()
+        }
+    }
+
+    func cycleFlash() {
+        flash = flash.next
+    }
+
+    /// Captures a single still. Returns nil if no camera is available
+    /// (e.g. Simulator) or the capture fails.
+    func capturePhoto() async -> UIImage? {
+        guard isRunning else { return nil }
+        let flashMode = flash.avMode
+        let isFront = position == .front
+        return await withCheckedContinuation { (continuation: CheckedContinuation<UIImage?, Never>) in
+            let delegate = PhotoCaptureDelegate { image in
+                continuation.resume(returning: image)
+            }
+            sessionQueue.async { [weak self] in
+                guard let self else {
+                    continuation.resume(returning: nil)
+                    return
+                }
+                if let connection = self.photoOutput.connection(with: .video) {
+                    if connection.isVideoRotationAngleSupported(90) {
+                        connection.videoRotationAngle = 90
+                    }
+                    if connection.isVideoMirroringSupported {
+                        connection.automaticallyAdjustsVideoMirroring = false
+                        connection.isVideoMirrored = isFront
+                    }
+                }
+                let settings = AVCapturePhotoSettings()
+                if self.photoOutput.supportedFlashModes.contains(flashMode) {
+                    settings.flashMode = flashMode
+                }
+                self.photoOutput.capturePhoto(with: settings, delegate: delegate)
+            }
+        }
+    }
+
+    // MARK: - Configuration (sessionQueue only)
+
+    private func configureIfNeeded() {
+        guard !isConfigured else { return }
+        session.beginConfiguration()
+        session.sessionPreset = .photo
+        addVideoInput(position: .back)
+        if session.canAddOutput(photoOutput) {
+            session.addOutput(photoOutput)
+            photoOutput.maxPhotoQualityPrioritization = .quality
+        }
+        session.commitConfiguration()
+        isConfigured = true
+    }
+
+    private func addVideoInput(position: AVCaptureDevice.Position) {
+        guard let device = AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: position),
+              let input = try? AVCaptureDeviceInput(device: device) else {
+            logger.error("No camera input for position \(position.rawValue, privacy: .public)")
+            return
+        }
+        if let currentInput {
+            session.removeInput(currentInput)
+        }
+        if session.canAddInput(input) {
+            session.addInput(input)
+            currentInput = input
+        }
+    }
+}
+
+/// One-shot delegate that retains itself until the capture completes — AVFoundation
+/// holds its delegate weakly, so this keeps the callback alive without shared state
+/// on `CameraSession`.
+private final class PhotoCaptureDelegate: NSObject, AVCapturePhotoCaptureDelegate {
+    private let completion: (UIImage?) -> Void
+    private var retain: PhotoCaptureDelegate?
+
+    init(completion: @escaping (UIImage?) -> Void) {
+        self.completion = completion
+        super.init()
+        retain = self
+    }
+
+    func photoOutput(_ output: AVCapturePhotoOutput, didFinishProcessingPhoto photo: AVCapturePhoto, error: Error?) {
+        defer { retain = nil }
+        guard error == nil,
+              let data = photo.fileDataRepresentation(),
+              let image = UIImage(data: data) else {
+            completion(nil)
+            return
+        }
+        completion(image)
+    }
+}
+
+/// Hosts an `AVCaptureVideoPreviewLayer` as the view's backing layer.
+struct CameraPreview: UIViewRepresentable {
+    let session: AVCaptureSession
+
+    func makeUIView(context: Context) -> PreviewView {
+        let view = PreviewView()
+        view.previewLayer.session = session
+        view.previewLayer.videoGravity = .resizeAspectFill
+        view.backgroundColor = .black
+        return view
+    }
+
+    func updateUIView(_ uiView: PreviewView, context: Context) {}
+
+    final class PreviewView: UIView {
+        override class var layerClass: AnyClass { AVCaptureVideoPreviewLayer.self }
+        var previewLayer: AVCaptureVideoPreviewLayer { layer as! AVCaptureVideoPreviewLayer }
+
+        override func layoutSubviews() {
+            super.layoutSubviews()
+            if let connection = previewLayer.connection,
+               connection.isVideoRotationAngleSupported(90) {
+                connection.videoRotationAngle = 90
+            }
+        }
+    }
+}

--- a/PlaceNotes/Views/ContentView.swift
+++ b/PlaceNotes/Views/ContentView.swift
@@ -34,18 +34,6 @@ struct ContentView: View {
                 }
         }
         .tint(.accentColor)
-        .fullScreenCover(isPresented: $quickCapture.showCamera) {
-            DynamicIslandCameraView(
-                onCaptured: { image in
-                    quickCapture.showCamera = false
-                    quickCapture.photoCaptured(image: image, exifLocation: nil)
-                },
-                onClose: {
-                    quickCapture.showCamera = false
-                    quickCapture.cancelCapture()
-                }
-            )
-        }
         .sheet(isPresented: Binding(
             get: { quickCapture.state == .manualPickNeeded },
             set: { newValue in
@@ -90,8 +78,31 @@ struct ContentView: View {
                 .transition(.move(edge: .bottom).combined(with: .opacity))
             }
         }
+        .overlay {
+            if quickCapture.showCamera {
+                DynamicIslandCameraView(
+                    onCaptured: { image in
+                        quickCapture.photoCaptured(image: image, exifLocation: nil)
+                        quickCapture.showCamera = false
+                    },
+                    onClose: { quickCapture.cancelCapture() }
+                )
+                .transition(.dynamicIslandExpand)
+                .zIndex(100)
+            }
+        }
         .animation(.easeInOut(duration: 0.2), value: quickCapture.isWorkingInBackground)
         .animation(.easeInOut(duration: 0.2), value: quickCapture.state)
+        .animation(.spring(response: 0.5, dampingFraction: 0.82), value: quickCapture.showCamera)
+    }
+}
+
+extension AnyTransition {
+    /// Grows the camera page out of the Dynamic Island pill at top-center,
+    /// so opening the camera reads as the island expanding.
+    static var dynamicIslandExpand: AnyTransition {
+        .scale(scale: 0.06, anchor: UnitPoint(x: 0.5, y: 0.04))
+            .combined(with: .opacity)
     }
 }
 

--- a/PlaceNotes/Views/ContentView.swift
+++ b/PlaceNotes/Views/ContentView.swift
@@ -35,17 +35,16 @@ struct ContentView: View {
         }
         .tint(.accentColor)
         .fullScreenCover(isPresented: $quickCapture.showCamera) {
-            CameraPickerView(
-                onCaptured: { image, exif in
+            DynamicIslandCameraView(
+                onCaptured: { image in
                     quickCapture.showCamera = false
-                    quickCapture.photoCaptured(image: image, exifLocation: exif)
+                    quickCapture.photoCaptured(image: image, exifLocation: nil)
                 },
-                onCancelled: {
+                onClose: {
                     quickCapture.showCamera = false
                     quickCapture.cancelCapture()
                 }
             )
-            .ignoresSafeArea()
         }
         .sheet(isPresented: Binding(
             get: { quickCapture.state == .manualPickNeeded },

--- a/PlaceNotes/Views/DynamicIslandCameraView.swift
+++ b/PlaceNotes/Views/DynamicIslandCameraView.swift
@@ -1,0 +1,301 @@
+import SwiftUI
+import UIKit
+
+/// Full-screen capture experience that frames the hardware Dynamic Island as
+/// the camera's lens. A live viewfinder sits directly beneath the island; on
+/// shutter, the captured photo "prints" downward out of the island slot before
+/// being handed back to the QuickCapture pipeline.
+///
+/// Note: Apple exposes no public API to render a live camera feed inside the
+/// real Dynamic Island. This is a screen-aligned illusion — the on-screen UI is
+/// positioned around the physical island cutout so the pill reads as the lens.
+struct DynamicIslandCameraView: View {
+    let onCaptured: (UIImage) -> Void
+    let onClose: () -> Void
+
+    @StateObject private var camera = CameraSession()
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    @State private var isCapturing = false
+    @State private var shutterFlash = false
+    @State private var printing: PrintingPhoto?
+    @State private var printProgress: CGFloat = 0
+
+    private struct PrintingPhoto: Identifiable {
+        let id = UUID()
+        let image: UIImage
+    }
+
+    // Slate palette aligned with PhotographicShutterButton.
+    private static let bodyTop = Color(red: 0.165, green: 0.227, blue: 0.290)
+    private static let bodyBottom = Color(red: 0.078, green: 0.110, blue: 0.149)
+    private static let housingFill = Color(red: 0.122, green: 0.169, blue: 0.224)
+
+    var body: some View {
+        GeometryReader { proxy in
+            // Read insets from the proxy (which respects the safe area) so the
+            // island position is known, then ignore the safe area on the ZStack
+            // itself so its coordinate origin is the physical screen top.
+            let metrics = IslandMetrics(safeTop: proxy.safeAreaInsets.top, width: proxy.size.width)
+            let safeBottom = proxy.safeAreaInsets.bottom
+            ZStack {
+                LinearGradient(
+                    colors: [Self.bodyTop, Self.bodyBottom],
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+
+                mainColumn(metrics: metrics, safeBottom: safeBottom)
+
+                if let printing {
+                    printingPolaroid(printing, metrics: metrics, width: proxy.size.width)
+                }
+
+                // Occludes the polaroid above the island slot so it reads as
+                // emerging from underneath the housing.
+                Self.bodyTop
+                    .frame(height: metrics.housingBottomY)
+                    .frame(maxHeight: .infinity, alignment: .top)
+                    .allowsHitTesting(false)
+
+                housing(metrics: metrics, width: proxy.size.width)
+
+                topBar(metrics: metrics)
+
+                if shutterFlash {
+                    Color.white.transition(.opacity)
+                }
+            }
+            .ignoresSafeArea()
+        }
+        .statusBarHidden(true)
+        .onAppear { camera.start() }
+        .onDisappear { camera.stop() }
+    }
+
+    // MARK: - Layout
+
+    @ViewBuilder
+    private func mainColumn(metrics: IslandMetrics, safeBottom: CGFloat) -> some View {
+        VStack(spacing: 0) {
+            Color.clear.frame(height: metrics.housingBottomY + 24)
+
+            viewfinder
+                .padding(.horizontal, 20)
+
+            Spacer(minLength: 24)
+
+            controls
+                .padding(.bottom, max(safeBottom, 16) + 24)
+        }
+    }
+
+    private var viewfinder: some View {
+        ZStack {
+            if camera.isRunning {
+                CameraPreview(session: camera.session)
+            } else {
+                Color.black
+                    .overlay {
+                        VStack(spacing: 10) {
+                            ProgressView().tint(.white)
+                            Text("Starting camera…")
+                                .font(.footnote)
+                                .foregroundStyle(.white.opacity(0.7))
+                        }
+                    }
+            }
+        }
+        .aspectRatio(3.0 / 4.0, contentMode: .fit)
+        .clipShape(RoundedRectangle(cornerRadius: 28, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 28, style: .continuous)
+                .stroke(Color.white.opacity(0.12), lineWidth: 1)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 32, style: .continuous)
+                .stroke(Color.black.opacity(0.35), lineWidth: 6)
+                .blur(radius: 3)
+                .padding(-4)
+        )
+        .shadow(color: .black.opacity(0.4), radius: 14, y: 8)
+    }
+
+    private var controls: some View {
+        HStack {
+            Button {
+                camera.cycleFlash()
+            } label: {
+                controlIcon(systemName: camera.flash.symbol)
+            }
+            .accessibilityLabel("Flash")
+
+            Spacer()
+
+            PhotographicShutterButton(isBusy: isCapturing) {
+                capture()
+            }
+
+            Spacer()
+
+            Button {
+                camera.flip()
+            } label: {
+                controlIcon(systemName: "arrow.triangle.2.circlepath.camera.fill")
+            }
+            .accessibilityLabel("Flip camera")
+        }
+        .padding(.horizontal, 44)
+    }
+
+    private func controlIcon(systemName: String) -> some View {
+        Image(systemName: systemName)
+            .font(.system(size: 22, weight: .semibold))
+            .foregroundStyle(.white)
+            .frame(width: 54, height: 54)
+            .background(Color.white.opacity(0.12), in: Circle())
+            .overlay(Circle().stroke(Color.white.opacity(0.18), lineWidth: 0.5))
+    }
+
+    // MARK: - Island housing & top bar
+
+    @ViewBuilder
+    private func housing(metrics: IslandMetrics, width: CGFloat) -> some View {
+        ZStack {
+            Capsule(style: .continuous)
+                .fill(Self.housingFill)
+                .frame(width: metrics.housingWidth, height: metrics.housingHeight)
+                .overlay(
+                    Capsule(style: .continuous)
+                        .stroke(Color.white.opacity(0.10), lineWidth: 1)
+                )
+                .shadow(color: .black.opacity(0.5), radius: 6, y: 3)
+        }
+        .frame(maxWidth: .infinity, alignment: .center)
+        .position(x: width / 2, y: metrics.islandCenterY)
+        .allowsHitTesting(false)
+    }
+
+    @ViewBuilder
+    private func topBar(metrics: IslandMetrics) -> some View {
+        VStack {
+            HStack {
+                Button(action: onClose) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 16, weight: .bold))
+                        .foregroundStyle(.white)
+                        .frame(width: 38, height: 38)
+                        .background(Color.white.opacity(0.14), in: Circle())
+                }
+                .accessibilityLabel("Close camera")
+
+                Spacer()
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, metrics.safeTop + 4)
+
+            Spacer()
+        }
+    }
+
+    // MARK: - Print animation
+
+    @ViewBuilder
+    private func printingPolaroid(_ photo: PrintingPhoto, metrics: IslandMetrics, width: CGFloat) -> some View {
+        let polaroidWidth = width * 0.46
+        let photoSide = polaroidWidth - 16
+        let polaroidHeight = photoSide + 40
+        let startY = metrics.islandCenterY
+        let endY = metrics.housingBottomY + polaroidHeight / 2 + 36
+        let centerY = startY + (endY - startY) * printProgress
+
+        VStack(spacing: 0) {
+            Image(uiImage: photo.image)
+                .resizable()
+                .scaledToFill()
+                .frame(width: photoSide, height: photoSide)
+                .clipped()
+                .padding(.top, 8)
+                .padding(.horizontal, 8)
+            Spacer(minLength: 0)
+        }
+        .frame(width: polaroidWidth, height: polaroidHeight)
+        .background(Color.white)
+        .clipShape(RoundedRectangle(cornerRadius: 4))
+        .shadow(color: .black.opacity(0.35), radius: 6, y: 4)
+        .rotationEffect(.degrees(-2 * Double(printProgress)))
+        .position(x: width / 2, y: centerY)
+        .allowsHitTesting(false)
+    }
+
+    // MARK: - Actions
+
+    private func capture() {
+        guard !isCapturing, printing == nil else { return }
+        isCapturing = true
+
+        if !reduceMotion {
+            withAnimation(.easeOut(duration: 0.1)) { shutterFlash = true }
+        }
+
+        Task { @MainActor in
+            let image = await camera.capturePhoto()
+
+            if !reduceMotion {
+                withAnimation(.easeIn(duration: 0.2)) { shutterFlash = false }
+            } else {
+                shutterFlash = false
+            }
+
+            guard let image else {
+                isCapturing = false
+                return
+            }
+
+            await runPrintAnimation(image)
+            onCaptured(image)
+        }
+    }
+
+    @MainActor
+    private func runPrintAnimation(_ image: UIImage) async {
+        printing = PrintingPhoto(image: image)
+        printProgress = 0
+
+        if reduceMotion {
+            printProgress = 1
+            try? await Task.sleep(for: .milliseconds(300))
+        } else {
+            withAnimation(.spring(response: 0.7, dampingFraction: 0.85)) {
+                printProgress = 1
+            }
+            try? await Task.sleep(for: .milliseconds(850))
+        }
+    }
+}
+
+/// Approximate geometry of the Dynamic Island region. Devices with the island
+/// report a top safe-area inset of ~59pt; notch/older devices report less, in
+/// which case the housing renders as a decorative lens at the top center.
+private struct IslandMetrics {
+    let safeTop: CGFloat
+    let islandCenterY: CGFloat
+    let housingWidth: CGFloat
+    let housingHeight: CGFloat
+    let housingBottomY: CGFloat
+
+    init(safeTop: CGFloat, width: CGFloat) {
+        self.safeTop = safeTop
+        let hasIsland = safeTop >= 51
+
+        let islandTop: CGFloat = hasIsland ? 11 : 8
+        let islandHeight: CGFloat = hasIsland ? 37.33 : 28
+        self.islandCenterY = islandTop + islandHeight / 2
+
+        let extraWidth: CGFloat = 36
+        let pillWidth: CGFloat = hasIsland ? 126 : 100
+        self.housingWidth = min(pillWidth + extraWidth, width - 80)
+        self.housingHeight = islandHeight + 22
+        self.housingBottomY = islandCenterY + housingHeight / 2
+    }
+}

--- a/PlaceNotes/Views/TrackingControlView.swift
+++ b/PlaceNotes/Views/TrackingControlView.swift
@@ -19,8 +19,10 @@ struct TrackingControlView: View {
     var body: some View {
         NavigationStack {
             VStack(spacing: 28) {
+                pullDownHint
+                    .padding(.top, 4)
+
                 trackingChip
-                    .padding(.top, 8)
 
                 CurrentlyAtCard()
 
@@ -29,20 +31,25 @@ struct TrackingControlView: View {
                 PolaroidDecorationBand(entries: Array(recentJournalEntries.prefix(20)))
 
                 PhotographicShutterButton(isBusy: isBusy) {
-                    if isTrackingActive {
-                        attemptCapture()
-                    } else {
-                        showTrackingOffAlert = true
-                    }
+                    logThisPlace()
                 }
 
-                Text("Tap to log this place")
+                Text("Tap or pull down to log this place")
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
 
                 Spacer()
             }
             .padding()
+            .contentShape(Rectangle())
+            .gesture(
+                DragGesture(minimumDistance: 24)
+                    .onEnded { value in
+                        guard value.translation.height > 80,
+                              value.translation.height > abs(value.translation.width) else { return }
+                        logThisPlace()
+                    }
+            )
             .navigationTitle("Placelore")
             .sheet(isPresented: $showTrackingSheet) { trackingSheet }
             .alert("Camera access needed", isPresented: $showCameraPermissionAlert) {
@@ -124,6 +131,28 @@ struct TrackingControlView: View {
 
     private var isTrackingActive: Bool {
         trackingViewModel.trackingManager.state.status == .active
+    }
+
+    private func logThisPlace() {
+        if isTrackingActive {
+            attemptCapture()
+        } else {
+            showTrackingOffAlert = true
+        }
+    }
+
+    @ViewBuilder
+    private var pullDownHint: some View {
+        VStack(spacing: 2) {
+            Image(systemName: "chevron.compact.down")
+                .font(.system(size: 24, weight: .semibold))
+            Text("Pull down for camera")
+                .font(.caption2)
+        }
+        .foregroundStyle(.secondary)
+        .frame(maxWidth: .infinity)
+        .accessibilityElement(children: .combine)
+        .accessibilityHint("Pull down to open the camera")
     }
 
     private func attemptCapture() {


### PR DESCRIPTION
Replace the system camera picker in the photo-log flow with a full-screen
capture screen that aligns a live AVCaptureSession viewfinder around the
physical Dynamic Island cutout, so the pill reads as the lens. On shutter,
the captured photo "prints" downward out of the island slot before handing
off to the existing QuickCapture pipeline.

The real Dynamic Island has no public API for live camera feeds, so this is
a screen-aligned illusion positioned via the device's top safe-area inset.

https://claude.ai/code/session_01BTA9oP7TTo1ur5HNA2iRtr