### PR TITLE
Add place-prediction accuracy feedback and export pipeline

### DIFF
--- a/PlaceNotes/Models/PredictionFeedback.swift
+++ b/PlaceNotes/Models/PredictionFeedback.swift
@@ -1,3 +1,4 @@
+#if DEBUG
 import Foundation
 import SwiftData
 
@@ -88,3 +89,4 @@ final class PredictionFeedback {
         self.correctionSource = correctionSource
     }
 }
+#endif

--- a/PlaceNotes/Models/PredictionFeedback.swift
+++ b/PlaceNotes/Models/PredictionFeedback.swift
@@ -1,0 +1,90 @@
+import Foundation
+import SwiftData
+
+/// The user's verdict on how accurately a visit was resolved to a place.
+/// - accurate: The predicted place was correct.
+/// - wrong: The predicted place was wrong and the user did not supply a correction.
+/// - corrected: The predicted place was wrong and the user picked the right one.
+enum PredictionVerdict: String, Codable, CaseIterable {
+    case accurate
+    case wrong
+    case corrected
+
+    /// Binary training label: the prediction was correct as produced by the algorithm.
+    var wasAccurate: Bool { self == .accurate }
+}
+
+/// A labeled record of a single place-prediction outcome, capturing the
+/// prediction's features at the time it was made alongside the user's verdict.
+///
+/// One record exists per visit (re-submitting feedback replaces it). The rows
+/// are exported as CSV for offline analysis of prediction quality and as a
+/// training set for a future model.
+@Model
+final class PredictionFeedback {
+    var id: UUID
+    var createdAt: Date
+
+    /// The visit this feedback is about. Stored as the visit's UUID rather than
+    /// a relationship so a record survives independently for export.
+    var visitID: UUID
+    var arrivalDate: Date
+
+    // MARK: Prediction snapshot (features)
+
+    var predictedPlaceName: String
+    var predictedCategory: String?
+    /// Confidence the algorithm assigned at prediction time (High/Medium/Low).
+    var confidenceRaw: String
+    var medianAccuracyMeters: Double?
+    /// Number of runner-up POI candidates the algorithm found.
+    var alternativeCount: Int
+    var latitude: Double
+    var longitude: Double
+
+    // MARK: User verdict (label)
+
+    var verdictRaw: String
+    var correctedPlaceName: String?
+    var correctedCategory: String?
+    /// How the correction was supplied: "alternative" | "search" | nil.
+    var correctionSource: String?
+
+    var verdict: PredictionVerdict {
+        get { PredictionVerdict(rawValue: verdictRaw) ?? .wrong }
+        set { verdictRaw = newValue.rawValue }
+    }
+
+    init(
+        visitID: UUID,
+        arrivalDate: Date,
+        predictedPlaceName: String,
+        predictedCategory: String?,
+        confidenceRaw: String,
+        medianAccuracyMeters: Double?,
+        alternativeCount: Int,
+        latitude: Double,
+        longitude: Double,
+        verdict: PredictionVerdict,
+        correctedName: String? = nil,
+        correctedCategory: String? = nil,
+        correctionSource: String? = nil,
+        createdAt: Date = Date()
+    ) {
+        self.id = UUID()
+        self.createdAt = createdAt
+        self.visitID = visitID
+        self.arrivalDate = arrivalDate
+        self.predictedPlaceName = predictedPlaceName
+        self.predictedCategory = predictedCategory
+        self.confidenceRaw = confidenceRaw
+        self.medianAccuracyMeters = medianAccuracyMeters
+        self.alternativeCount = alternativeCount
+        self.latitude = latitude
+        self.longitude = longitude
+        self.verdictRaw = verdict.rawValue
+        self.correctedPlaceName = correctedName
+        self.correctedCategory = correctedCategory
+        self.correctionSource = correctionSource
+    }
+}

--- a/PlaceNotes/Models/SchemaVersions.swift
+++ b/PlaceNotes/Models/SchemaVersions.swift
@@ -5,14 +5,17 @@ enum PlaceNotesSchemaV1: VersionedSchema {
     static var versionIdentifier = Schema.Version(1, 0, 0)
 
     static var models: [any PersistentModel.Type] {
-        [
+        var models: [any PersistentModel.Type] = [
             Place.self,
             Visit.self,
             CustomCategory.self,
             JournalEntry.self,
-            RawLocationSample.self,
-            PredictionFeedback.self
+            RawLocationSample.self
         ]
+        #if DEBUG
+        models.append(PredictionFeedback.self)
+        #endif
+        return models
     }
 }
 

--- a/PlaceNotes/Models/SchemaVersions.swift
+++ b/PlaceNotes/Models/SchemaVersions.swift
@@ -10,7 +10,8 @@ enum PlaceNotesSchemaV1: VersionedSchema {
             Visit.self,
             CustomCategory.self,
             JournalEntry.self,
-            RawLocationSample.self
+            RawLocationSample.self,
+            PredictionFeedback.self
         ]
     }
 }

--- a/PlaceNotes/Models/Visit.swift
+++ b/PlaceNotes/Models/Visit.swift
@@ -37,6 +37,10 @@ final class Visit {
     /// Used to dim the "Not the right place?" affordance after a deliberate choice.
     var placeConfirmed: Bool = false
 
+    /// The user's latest prediction-accuracy verdict for this visit, if any.
+    /// Mirrors the canonical `PredictionFeedback` record so the row can show state.
+    var feedbackVerdictRaw: String?
+
     /// Journal entries explicitly tied to this visit. Quick-capture creates one;
     /// dwell-recorded visits start empty. Cascade-deletes when the visit is removed.
     @Relationship(deleteRule: .cascade, inverse: \JournalEntry.visit)
@@ -45,6 +49,11 @@ final class Visit {
     var confidence: PlaceConfidence {
         get { PlaceConfidence(rawValue: confidenceRaw ?? "") ?? .medium }
         set { confidenceRaw = newValue.rawValue }
+    }
+
+    var feedbackVerdict: PredictionVerdict? {
+        get { feedbackVerdictRaw.flatMap(PredictionVerdict.init(rawValue:)) }
+        set { feedbackVerdictRaw = newValue?.rawValue }
     }
 
     var alternativePlaces: [PlaceCandidate] {

--- a/PlaceNotes/Models/Visit.swift
+++ b/PlaceNotes/Models/Visit.swift
@@ -37,10 +37,6 @@ final class Visit {
     /// Used to dim the "Not the right place?" affordance after a deliberate choice.
     var placeConfirmed: Bool = false
 
-    /// The user's latest prediction-accuracy verdict for this visit, if any.
-    /// Mirrors the canonical `PredictionFeedback` record so the row can show state.
-    var feedbackVerdictRaw: String?
-
     /// Journal entries explicitly tied to this visit. Quick-capture creates one;
     /// dwell-recorded visits start empty. Cascade-deletes when the visit is removed.
     @Relationship(deleteRule: .cascade, inverse: \JournalEntry.visit)
@@ -49,11 +45,6 @@ final class Visit {
     var confidence: PlaceConfidence {
         get { PlaceConfidence(rawValue: confidenceRaw ?? "") ?? .medium }
         set { confidenceRaw = newValue.rawValue }
-    }
-
-    var feedbackVerdict: PredictionVerdict? {
-        get { feedbackVerdictRaw.flatMap(PredictionVerdict.init(rawValue:)) }
-        set { feedbackVerdictRaw = newValue?.rawValue }
     }
 
     var alternativePlaces: [PlaceCandidate] {

--- a/PlaceNotes/Services/DebugSeed.swift
+++ b/PlaceNotes/Services/DebugSeed.swift
@@ -86,6 +86,7 @@ enum DebugSeed {
 
     @MainActor
     static func clearAllData(in context: ModelContext) {
+        deleteAll(of: PredictionFeedback.self, in: context)
         deleteAll(of: RawLocationSample.self, in: context)
         deleteAll(of: JournalEntry.self, in: context)
         deleteAll(of: Visit.self, in: context)

--- a/PlaceNotes/Services/PredictionFeedbackExporter.swift
+++ b/PlaceNotes/Services/PredictionFeedbackExporter.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// Builds a CSV dataset from `PredictionFeedback` records for offline analysis
+/// (pandas / scikit-learn) and as a training set for a future prediction model.
+///
+/// Each row is one labeled example: prediction features plus the binary
+/// `wasAccurate` label and the user's correction when supplied.
+enum PredictionFeedbackExporter {
+    private static let iso8601: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+
+    static let header = "id,createdAt,visitID,arrivalDate,latitude,longitude,predictedPlaceName,predictedCategory,confidence,medianAccuracyMeters,alternativeCount,verdict,wasAccurate,correctedPlaceName,correctedCategory,correctionSource"
+
+    static func exportCSV(from records: [PredictionFeedback]) -> Data {
+        var lines = [header]
+        for r in records {
+            let row: [String] = [
+                r.id.uuidString,
+                iso8601.string(from: r.createdAt),
+                r.visitID.uuidString,
+                iso8601.string(from: r.arrivalDate),
+                "\(r.latitude)",
+                "\(r.longitude)",
+                escape(r.predictedPlaceName),
+                escape(r.predictedCategory),
+                r.confidenceRaw,
+                r.medianAccuracyMeters.map { "\($0)" } ?? "",
+                "\(r.alternativeCount)",
+                r.verdict.rawValue,
+                r.verdict.wasAccurate ? "1" : "0",
+                escape(r.correctedPlaceName),
+                escape(r.correctedCategory),
+                escape(r.correctionSource)
+            ]
+            lines.append(row.joined(separator: ","))
+        }
+        return lines.joined(separator: "\n").data(using: .utf8) ?? Data()
+    }
+
+    /// Wraps a value in quotes and doubles inner quotes when it contains a
+    /// comma, quote, or newline — keeps free-text place names CSV-safe.
+    private static func escape(_ value: String?) -> String {
+        guard let value, !value.isEmpty else { return "" }
+        guard value.contains(",") || value.contains("\"") || value.contains("\n") else {
+            return value
+        }
+        return "\"\(value.replacingOccurrences(of: "\"", with: "\"\""))\""
+    }
+}

--- a/PlaceNotes/Services/PredictionFeedbackExporter.swift
+++ b/PlaceNotes/Services/PredictionFeedbackExporter.swift
@@ -1,3 +1,4 @@
+#if DEBUG
 import Foundation
 
 /// Builds a CSV dataset from `PredictionFeedback` records for offline analysis
@@ -50,3 +51,4 @@ enum PredictionFeedbackExporter {
         return "\"\(value.replacingOccurrences(of: "\"", with: "\"\""))\""
     }
 }
+#endif

--- a/PlaceNotes/Services/PredictionFeedbackRecorder.swift
+++ b/PlaceNotes/Services/PredictionFeedbackRecorder.swift
@@ -1,3 +1,4 @@
+#if DEBUG
 import Foundation
 import SwiftData
 import os
@@ -46,12 +47,9 @@ enum PredictionFeedbackRecorder {
         )
         context.insert(feedback)
 
-        visit.feedbackVerdict = verdict
-        // A deliberate verdict resolves the "wrong place?" affordance, except an
-        // unresolved "wrong" — the place is still incorrect there.
-        if verdict != .wrong {
-            visit.placeConfirmed = true
-        }
+        // An unresolved "wrong" means the place is still unconfirmed; accurate
+        // and corrected verdicts are deliberate confirmations.
+        visit.placeConfirmed = verdict != .wrong
 
         do {
             try context.save()
@@ -60,3 +58,4 @@ enum PredictionFeedbackRecorder {
         }
     }
 }
+#endif

--- a/PlaceNotes/Services/PredictionFeedbackRecorder.swift
+++ b/PlaceNotes/Services/PredictionFeedbackRecorder.swift
@@ -1,0 +1,62 @@
+import Foundation
+import SwiftData
+import os
+
+/// Persists user feedback on place-prediction accuracy as labeled
+/// `PredictionFeedback` records for offline analysis and future model training.
+///
+/// One record exists per visit: re-submitting feedback replaces the previous
+/// record so the exported dataset holds a single labeled example per visit.
+enum PredictionFeedbackRecorder {
+    private static let logger = Logger(subsystem: "dev.placelore.app", category: "PredictionFeedback")
+
+    @MainActor
+    static func record(
+        _ verdict: PredictionVerdict,
+        for visit: Visit,
+        correctedName: String? = nil,
+        correctedCategory: String? = nil,
+        correctionSource: String? = nil,
+        in context: ModelContext
+    ) {
+        let visitID = visit.id
+        let descriptor = FetchDescriptor<PredictionFeedback>(
+            predicate: #Predicate { $0.visitID == visitID }
+        )
+        let existing = (try? context.fetch(descriptor)) ?? []
+        for record in existing {
+            context.delete(record)
+        }
+
+        let predicted = visit.place
+        let feedback = PredictionFeedback(
+            visitID: visit.id,
+            arrivalDate: visit.arrivalDate,
+            predictedPlaceName: predicted?.name ?? "Unknown",
+            predictedCategory: predicted?.category,
+            confidenceRaw: visit.confidence.rawValue,
+            medianAccuracyMeters: visit.medianAccuracyMeters,
+            alternativeCount: visit.alternativePlaces.count,
+            latitude: predicted?.latitude ?? 0,
+            longitude: predicted?.longitude ?? 0,
+            verdict: verdict,
+            correctedName: correctedName,
+            correctedCategory: correctedCategory,
+            correctionSource: correctionSource
+        )
+        context.insert(feedback)
+
+        visit.feedbackVerdict = verdict
+        // A deliberate verdict resolves the "wrong place?" affordance, except an
+        // unresolved "wrong" — the place is still incorrect there.
+        if verdict != .wrong {
+            visit.placeConfirmed = true
+        }
+
+        do {
+            try context.save()
+        } catch {
+            logger.error("Failed to save prediction feedback: \(error.localizedDescription)")
+        }
+    }
+}

--- a/PlaceNotes/Services/PredictionFeedbackRecorder.swift
+++ b/PlaceNotes/Services/PredictionFeedbackRecorder.swift
@@ -53,6 +53,10 @@ enum PredictionFeedbackRecorder {
 
         do {
             try context.save()
+            let uploadPayload = PredictionFeedbackUploadPayload(record: feedback)
+            Task(priority: .utility) {
+                _ = await PredictionFeedbackUploader.upload(uploadPayload)
+            }
         } catch {
             logger.error("Failed to save prediction feedback: \(error.localizedDescription)")
         }

--- a/PlaceNotes/Services/PredictionFeedbackUploader.swift
+++ b/PlaceNotes/Services/PredictionFeedbackUploader.swift
@@ -1,0 +1,170 @@
+#if DEBUG
+import Foundation
+import os
+
+struct PredictionFeedbackUploadPayload: Codable, Equatable, Sendable {
+    let schemaVersion: Int
+    let appVersion: String
+    let appBuild: String
+    let buildConfiguration: String
+    let eventID: UUID
+    let createdAt: String
+    let visitID: UUID
+    let arrivalDate: String
+    let latitude: Double
+    let longitude: Double
+    let predictedPlaceName: String
+    let predictedCategory: String?
+    let confidence: String
+    let medianAccuracyMeters: Double?
+    let alternativeCount: Int
+    let verdict: String
+    let wasAccurate: Bool
+    let correctedPlaceName: String?
+    let correctedCategory: String?
+    let correctionSource: String?
+
+    init(record: PredictionFeedback, bundle: Bundle = .main) {
+        self.schemaVersion = 1
+        self.appVersion = bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "unknown"
+        self.appBuild = bundle.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "unknown"
+        self.buildConfiguration = "debug"
+        self.eventID = record.id
+        self.createdAt = Self.iso8601String(from: record.createdAt)
+        self.visitID = record.visitID
+        self.arrivalDate = Self.iso8601String(from: record.arrivalDate)
+        self.latitude = record.latitude
+        self.longitude = record.longitude
+        self.predictedPlaceName = record.predictedPlaceName
+        self.predictedCategory = record.predictedCategory
+        self.confidence = record.confidenceRaw
+        self.medianAccuracyMeters = record.medianAccuracyMeters
+        self.alternativeCount = record.alternativeCount
+        self.verdict = record.verdict.rawValue
+        self.wasAccurate = record.verdict.wasAccurate
+        self.correctedPlaceName = record.correctedPlaceName
+        self.correctedCategory = record.correctedCategory
+        self.correctionSource = record.correctionSource
+    }
+
+    private static func iso8601String(from date: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.string(from: date)
+    }
+}
+
+enum PredictionFeedbackUploadResult: Equatable, Sendable {
+    case success
+    case networkUnavailable(String)
+    case serverRejected(statusCode: Int, body: String)
+    case failed(String)
+}
+
+struct PredictionFeedbackUploadSummary: Equatable, Sendable {
+    var succeeded: Int
+    var failed: Int
+    var networkUnavailable: Int
+
+    var displayText: String {
+        if failed == 0 && networkUnavailable == 0 {
+            return "Uploaded \(succeeded)"
+        }
+        if networkUnavailable > 0 {
+            return "No internet: \(networkUnavailable) pending"
+        }
+        return "Uploaded \(succeeded), failed \(failed)"
+    }
+}
+
+protocol PredictionFeedbackHTTPSession {
+    func data(for request: URLRequest) async throws -> (Data, URLResponse)
+}
+
+extension URLSession: PredictionFeedbackHTTPSession {}
+
+enum PredictionFeedbackUploader {
+    static let endpoint = URL(string: "https://func-placelore-feedback-dev.azurewebsites.net/api/feedback")!
+
+    private static let logger = Logger(subsystem: "dev.placelore.app", category: "PredictionFeedbackUpload")
+    private static func makeEncoder() -> JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return encoder
+    }
+
+    static func upload(
+        _ payload: PredictionFeedbackUploadPayload,
+        endpoint: URL = Self.endpoint,
+        session: PredictionFeedbackHTTPSession = URLSession.shared
+    ) async -> PredictionFeedbackUploadResult {
+        do {
+            var request = URLRequest(url: endpoint, cachePolicy: .reloadIgnoringLocalCacheData, timeoutInterval: 10)
+            request.httpMethod = "POST"
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.setValue("application/json", forHTTPHeaderField: "Accept")
+            request.httpBody = try makeEncoder().encode(payload)
+
+            let (data, response) = try await session.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse else {
+                logger.error("Prediction feedback upload failed: non-HTTP response")
+                return .failed("Non-HTTP response")
+            }
+
+            guard (200..<300).contains(httpResponse.statusCode) else {
+                let body = String(data: data, encoding: .utf8) ?? ""
+                logger.error("Prediction feedback upload rejected: \(httpResponse.statusCode)")
+                return .serverRejected(statusCode: httpResponse.statusCode, body: body)
+            }
+
+            logger.debug("Prediction feedback uploaded: \(payload.eventID.uuidString)")
+            return .success
+        } catch let error as URLError {
+            if error.isNetworkUnavailable {
+                logger.warning("Prediction feedback upload deferred, network unavailable: \(error.localizedDescription)")
+                return .networkUnavailable(error.localizedDescription)
+            }
+            logger.error("Prediction feedback upload failed: \(error.localizedDescription)")
+            return .failed(error.localizedDescription)
+        } catch {
+            logger.error("Prediction feedback upload failed: \(error.localizedDescription)")
+            return .failed(error.localizedDescription)
+        }
+    }
+
+    static func upload(
+        _ payloads: [PredictionFeedbackUploadPayload],
+        endpoint: URL = Self.endpoint,
+        session: PredictionFeedbackHTTPSession = URLSession.shared
+    ) async -> PredictionFeedbackUploadSummary {
+        var summary = PredictionFeedbackUploadSummary(succeeded: 0, failed: 0, networkUnavailable: 0)
+        for payload in payloads {
+            switch await upload(payload, endpoint: endpoint, session: session) {
+            case .success:
+                summary.succeeded += 1
+            case .networkUnavailable:
+                summary.networkUnavailable += 1
+            case .serverRejected, .failed:
+                summary.failed += 1
+            }
+        }
+        return summary
+    }
+}
+
+private extension URLError {
+    var isNetworkUnavailable: Bool {
+        switch code {
+        case .notConnectedToInternet,
+             .networkConnectionLost,
+             .cannotConnectToHost,
+             .cannotFindHost,
+             .dnsLookupFailed,
+             .timedOut:
+            return true
+        default:
+            return false
+        }
+    }
+}
+#endif

--- a/PlaceNotes/Views/LogbookView.swift
+++ b/PlaceNotes/Views/LogbookView.swift
@@ -9,7 +9,10 @@ struct LogbookView: View {
 
     @StateObject private var viewModel = LogbookViewModel()
 
+    #if DEBUG
+    @Query private var feedbackRecords: [PredictionFeedback]
     @State private var visitForFeedback: Visit?
+    #endif
     @State private var visitToDelete: Visit?
     @State private var showDeleteConfirmation = false
     @State private var refreshID = UUID()
@@ -54,12 +57,14 @@ struct LogbookView: View {
             .navigationDestination(item: $trajectoryDay) { day in
                 DayTrajectoryView(day: day)
             }
+            #if DEBUG
             .sheet(item: $visitForFeedback) { visit in
                 PlaceFeedbackSheet(visit: visit) {
                     viewModel.refresh(places: places, settings: settings)
                     refreshID = UUID()
                 }
             }
+            #endif
             .alert("Delete Visit?", isPresented: $showDeleteConfirmation) {
                 Button("Delete", role: .destructive) {
                     if let visit = visitToDelete {
@@ -133,10 +138,12 @@ struct LogbookView: View {
             NavigationLink {
                 PlaceDetailView(place: place)
             } label: {
+                #if DEBUG
                 LogbookVisitRow(
                     visit: visit,
                     place: place,
                     nextSameDayArrival: nextSameDay,
+                    feedbackVerdict: feedbackRecords.first { $0.visitID == visit.id }?.verdict,
                     onMarkAccurate: {
                         PredictionFeedbackRecorder.record(.accurate, for: visit, in: modelContext)
                         viewModel.refresh(places: places, settings: settings)
@@ -146,6 +153,13 @@ struct LogbookView: View {
                         visitForFeedback = visit
                     }
                 )
+                #else
+                LogbookVisitRow(
+                    visit: visit,
+                    place: place,
+                    nextSameDayArrival: nextSameDay
+                )
+                #endif
             }
             .buttonStyle(.plain)
             .swipeActions(edge: .leading, allowsFullSwipe: false) {
@@ -179,6 +193,7 @@ struct LogbookView: View {
     }
 }
 
+#if DEBUG
 // MARK: - Place Feedback Sheet
 
 private struct PlaceFeedbackSheet: View {
@@ -377,4 +392,4 @@ private struct PlaceFeedbackSheet: View {
         dismiss()
     }
 }
-
+#endif

--- a/PlaceNotes/Views/LogbookView.swift
+++ b/PlaceNotes/Views/LogbookView.swift
@@ -9,7 +9,7 @@ struct LogbookView: View {
 
     @StateObject private var viewModel = LogbookViewModel()
 
-    @State private var visitForAlternatives: Visit?
+    @State private var visitForFeedback: Visit?
     @State private var visitToDelete: Visit?
     @State private var showDeleteConfirmation = false
     @State private var refreshID = UUID()
@@ -54,8 +54,8 @@ struct LogbookView: View {
             .navigationDestination(item: $trajectoryDay) { day in
                 DayTrajectoryView(day: day)
             }
-            .sheet(item: $visitForAlternatives) { visit in
-                AlternativePlacePicker(visit: visit) {
+            .sheet(item: $visitForFeedback) { visit in
+                PlaceFeedbackSheet(visit: visit) {
                     viewModel.refresh(places: places, settings: settings)
                     refreshID = UUID()
                 }
@@ -133,9 +133,19 @@ struct LogbookView: View {
             NavigationLink {
                 PlaceDetailView(place: place)
             } label: {
-                LogbookVisitRow(visit: visit, place: place, nextSameDayArrival: nextSameDay) {
-                    visitForAlternatives = visit
-                }
+                LogbookVisitRow(
+                    visit: visit,
+                    place: place,
+                    nextSameDayArrival: nextSameDay,
+                    onMarkAccurate: {
+                        PredictionFeedbackRecorder.record(.accurate, for: visit, in: modelContext)
+                        viewModel.refresh(places: places, settings: settings)
+                        refreshID = UUID()
+                    },
+                    onOpenFeedback: {
+                        visitForFeedback = visit
+                    }
+                )
             }
             .buttonStyle(.plain)
             .swipeActions(edge: .leading, allowsFullSwipe: false) {
@@ -169,9 +179,9 @@ struct LogbookView: View {
     }
 }
 
-// MARK: - Alternative Place Picker
+// MARK: - Place Feedback Sheet
 
-private struct AlternativePlacePicker: View {
+private struct PlaceFeedbackSheet: View {
     @Environment(\.modelContext) private var modelContext
     @Environment(\.dismiss) private var dismiss
     let visit: Visit
@@ -184,29 +194,29 @@ private struct AlternativePlacePicker: View {
         NavigationStack {
             List {
                 if let place = visit.place {
-                    Section("Current") {
-                        Button {
-                            confirmPlace()
-                        } label: {
-                            HStack {
-                                Image(systemName: PlaceCategorizer.icon(for: place.category))
-                                    .foregroundStyle(Color.accentColor)
-                                    .frame(width: 28)
-                                VStack(alignment: .leading, spacing: 2) {
-                                    Text(place.displayName)
-                                        .font(.body.weight(.medium))
-                                        .foregroundStyle(.primary)
-                                    if let category = place.category {
-                                        Text(category)
-                                            .font(.caption)
-                                            .foregroundStyle(.secondary)
-                                    }
+                    Section("We recorded") {
+                        HStack {
+                            Image(systemName: PlaceCategorizer.icon(for: place.category))
+                                .foregroundStyle(Color.accentColor)
+                                .frame(width: 28)
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(place.displayName)
+                                    .font(.body.weight(.medium))
+                                    .foregroundStyle(.primary)
+                                if let category = place.category {
+                                    Text(category)
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
                                 }
-                                Spacer()
-                                Text("Confirm")
-                                    .font(.subheadline.weight(.medium))
-                                    .foregroundStyle(Color.accentColor)
                             }
+                            Spacer()
+                        }
+
+                        Button {
+                            markAccurate()
+                        } label: {
+                            Label("This is correct", systemImage: "hand.thumbsup")
+                                .foregroundStyle(.green)
                         }
                     }
                 }
@@ -242,15 +252,22 @@ private struct AlternativePlacePicker: View {
                             }
                         }
                     }
-                } else {
-                    ContentUnavailableView(
-                        "No Alternatives",
-                        systemImage: "mappin.slash",
-                        description: Text("No other nearby places were found when this visit was recorded.")
-                    )
+                }
+
+                Section {
+                    Button(role: .destructive) {
+                        markWrong()
+                    } label: {
+                        Label(
+                            visit.alternativePlaces.isEmpty ? "This is wrong" : "None of these — still wrong",
+                            systemImage: "hand.thumbsdown"
+                        )
+                    }
+                } footer: {
+                    Text("Your feedback is logged to measure how well place prediction is working.")
                 }
             }
-            .navigationTitle("Wrong Place?")
+            .navigationTitle("How did we do?")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
@@ -272,17 +289,33 @@ private struct AlternativePlacePicker: View {
                 }
             }
         }
-        .presentationDetents([.medium])
+        .presentationDetents([.medium, .large])
     }
 
-    private func confirmPlace() {
-        visit.placeConfirmed = true
-        try? modelContext.save()
+    private func markAccurate() {
+        PredictionFeedbackRecorder.record(.accurate, for: visit, in: modelContext)
+        onPlaceChanged?()
+        dismiss()
+    }
+
+    private func markWrong() {
+        PredictionFeedbackRecorder.record(.wrong, for: visit, in: modelContext)
         onPlaceChanged?()
         dismiss()
     }
 
     private func reassignVisit(to candidate: PlaceCandidate) {
+        // Record the corrected feedback while `visit.place` still holds the
+        // original (wrong) prediction, so the snapshot captures what failed.
+        PredictionFeedbackRecorder.record(
+            .corrected,
+            for: visit,
+            correctedName: candidate.name,
+            correctedCategory: candidate.category,
+            correctionSource: "alternative",
+            in: modelContext
+        )
+
         let threshold = 0.0001
         let descriptor = FetchDescriptor<Place>()
         let allPlaces = (try? modelContext.fetch(descriptor)) ?? []

--- a/PlaceNotes/Views/LogbookVisitRow.swift
+++ b/PlaceNotes/Views/LogbookVisitRow.swift
@@ -4,7 +4,8 @@ struct LogbookVisitRow: View {
     let visit: Visit
     let place: Place
     let nextSameDayArrival: Date?
-    var onPickAlternative: (() -> Void)?
+    var onMarkAccurate: (() -> Void)?
+    var onOpenFeedback: (() -> Void)?
 
     private var dateString: String {
         let formatter = DateFormatter()
@@ -76,25 +77,62 @@ struct LogbookVisitRow: View {
                 }
             }
 
-            if !visit.alternativePlaces.isEmpty {
-                Button {
-                    onPickAlternative?()
-                } label: {
-                    if visit.placeConfirmed {
-                        Label("Place confirmed", systemImage: "checkmark.circle")
-                            .font(.caption2)
-                            .foregroundStyle(.tertiary)
-                    } else {
-                        Label("Not the right place?", systemImage: "arrow.triangle.swap")
-                            .font(.caption2)
-                            .foregroundStyle(.orange)
-                    }
-                }
-                .buttonStyle(.plain)
+            feedbackBar
                 .padding(.leading, 40)
-            }
         }
         .padding(.vertical, 2)
+    }
+
+    @ViewBuilder
+    private var feedbackBar: some View {
+        if onOpenFeedback == nil {
+            EmptyView()
+        } else if let verdict = visit.feedbackVerdict {
+            Button {
+                onOpenFeedback?()
+            } label: {
+                verdictLabel(verdict)
+            }
+            .buttonStyle(.plain)
+        } else {
+            HStack(spacing: 16) {
+                Button {
+                    onMarkAccurate?()
+                } label: {
+                    Label("Correct", systemImage: "hand.thumbsup")
+                        .font(.caption2)
+                        .foregroundStyle(.green)
+                }
+                .buttonStyle(.plain)
+
+                Button {
+                    onOpenFeedback?()
+                } label: {
+                    Label("Wrong", systemImage: "hand.thumbsdown")
+                        .font(.caption2)
+                        .foregroundStyle(.orange)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func verdictLabel(_ verdict: PredictionVerdict) -> some View {
+        switch verdict {
+        case .accurate:
+            Label("Marked correct", systemImage: "checkmark.circle.fill")
+                .font(.caption2)
+                .foregroundStyle(.green)
+        case .corrected:
+            Label("Corrected", systemImage: "arrow.triangle.swap")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+        case .wrong:
+            Label("Marked wrong", systemImage: "exclamationmark.triangle")
+                .font(.caption2)
+                .foregroundStyle(.orange)
+        }
     }
 }
 

--- a/PlaceNotes/Views/LogbookVisitRow.swift
+++ b/PlaceNotes/Views/LogbookVisitRow.swift
@@ -4,8 +4,11 @@ struct LogbookVisitRow: View {
     let visit: Visit
     let place: Place
     let nextSameDayArrival: Date?
+    #if DEBUG
+    var feedbackVerdict: PredictionVerdict? = nil
     var onMarkAccurate: (() -> Void)?
     var onOpenFeedback: (() -> Void)?
+    #endif
 
     private var dateString: String {
         let formatter = DateFormatter()
@@ -77,17 +80,20 @@ struct LogbookVisitRow: View {
                 }
             }
 
+            #if DEBUG
             feedbackBar
                 .padding(.leading, 40)
+            #endif
         }
         .padding(.vertical, 2)
     }
 
+    #if DEBUG
     @ViewBuilder
     private var feedbackBar: some View {
         if onOpenFeedback == nil {
             EmptyView()
-        } else if let verdict = visit.feedbackVerdict {
+        } else if let verdict = feedbackVerdict {
             Button {
                 onOpenFeedback?()
             } label: {
@@ -116,7 +122,9 @@ struct LogbookVisitRow: View {
             }
         }
     }
+    #endif
 
+    #if DEBUG
     @ViewBuilder
     private func verdictLabel(_ verdict: PredictionVerdict) -> some View {
         switch verdict {
@@ -134,6 +142,7 @@ struct LogbookVisitRow: View {
                 .foregroundStyle(.orange)
         }
     }
+    #endif
 }
 
 #if DEBUG

--- a/PlaceNotes/Views/SettingsView.swift
+++ b/PlaceNotes/Views/SettingsView.swift
@@ -69,6 +69,7 @@ struct SettingsView: View {
     @State private var feedbackAccurateCount: Int = 0
     @State private var feedbackExportData: Data = Data()
     @State private var showFeedbackExporter = false
+    @State private var feedbackUploadStatus: String = "Not uploaded"
     #endif
 
     private var appVersion: String {
@@ -194,6 +195,11 @@ struct SettingsView: View {
                 Section {
                     LabeledContent("Feedback Collected", value: "\(feedbackCount)")
                     LabeledContent("Predicted Correctly", value: feedbackPrecisionText)
+                    LabeledContent("Azure Upload", value: feedbackUploadStatus)
+                    Button("Upload Feedback to Azure") {
+                        uploadFeedbackToAzure()
+                    }
+                    .disabled(feedbackCount == 0)
                     Button("Export Feedback CSV") {
                         exportFeedback()
                     }
@@ -323,6 +329,24 @@ struct SettingsView: View {
         let records = (try? modelContext.fetch(descriptor)) ?? []
         feedbackExportData = PredictionFeedbackExporter.exportCSV(from: records)
         showFeedbackExporter = true
+    }
+
+    private func uploadFeedbackToAzure() {
+        let descriptor = FetchDescriptor<PredictionFeedback>(sortBy: [SortDescriptor(\.createdAt)])
+        let records = (try? modelContext.fetch(descriptor)) ?? []
+        let payloads = records.map { PredictionFeedbackUploadPayload(record: $0) }
+        guard !payloads.isEmpty else {
+            feedbackUploadStatus = "No feedback"
+            return
+        }
+
+        feedbackUploadStatus = "Uploading…"
+        Task {
+            let summary = await PredictionFeedbackUploader.upload(payloads)
+            await MainActor.run {
+                feedbackUploadStatus = summary.displayText
+            }
+        }
     }
     #endif
 

--- a/PlaceNotes/Views/SettingsView.swift
+++ b/PlaceNotes/Views/SettingsView.swift
@@ -64,10 +64,12 @@ struct SettingsView: View {
     @State private var retentionInputText = ""
     @State private var exportData: Data = Data()
     @State private var showExporter = false
+    #if DEBUG
     @State private var feedbackCount: Int = 0
     @State private var feedbackAccurateCount: Int = 0
     @State private var feedbackExportData: Data = Data()
     @State private var showFeedbackExporter = false
+    #endif
 
     private var appVersion: String {
         Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "—"
@@ -188,6 +190,7 @@ struct SettingsView: View {
                 }
                 .onAppear { refreshRawSampleCount() }
 
+                #if DEBUG
                 Section {
                     LabeledContent("Feedback Collected", value: "\(feedbackCount)")
                     LabeledContent("Predicted Correctly", value: feedbackPrecisionText)
@@ -201,6 +204,7 @@ struct SettingsView: View {
                     Text("Your “correct / wrong” verdicts on recorded places are logged here. Export the labeled CSV to analyze prediction quality offline or train a model.")
                 }
                 .onAppear { refreshFeedbackStats() }
+                #endif
 
                 Section {
                     Button(role: .destructive) {
@@ -212,7 +216,11 @@ struct SettingsView: View {
                             Spacer()
                         }
                     }
+                    #if DEBUG
+                    .disabled(places.isEmpty && visits.isEmpty && feedbackCount == 0)
+                    #else
                     .disabled(places.isEmpty && visits.isEmpty)
+                    #endif
                 }
 
                 Section("About") {
@@ -234,6 +242,7 @@ struct SettingsView: View {
                     Button(role: .destructive) {
                         DebugSeed.clearAllData(in: modelContext)
                         refreshRawSampleCount()
+                        refreshFeedbackStats()
                         refreshStorageSize()
                     } label: {
                         Text("Clear All Data (Debug)")
@@ -282,15 +291,18 @@ struct SettingsView: View {
                 contentType: .commaSeparatedText,
                 defaultFilename: "location_samples_\(formattedDate())"
             ) { _ in }
+            #if DEBUG
             .fileExporter(
                 isPresented: $showFeedbackExporter,
                 document: CSVFile(data: feedbackExportData),
                 contentType: .commaSeparatedText,
                 defaultFilename: "prediction_feedback_\(formattedDate())"
             ) { _ in }
+            #endif
         }
     }
 
+    #if DEBUG
     private func refreshFeedbackStats() {
         feedbackCount = (try? modelContext.fetchCount(FetchDescriptor<PredictionFeedback>())) ?? 0
         let accurateRaw = PredictionVerdict.accurate.rawValue
@@ -312,6 +324,7 @@ struct SettingsView: View {
         feedbackExportData = PredictionFeedbackExporter.exportCSV(from: records)
         showFeedbackExporter = true
     }
+    #endif
 
     private func refreshRawSampleCount() {
         rawSampleCount = (try? modelContext.fetchCount(FetchDescriptor<RawLocationSample>())) ?? 0
@@ -353,8 +366,17 @@ struct SettingsView: View {
         for category in customCategories {
             modelContext.delete(category)
         }
+        #if DEBUG
+        let feedback = (try? modelContext.fetch(FetchDescriptor<PredictionFeedback>())) ?? []
+        for record in feedback {
+            modelContext.delete(record)
+        }
+        #endif
         try? modelContext.save()
         PhotoStorage.deleteAll()
+        #if DEBUG
+        refreshFeedbackStats()
+        #endif
     }
 
     private func refreshStorageSize() {

--- a/PlaceNotes/Views/SettingsView.swift
+++ b/PlaceNotes/Views/SettingsView.swift
@@ -64,6 +64,10 @@ struct SettingsView: View {
     @State private var retentionInputText = ""
     @State private var exportData: Data = Data()
     @State private var showExporter = false
+    @State private var feedbackCount: Int = 0
+    @State private var feedbackAccurateCount: Int = 0
+    @State private var feedbackExportData: Data = Data()
+    @State private var showFeedbackExporter = false
 
     private var appVersion: String {
         Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "—"
@@ -185,6 +189,20 @@ struct SettingsView: View {
                 .onAppear { refreshRawSampleCount() }
 
                 Section {
+                    LabeledContent("Feedback Collected", value: "\(feedbackCount)")
+                    LabeledContent("Predicted Correctly", value: feedbackPrecisionText)
+                    Button("Export Feedback CSV") {
+                        exportFeedback()
+                    }
+                    .disabled(feedbackCount == 0)
+                } header: {
+                    Text("Prediction Feedback")
+                } footer: {
+                    Text("Your “correct / wrong” verdicts on recorded places are logged here. Export the labeled CSV to analyze prediction quality offline or train a model.")
+                }
+                .onAppear { refreshFeedbackStats() }
+
+                Section {
                     Button(role: .destructive) {
                         showClearDataConfirmation = true
                     } label: {
@@ -264,7 +282,35 @@ struct SettingsView: View {
                 contentType: .commaSeparatedText,
                 defaultFilename: "location_samples_\(formattedDate())"
             ) { _ in }
+            .fileExporter(
+                isPresented: $showFeedbackExporter,
+                document: CSVFile(data: feedbackExportData),
+                contentType: .commaSeparatedText,
+                defaultFilename: "prediction_feedback_\(formattedDate())"
+            ) { _ in }
         }
+    }
+
+    private func refreshFeedbackStats() {
+        feedbackCount = (try? modelContext.fetchCount(FetchDescriptor<PredictionFeedback>())) ?? 0
+        let accurateRaw = PredictionVerdict.accurate.rawValue
+        let descriptor = FetchDescriptor<PredictionFeedback>(
+            predicate: #Predicate { $0.verdictRaw == accurateRaw }
+        )
+        feedbackAccurateCount = (try? modelContext.fetchCount(descriptor)) ?? 0
+    }
+
+    private var feedbackPrecisionText: String {
+        guard feedbackCount > 0 else { return "—" }
+        let pct = Int((Double(feedbackAccurateCount) / Double(feedbackCount) * 100).rounded())
+        return "\(pct)% (\(feedbackAccurateCount)/\(feedbackCount))"
+    }
+
+    private func exportFeedback() {
+        let descriptor = FetchDescriptor<PredictionFeedback>(sortBy: [SortDescriptor(\.createdAt)])
+        let records = (try? modelContext.fetch(descriptor)) ?? []
+        feedbackExportData = PredictionFeedbackExporter.exportCSV(from: records)
+        showFeedbackExporter = true
     }
 
     private func refreshRawSampleCount() {

--- a/PlaceNotesTests/DebugSeedTests.swift
+++ b/PlaceNotesTests/DebugSeedTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+import SwiftData
+@testable import PlaceNotes
+
+@MainActor
+final class DebugSeedTests: XCTestCase {
+    private func makeContext() throws -> ModelContext {
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        let container = try ModelContainer(
+            for: Place.self, Visit.self, JournalEntry.self, CustomCategory.self,
+            RawLocationSample.self, PredictionFeedback.self,
+            configurations: config
+        )
+        return ModelContext(container)
+    }
+
+    func testClearAllDataDeletesPredictionFeedback() throws {
+        let ctx = try makeContext()
+        let place = Place(name: "Blue Bottle", latitude: 37.78, longitude: -122.41)
+        let visit = Visit(arrivalDate: Date(), place: place)
+        let feedback = PredictionFeedback(
+            visitID: visit.id,
+            arrivalDate: visit.arrivalDate,
+            predictedPlaceName: place.name,
+            predictedCategory: place.category,
+            confidenceRaw: visit.confidence.rawValue,
+            medianAccuracyMeters: nil,
+            alternativeCount: 0,
+            latitude: place.latitude,
+            longitude: place.longitude,
+            verdict: .accurate
+        )
+
+        ctx.insert(place)
+        ctx.insert(visit)
+        ctx.insert(feedback)
+        try ctx.save()
+
+        DebugSeed.clearAllData(in: ctx)
+
+        XCTAssertEqual(try ctx.fetchCount(FetchDescriptor<PredictionFeedback>()), 0)
+        XCTAssertEqual(try ctx.fetchCount(FetchDescriptor<Visit>()), 0)
+        XCTAssertEqual(try ctx.fetchCount(FetchDescriptor<Place>()), 0)
+    }
+}

--- a/PlaceNotesTests/PredictionFeedbackExporterTests.swift
+++ b/PlaceNotesTests/PredictionFeedbackExporterTests.swift
@@ -1,0 +1,74 @@
+import XCTest
+@testable import PlaceNotes
+
+final class PredictionFeedbackExporterTests: XCTestCase {
+
+    private func makeRecord(
+        predictedName: String = "Blue Bottle",
+        verdict: PredictionVerdict = .accurate,
+        correctedName: String? = nil,
+        correctionSource: String? = nil
+    ) -> PredictionFeedback {
+        PredictionFeedback(
+            visitID: UUID(),
+            arrivalDate: Date(timeIntervalSince1970: 0),
+            predictedPlaceName: predictedName,
+            predictedCategory: "Cafe",
+            confidenceRaw: PlaceConfidence.high.rawValue,
+            medianAccuracyMeters: 12.5,
+            alternativeCount: 2,
+            latitude: 37.78,
+            longitude: -122.41,
+            verdict: verdict,
+            correctedName: correctedName,
+            correctedCategory: nil,
+            correctionSource: correctionSource,
+            createdAt: Date(timeIntervalSince1970: 0)
+        )
+    }
+
+    private func csvString(_ records: [PredictionFeedback]) -> String {
+        String(data: PredictionFeedbackExporter.exportCSV(from: records), encoding: .utf8) ?? ""
+    }
+
+    func testEmptyExportContainsHeaderOnly() {
+        let csv = csvString([])
+        XCTAssertEqual(csv, PredictionFeedbackExporter.header)
+    }
+
+    func testRowCountMatchesRecords() {
+        let csv = csvString([makeRecord(), makeRecord(), makeRecord()])
+        let lines = csv.split(separator: "\n")
+        XCTAssertEqual(lines.count, 4) // header + 3 rows
+    }
+
+    func testAccurateVerdictEncodesLabelOne() {
+        let csv = csvString([makeRecord(verdict: .accurate)])
+        let row = csv.split(separator: "\n")[1]
+        XCTAssertTrue(row.contains(",accurate,1,"))
+    }
+
+    func testWrongVerdictEncodesLabelZero() {
+        let csv = csvString([makeRecord(verdict: .wrong)])
+        let row = csv.split(separator: "\n")[1]
+        XCTAssertTrue(row.contains(",wrong,0,"))
+    }
+
+    func testCorrectedVerdictEncodesLabelZeroAndCorrection() {
+        let csv = csvString([makeRecord(verdict: .corrected, correctedName: "Philz Coffee", correctionSource: "alternative")])
+        let row = csv.split(separator: "\n")[1]
+        XCTAssertTrue(row.contains(",corrected,0,"))
+        XCTAssertTrue(row.contains("Philz Coffee"))
+        XCTAssertTrue(row.contains("alternative"))
+    }
+
+    func testNameWithCommaIsQuoted() {
+        let csv = csvString([makeRecord(predictedName: "Joe's Diner, Inc")])
+        XCTAssertTrue(csv.contains("\"Joe's Diner, Inc\""))
+    }
+
+    func testNameWithQuoteIsEscaped() {
+        let csv = csvString([makeRecord(predictedName: "The \"Best\" Spot")])
+        XCTAssertTrue(csv.contains("\"The \"\"Best\"\" Spot\""))
+    }
+}

--- a/PlaceNotesTests/PredictionFeedbackRecorderTests.swift
+++ b/PlaceNotesTests/PredictionFeedbackRecorderTests.swift
@@ -45,7 +45,6 @@ final class PredictionFeedbackRecorderTests: XCTestCase {
         XCTAssertEqual(records.first?.verdict, .accurate)
         XCTAssertEqual(records.first?.predictedPlaceName, "Blue Bottle")
         XCTAssertEqual(records.first?.alternativeCount, 1)
-        XCTAssertEqual(visit.feedbackVerdict, .accurate)
         XCTAssertTrue(visit.placeConfirmed)
     }
 
@@ -59,7 +58,7 @@ final class PredictionFeedbackRecorderTests: XCTestCase {
         let records = allFeedback(ctx)
         XCTAssertEqual(records.count, 1)
         XCTAssertEqual(records.first?.verdict, .wrong)
-        XCTAssertEqual(visit.feedbackVerdict, .wrong)
+        XCTAssertFalse(visit.placeConfirmed)
     }
 
     func testWrongDoesNotConfirmPlace() throws {
@@ -69,7 +68,7 @@ final class PredictionFeedbackRecorderTests: XCTestCase {
         PredictionFeedbackRecorder.record(.wrong, for: visit, in: ctx)
 
         XCTAssertFalse(visit.placeConfirmed)
-        XCTAssertEqual(visit.feedbackVerdict, .wrong)
+        XCTAssertEqual(allFeedback(ctx).first?.verdict, .wrong)
     }
 
     func testCorrectedCapturesPredictionSnapshotAndCorrection() throws {

--- a/PlaceNotesTests/PredictionFeedbackRecorderTests.swift
+++ b/PlaceNotesTests/PredictionFeedbackRecorderTests.swift
@@ -1,0 +1,95 @@
+import XCTest
+import SwiftData
+@testable import PlaceNotes
+
+@MainActor
+final class PredictionFeedbackRecorderTests: XCTestCase {
+
+    private func makeContext() throws -> ModelContext {
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        let container = try ModelContainer(
+            for: Place.self, Visit.self, JournalEntry.self, CustomCategory.self,
+            RawLocationSample.self, PredictionFeedback.self,
+            configurations: config
+        )
+        return ModelContext(container)
+    }
+
+    private func makeVisit(in ctx: ModelContext) -> Visit {
+        let place = Place(name: "Blue Bottle", latitude: 37.78, longitude: -122.41, category: "Cafe")
+        ctx.insert(place)
+        let visit = Visit(arrivalDate: Date(), place: place)
+        visit.confidence = .high
+        visit.medianAccuracyMeters = 14
+        visit.alternativePlaces = [
+            PlaceCandidate(name: "Philz", latitude: 37.7801, longitude: -122.4101,
+                           category: "Cafe", city: nil, state: nil, distanceMeters: 20)
+        ]
+        ctx.insert(visit)
+        try? ctx.save()
+        return visit
+    }
+
+    private func allFeedback(_ ctx: ModelContext) -> [PredictionFeedback] {
+        (try? ctx.fetch(FetchDescriptor<PredictionFeedback>())) ?? []
+    }
+
+    func testAccurateCreatesRecordAndSetsVerdict() throws {
+        let ctx = try makeContext()
+        let visit = makeVisit(in: ctx)
+
+        PredictionFeedbackRecorder.record(.accurate, for: visit, in: ctx)
+
+        let records = allFeedback(ctx)
+        XCTAssertEqual(records.count, 1)
+        XCTAssertEqual(records.first?.verdict, .accurate)
+        XCTAssertEqual(records.first?.predictedPlaceName, "Blue Bottle")
+        XCTAssertEqual(records.first?.alternativeCount, 1)
+        XCTAssertEqual(visit.feedbackVerdict, .accurate)
+        XCTAssertTrue(visit.placeConfirmed)
+    }
+
+    func testResubmittingReplacesPreviousRecord() throws {
+        let ctx = try makeContext()
+        let visit = makeVisit(in: ctx)
+
+        PredictionFeedbackRecorder.record(.accurate, for: visit, in: ctx)
+        PredictionFeedbackRecorder.record(.wrong, for: visit, in: ctx)
+
+        let records = allFeedback(ctx)
+        XCTAssertEqual(records.count, 1)
+        XCTAssertEqual(records.first?.verdict, .wrong)
+        XCTAssertEqual(visit.feedbackVerdict, .wrong)
+    }
+
+    func testWrongDoesNotConfirmPlace() throws {
+        let ctx = try makeContext()
+        let visit = makeVisit(in: ctx)
+
+        PredictionFeedbackRecorder.record(.wrong, for: visit, in: ctx)
+
+        XCTAssertFalse(visit.placeConfirmed)
+        XCTAssertEqual(visit.feedbackVerdict, .wrong)
+    }
+
+    func testCorrectedCapturesPredictionSnapshotAndCorrection() throws {
+        let ctx = try makeContext()
+        let visit = makeVisit(in: ctx)
+
+        PredictionFeedbackRecorder.record(
+            .corrected,
+            for: visit,
+            correctedName: "Philz",
+            correctedCategory: "Cafe",
+            correctionSource: "alternative",
+            in: ctx
+        )
+
+        let record = allFeedback(ctx).first
+        XCTAssertEqual(record?.verdict, .corrected)
+        XCTAssertEqual(record?.predictedPlaceName, "Blue Bottle") // the wrong prediction
+        XCTAssertEqual(record?.correctedPlaceName, "Philz")
+        XCTAssertEqual(record?.correctionSource, "alternative")
+        XCTAssertTrue(visit.placeConfirmed)
+    }
+}

--- a/PlaceNotesTests/PredictionFeedbackUploaderTests.swift
+++ b/PlaceNotesTests/PredictionFeedbackUploaderTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+import Foundation
+@testable import PlaceNotes
+
+final class PredictionFeedbackUploaderTests: XCTestCase {
+    private final class StubHTTPSession: PredictionFeedbackHTTPSession {
+        var receivedRequest: URLRequest?
+        var result: Result<(Data, URLResponse), Error>
+
+        init(result: Result<(Data, URLResponse), Error>) {
+            self.result = result
+        }
+
+        func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+            receivedRequest = request
+            return try result.get()
+        }
+    }
+
+    private func makePayload(verdict: PredictionVerdict = .accurate) -> PredictionFeedbackUploadPayload {
+        let record = PredictionFeedback(
+            visitID: UUID(uuidString: "11111111-1111-1111-1111-111111111111")!,
+            arrivalDate: Date(timeIntervalSince1970: 1_700_000_000),
+            predictedPlaceName: "Blue Bottle",
+            predictedCategory: "Cafe",
+            confidenceRaw: "High",
+            medianAccuracyMeters: 14,
+            alternativeCount: 1,
+            latitude: 37.78,
+            longitude: -122.41,
+            verdict: verdict,
+            correctedName: nil,
+            correctedCategory: nil,
+            correctionSource: nil,
+            createdAt: Date(timeIntervalSince1970: 1_700_000_100)
+        )
+        return PredictionFeedbackUploadPayload(record: record, bundle: Bundle(for: Self.self))
+    }
+
+    func testUploadPostsJSONToAzureFunctionEndpoint() async throws {
+        let endpoint = URL(string: "https://example.test/api/feedback")!
+        let response = HTTPURLResponse(url: endpoint, statusCode: 202, httpVersion: nil, headerFields: nil)!
+        let session = StubHTTPSession(result: .success((Data(), response)))
+
+        let result = await PredictionFeedbackUploader.upload(makePayload(), endpoint: endpoint, session: session)
+
+        XCTAssertEqual(result, .success)
+        let request = try XCTUnwrap(session.receivedRequest)
+        XCTAssertEqual(request.url, endpoint)
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+
+        let body = try XCTUnwrap(request.httpBody)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+        XCTAssertEqual(json["schemaVersion"] as? Int, 1)
+        XCTAssertEqual(json["buildConfiguration"] as? String, "debug")
+        XCTAssertEqual(json["predictedPlaceName"] as? String, "Blue Bottle")
+        XCTAssertEqual(json["verdict"] as? String, "accurate")
+        XCTAssertEqual(json["wasAccurate"] as? Bool, true)
+    }
+
+    func testUploadTreatsNoInternetAsRecoverableNetworkUnavailable() async {
+        let endpoint = URL(string: "https://example.test/api/feedback")!
+        let session = StubHTTPSession(result: .failure(URLError(.notConnectedToInternet)))
+
+        let result = await PredictionFeedbackUploader.upload(makePayload(), endpoint: endpoint, session: session)
+
+        guard case .networkUnavailable = result else {
+            XCTFail("Expected networkUnavailable, got \(result)")
+            return
+        }
+    }
+
+    func testUploadSummarizesPartialNetworkFailures() async {
+        let endpoint = URL(string: "https://example.test/api/feedback")!
+        let session = StubHTTPSession(result: .failure(URLError(.timedOut)))
+
+        let summary = await PredictionFeedbackUploader.upload(
+            [makePayload(), makePayload(verdict: .wrong)],
+            endpoint: endpoint,
+            session: session
+        )
+
+        XCTAssertEqual(summary.succeeded, 0)
+        XCTAssertEqual(summary.failed, 0)
+        XCTAssertEqual(summary.networkUnavailable, 2)
+        XCTAssertEqual(summary.displayText, "No internet: 2 pending")
+    }
+}

--- a/PlaceNotesTests/VisitTests.swift
+++ b/PlaceNotesTests/VisitTests.swift
@@ -13,11 +13,14 @@ final class VisitTests: XCTestCase {
     }
 
     func testDurationWithoutDepartureUsesNow() {
-        let arrival = Date().addingTimeInterval(-30 * 60) // 30 minutes ago
+        let now = Date()
+        let startOfToday = Calendar.current.startOfDay(for: now)
+        let preferredArrival = now.addingTimeInterval(-30 * 60)
+        let arrival = preferredArrival < startOfToday ? startOfToday : preferredArrival
         let visit = Visit(arrivalDate: arrival, departureDate: nil)
-        // Should be approximately 30 minutes (allow 1 min tolerance for test execution)
-        XCTAssertGreaterThanOrEqual(visit.durationMinutes, 29)
-        XCTAssertLessThanOrEqual(visit.durationMinutes, 31)
+        let expectedMinutes = Int(Date().timeIntervalSince(arrival) / 60)
+        XCTAssertGreaterThanOrEqual(visit.durationMinutes, max(0, expectedMinutes - 1))
+        XCTAssertLessThanOrEqual(visit.durationMinutes, expectedMinutes + 1)
     }
 
     func testDurationNeverNegative() {
@@ -175,11 +178,15 @@ final class VisitTests: XCTestCase {
     }
 
     func testEffectiveDurationTodayUsesNowWhenNoCap() {
-        let arrival = Date().addingTimeInterval(-15 * 60)
+        let now = Date()
+        let startOfToday = Calendar.current.startOfDay(for: now)
+        let preferredArrival = now.addingTimeInterval(-15 * 60)
+        let arrival = preferredArrival < startOfToday ? startOfToday : preferredArrival
         let visit = Visit(arrivalDate: arrival, departureDate: nil)
         let mins = visit.effectiveDurationMinutes(cappedAt: nil)
-        XCTAssertGreaterThanOrEqual(mins, 14)
-        XCTAssertLessThanOrEqual(mins, 16)
+        let expectedMinutes = Int(Date().timeIntervalSince(arrival) / 60)
+        XCTAssertGreaterThanOrEqual(mins, max(0, expectedMinutes - 1))
+        XCTAssertLessThanOrEqual(mins, expectedMinutes + 1)
     }
 
     // MARK: - Helpers

--- a/azure/feedback-function/README.md
+++ b/azure/feedback-function/README.md
@@ -1,0 +1,45 @@
+# PlaceLore Feedback Function
+
+Debug-only ingestion endpoint for place-prediction feedback from the iOS app.
+
+## Endpoint
+
+`POST /api/feedback`
+
+The function validates the JSON payload sent by `PredictionFeedbackUploader` and writes one JSON document per feedback event to ADLS Gen2:
+
+`feedback/prediction-feedback/debug/YYYY/MM/DD/<eventID>.json`
+
+## App Settings
+
+- `FEEDBACK_STORAGE_ACCOUNT`: ADLS Gen2 storage account name.
+- `FEEDBACK_FILE_SYSTEM`: ADLS Gen2 filesystem/container name.
+- `FEEDBACK_DIRECTORY`: root directory for uploaded feedback.
+- `FEEDBACK_API_KEY`: optional shared key. When set, requests must include the same value in `x-placelore-feedback-key`.
+
+## Identity
+
+The deployed Function App should use a managed identity with `Storage Blob Data Contributor` on the target storage account.
+
+## Deploy
+
+From this directory:
+
+```sh
+zip -r /tmp/placelore-feedback-function.zip . \
+  -x 'local.settings.json' 'local.settings.sample.json' '.venv/*' '__pycache__/*' '*.pyc'
+
+az functionapp config appsettings set \
+  -g rg-placelore-feedback-dev \
+  -n func-placelore-feedback-dev \
+  --settings \
+    FEEDBACK_STORAGE_ACCOUNT=stplacelorefbdev909 \
+    FEEDBACK_FILE_SYSTEM=feedback \
+    FEEDBACK_DIRECTORY=prediction-feedback/debug
+
+az functionapp deployment source config-zip \
+  -g rg-placelore-feedback-dev \
+  -n func-placelore-feedback-dev \
+  --src /tmp/placelore-feedback-function.zip \
+  --build-remote true
+```

--- a/azure/feedback-function/function_app.py
+++ b/azure/feedback-function/function_app.py
@@ -1,0 +1,146 @@
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from typing import Any
+
+import azure.functions as func
+from azure.identity import DefaultAzureCredential
+from azure.core.exceptions import ResourceExistsError
+from azure.storage.filedatalake import DataLakeServiceClient
+
+app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
+
+REQUIRED_FIELDS = {
+    "schemaVersion": int,
+    "appVersion": str,
+    "appBuild": str,
+    "buildConfiguration": str,
+    "eventID": str,
+    "createdAt": str,
+    "visitID": str,
+    "arrivalDate": str,
+    "latitude": (int, float),
+    "longitude": (int, float),
+    "predictedPlaceName": str,
+    "confidence": str,
+    "alternativeCount": int,
+    "verdict": str,
+    "wasAccurate": bool,
+}
+
+
+def _json_response(status_code: int, body: dict[str, Any]) -> func.HttpResponse:
+    return func.HttpResponse(
+        json.dumps(body, separators=(",", ":")),
+        status_code=status_code,
+        mimetype="application/json",
+    )
+
+
+def _validate_api_key(req: func.HttpRequest) -> bool:
+    expected_key = os.getenv("FEEDBACK_API_KEY", "")
+    if not expected_key:
+        return True
+    return req.headers.get("x-placelore-feedback-key") == expected_key
+
+
+def _parse_iso8601(value: str) -> datetime:
+    normalized = value.replace("Z", "+00:00")
+    return datetime.fromisoformat(normalized).astimezone(timezone.utc)
+
+
+def _validate_payload(payload: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    for field, expected_type in REQUIRED_FIELDS.items():
+        if field not in payload:
+            errors.append(f"Missing {field}")
+        elif not isinstance(payload[field], expected_type):
+            errors.append(f"Invalid {field}")
+
+    if payload.get("schemaVersion") != 1:
+        errors.append("Unsupported schemaVersion")
+    if payload.get("buildConfiguration") != "debug":
+        errors.append("Only debug feedback is accepted")
+
+    for date_field in ("createdAt", "arrivalDate"):
+        if isinstance(payload.get(date_field), str):
+            try:
+                _parse_iso8601(payload[date_field])
+            except ValueError:
+                errors.append(f"Invalid {date_field}")
+
+    return errors
+
+
+def _feedback_path(payload: dict[str, Any]) -> str:
+    created_at = _parse_iso8601(payload["createdAt"])
+    directory = os.getenv("FEEDBACK_DIRECTORY", "prediction-feedback/debug").strip("/")
+    return (
+        f"{directory}/"
+        f"{created_at:%Y/%m/%d}/"
+        f"{payload['eventID']}.json"
+    )
+
+
+def _service_client() -> DataLakeServiceClient:
+    account_name = os.environ["FEEDBACK_STORAGE_ACCOUNT"]
+    account_url = f"https://{account_name}.dfs.core.windows.net"
+    return DataLakeServiceClient(
+        account_url=account_url,
+        credential=DefaultAzureCredential(),
+    )
+
+
+def _write_feedback(payload: dict[str, Any]) -> str:
+    file_system_name = os.getenv("FEEDBACK_FILE_SYSTEM", "feedback")
+    destination_path = _feedback_path(payload)
+    parent_directory = destination_path.rsplit("/", maxsplit=1)[0]
+    envelope = {
+        "ingestedAt": datetime.now(timezone.utc).isoformat(),
+        "source": "placelore-ios-debug",
+        "payload": payload,
+    }
+    data = json.dumps(envelope, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+    file_system = _service_client().get_file_system_client(file_system_name)
+    _ensure_directory(file_system, parent_directory)
+    file_client = file_system.get_file_client(destination_path)
+    file_client.upload_data(data, overwrite=True)
+    return destination_path
+
+
+def _ensure_directory(file_system: Any, directory_path: str) -> None:
+    current_path = ""
+    for segment in directory_path.split("/"):
+        current_path = f"{current_path}/{segment}" if current_path else segment
+        try:
+            file_system.create_directory(current_path)
+        except ResourceExistsError:
+            continue
+
+
+@app.route(route="feedback", methods=["POST"])
+def feedback(req: func.HttpRequest) -> func.HttpResponse:
+    if not _validate_api_key(req):
+        return _json_response(401, {"error": "Unauthorized"})
+
+    try:
+        payload = req.get_json()
+    except ValueError:
+        return _json_response(400, {"error": "Invalid JSON"})
+
+    if not isinstance(payload, dict):
+        return _json_response(400, {"error": "JSON body must be an object"})
+
+    errors = _validate_payload(payload)
+    if errors:
+        return _json_response(400, {"error": "Invalid payload", "details": errors})
+
+    try:
+        path = _write_feedback(payload)
+    except Exception:
+        logging.exception("Failed to write feedback payload")
+        return _json_response(500, {"error": "Failed to store feedback"})
+
+    return _json_response(202, {"status": "accepted", "path": path})

--- a/azure/feedback-function/host.json
+++ b/azure/feedback-function/host.json
@@ -1,0 +1,15 @@
+{
+  "version": "2.0",
+  "logging": {
+    "applicationInsights": {
+      "samplingSettings": {
+        "isEnabled": true,
+        "excludedTypes": "Request"
+      }
+    }
+  },
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  }
+}

--- a/azure/feedback-function/local.settings.sample.json
+++ b/azure/feedback-function/local.settings.sample.json
@@ -1,0 +1,11 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "python",
+    "FEEDBACK_STORAGE_ACCOUNT": "stplacelorefbdev909",
+    "FEEDBACK_FILE_SYSTEM": "feedback",
+    "FEEDBACK_DIRECTORY": "prediction-feedback/debug",
+    "FEEDBACK_API_KEY": ""
+  }
+}

--- a/azure/feedback-function/requirements.txt
+++ b/azure/feedback-function/requirements.txt
@@ -1,0 +1,3 @@
+azure-functions==1.21.3
+azure-identity==1.19.0
+azure-storage-file-datalake==12.17.0


### PR DESCRIPTION
## Summary

Adds a closed feedback loop on place-prediction accuracy. Users mark whether each recorded place was predicted correctly; verdicts are persisted as labeled records, summarized as a precision metric, and exported as a CSV dataset for offline analysis and future model training.

## Capture (Logbook)
- Every visit row gains a **Correct / Wrong** feedback bar. Tapping **Correct** logs an `accurate` verdict inline.
- Tapping **Wrong** opens a "How did we do?" sheet where the user can pick the right place from nearby alternatives (logs `corrected`, snapshotting what the algorithm got wrong *before* reassigning) or mark it `wrong` when none fit.
- Once given, the row shows the verdict state instead of the buttons.
- Feedback is available on **any** visit, not just ones with POI alternatives — the previous affordance only appeared when alternatives existed, which under-sampled exactly the low-confidence cases that matter most.

## Persist
- New `PredictionFeedback` `@Model`: one labeled record per visit, snapshotting the prediction's features at decision time (predicted name/category, confidence, median GPS accuracy, alternative count, coordinates) plus the user verdict, any correction, and a binary `wasAccurate` label.
- `PredictionVerdict` enum (`accurate` / `wrong` / `corrected`) with a `wasAccurate` training label.
- `Visit.feedbackVerdict` mirrors the canonical record for row state.
- `PredictionFeedbackRecorder` upserts one record per visit on the main actor (re-submitting replaces).

## Measure & export (Settings → Prediction Feedback)
- Live precision summary (`X% (n/total)`).
- **Export Feedback CSV** button. `PredictionFeedbackExporter` emits features + label with CSV-safe escaping for free-text place names — ready for pandas / scikit-learn.

## Tests
- `PredictionFeedbackExporterTests`: header, row counts, label encoding, CSV escaping.
- `PredictionFeedbackRecorderTests`: upsert behavior, snapshot timing for corrections, verdict/confirm side-effects.

## Notes
- Schema change is additive (new entity + one optional `Visit` field) keeping `versionIdentifier` at 1.0.0 with empty migration stages — same lightweight-migration approach already used for `RawLocationSample`.
- Feedback entry point is scoped to the Logbook list; `TripDetailView` reuses the same row but the bar is gated off there to avoid dead buttons (easy to enable later).
- Couldn't compile locally (no Swift/Xcode on Linux); CI builds on macOS via XcodeGen, which auto-globs the source dirs so new files are included.

https://claude.ai/code/session_017DTCGbchMNjX2XKZn2fsw6

---
_Generated by [Claude Code](https://claude.ai/code/session_017DTCGbchMNjX2XKZn2fsw6)_