### PR TITLE
Fix empty place picker when location is too coarse (corp WiFi)

### DIFF
--- a/PlaceNotes/ViewModels/QuickCaptureViewModel.swift
+++ b/PlaceNotes/ViewModels/QuickCaptureViewModel.swift
@@ -32,6 +32,11 @@ final class QuickCaptureViewModel: ObservableObject {
     @Published var showCamera: Bool = false
     @Published private(set) var pendingPhotoAssetId: String?
 
+    /// Best-available coordinate when auto-resolution failed (e.g. indoors on WiFi where
+    /// accuracy exceeds the strict attribution threshold). Not precise enough to attribute
+    /// automatically, but lets the manual picker show nearby places and offer to save here.
+    @Published private(set) var pendingApproximateCoordinate: CLLocationCoordinate2D?
+
     var isWorkingInBackground: Bool {
         switch state {
         case .savingPhoto, .resolvingPlace: return true
@@ -112,6 +117,7 @@ final class QuickCaptureViewModel: ObservableObject {
         pendingLiveFix = nil
         pendingKnownPlace = nil
         pendingPhotoAssetId = nil
+        pendingApproximateCoordinate = nil
         showCamera = false
         state = .idle
     }
@@ -122,6 +128,21 @@ final class QuickCaptureViewModel: ObservableObject {
             guard let self else { return }
             let result = await QuickCaptureService.logCapture(
                 coordinate: CLLocation(latitude: place.latitude, longitude: place.longitude),
+                photoAssetId: photoAssetId,
+                in: self.context
+            )
+            await MainActor.run { self.state = .done(self.toast(from: result)) }
+        }
+    }
+
+    /// User-confirmed save at the approximate coordinate when no precise fix was available.
+    /// Resolves to an existing nearby place or creates a new one via `PlaceResolver`.
+    func manualLocationSelected(coordinate: CLLocationCoordinate2D, photoAssetId: String) {
+        state = .resolvingPlace
+        Task { [weak self] in
+            guard let self else { return }
+            let result = await QuickCaptureService.logCapture(
+                coordinate: CLLocation(latitude: coordinate.latitude, longitude: coordinate.longitude),
                 photoAssetId: photoAssetId,
                 in: self.context
             )
@@ -205,9 +226,11 @@ final class QuickCaptureViewModel: ObservableObject {
             cachedFix: cachedFix
         )
         guard let coord else {
-            logger.info("No coordinate available — falling back to manual picker")
+            logger.info("No coordinate accurate enough to attribute — falling back to manual picker")
+            let approximate = (pendingLiveFix ?? exifLocation ?? cachedFix)?.coordinate
             await MainActor.run {
                 self.pendingPhotoAssetId = photoAssetId
+                self.pendingApproximateCoordinate = approximate
                 self.state = .manualPickNeeded
             }
             return

--- a/PlaceNotes/Views/ContentView.swift
+++ b/PlaceNotes/Views/ContentView.swift
@@ -56,9 +56,16 @@ struct ContentView: View {
             }
         )) {
             ManualPlacePickerView(
+                nearCoordinate: quickCapture.pendingApproximateCoordinate,
                 onPicked: { place in
                     if let id = quickCapture.pendingPhotoAssetId {
                         quickCapture.manualPlaceSelected(place, photoAssetId: id)
+                    }
+                },
+                onUseCurrentLocation: {
+                    if let id = quickCapture.pendingPhotoAssetId,
+                       let coord = quickCapture.pendingApproximateCoordinate {
+                        quickCapture.manualLocationSelected(coordinate: coord, photoAssetId: id)
                     }
                 },
                 onCancelled: { quickCapture.cancelCapture() }

--- a/PlaceNotes/Views/ManualPlacePickerView.swift
+++ b/PlaceNotes/Views/ManualPlacePickerView.swift
@@ -1,12 +1,17 @@
 import SwiftUI
 import SwiftData
+import CoreLocation
 
 struct ManualPlacePickerView: View {
     @Environment(\.modelContext) private var context
     @Environment(\.dismiss) private var dismiss
     @Query(sort: \Place.name) private var allPlaces: [Place]
 
+    /// When present, the picker ranks places by distance to this coordinate and offers
+    /// to save the photo here directly. Nil when no location is available at all.
+    let nearCoordinate: CLLocationCoordinate2D?
     let onPicked: (Place) -> Void
+    let onUseCurrentLocation: () -> Void
     let onCancelled: () -> Void
 
     @State private var search = ""
@@ -14,7 +19,17 @@ struct ManualPlacePickerView: View {
     var body: some View {
         NavigationStack {
             List {
-                Section("Recent places") {
+                if search.isEmpty, nearCoordinate != nil {
+                    Section {
+                        Button {
+                            onUseCurrentLocation()
+                            dismiss()
+                        } label: {
+                            Label("Save at my current location", systemImage: "location.fill")
+                        }
+                    }
+                }
+                Section(sectionTitle) {
                     if filteredPlaces.isEmpty {
                         Text("No matching places")
                             .foregroundStyle(.secondary)
@@ -48,9 +63,39 @@ struct ManualPlacePickerView: View {
         }
     }
 
+    private var sectionTitle: LocalizedStringKey {
+        nearCoordinate == nil ? "Recent places" : "Nearby places"
+    }
+
     private var filteredPlaces: [Place] {
-        guard !search.isEmpty else { return Array(allPlaces.prefix(20)) }
-        let needle = search.lowercased()
-        return allPlaces.filter { $0.displayName.lowercased().contains(needle) }
+        ManualPlacePickerRanking.rank(allPlaces, near: nearCoordinate, search: search)
+    }
+}
+
+/// Pure ranking/filtering logic for the manual place picker, extracted for unit testing.
+enum ManualPlacePickerRanking {
+    static let unsearchedLimit = 20
+
+    static func rank(
+        _ places: [Place],
+        near coordinate: CLLocationCoordinate2D?,
+        search: String,
+        limit: Int = unsearchedLimit
+    ) -> [Place] {
+        let ordered: [Place]
+        if let coordinate {
+            let origin = CLLocation(latitude: coordinate.latitude, longitude: coordinate.longitude)
+            ordered = places.sorted {
+                origin.distance(from: CLLocation(latitude: $0.latitude, longitude: $0.longitude))
+                    < origin.distance(from: CLLocation(latitude: $1.latitude, longitude: $1.longitude))
+            }
+        } else {
+            ordered = places
+        }
+
+        let trimmed = search.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return Array(ordered.prefix(limit)) }
+        let needle = trimmed.lowercased()
+        return ordered.filter { $0.displayName.lowercased().contains(needle) }
     }
 }

--- a/PlaceNotesTests/ManualPlacePickerRankingTests.swift
+++ b/PlaceNotesTests/ManualPlacePickerRankingTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+import CoreLocation
+@testable import PlaceNotes
+
+@MainActor
+final class ManualPlacePickerRankingTests: XCTestCase {
+
+    private func place(_ name: String, lat: Double, lon: Double) -> Place {
+        Place(name: name, latitude: lat, longitude: lon)
+    }
+
+    func testRanksByDistanceWhenCoordinateProvided() {
+        let near = place("Near", lat: 37.7800, lon: -122.4100)
+        let mid = place("Mid", lat: 37.7900, lon: -122.4100)
+        let far = place("Far", lat: 38.0000, lon: -122.4100)
+        let origin = CLLocationCoordinate2D(latitude: 37.7801, longitude: -122.4100)
+
+        let ranked = ManualPlacePickerRanking.rank([far, mid, near], near: origin, search: "")
+
+        XCTAssertEqual(ranked.map(\.name), ["Near", "Mid", "Far"])
+    }
+
+    func testPreservesQueryOrderWhenNoCoordinate() {
+        let a = place("Alpha", lat: 0, lon: 0)
+        let b = place("Bravo", lat: 0, lon: 0)
+        let ranked = ManualPlacePickerRanking.rank([a, b], near: nil, search: "")
+        XCTAssertEqual(ranked.map(\.name), ["Alpha", "Bravo"])
+    }
+
+    func testSearchFiltersByDisplayNameCaseInsensitively() {
+        let cafe = place("Blue Bottle Cafe", lat: 0, lon: 0)
+        let gym = place("Gold's Gym", lat: 0, lon: 0)
+        let ranked = ManualPlacePickerRanking.rank([cafe, gym], near: nil, search: "cafe")
+        XCTAssertEqual(ranked.map(\.name), ["Blue Bottle Cafe"])
+    }
+
+    func testSearchAppliesAfterDistanceOrdering() {
+        let nearCafe = place("Corner Cafe", lat: 37.7800, lon: -122.4100)
+        let farCafe = place("Hill Cafe", lat: 38.0000, lon: -122.4100)
+        let gym = place("Gym", lat: 37.7801, lon: -122.4100)
+        let origin = CLLocationCoordinate2D(latitude: 37.7801, longitude: -122.4100)
+
+        let ranked = ManualPlacePickerRanking.rank([farCafe, gym, nearCafe], near: origin, search: "cafe")
+
+        XCTAssertEqual(ranked.map(\.name), ["Corner Cafe", "Hill Cafe"])
+    }
+
+    func testUnsearchedResultsAreLimited() {
+        let places = (0..<30).map { place("Place \($0)", lat: 0, lon: 0) }
+        let ranked = ManualPlacePickerRanking.rank(places, near: nil, search: "", limit: 20)
+        XCTAssertEqual(ranked.count, 20)
+    }
+
+    func testBlankSearchIsTreatedAsEmpty() {
+        let a = place("Alpha", lat: 0, lon: 0)
+        let ranked = ManualPlacePickerRanking.rank([a], near: nil, search: "   ")
+        XCTAssertEqual(ranked.map(\.name), ["Alpha"])
+    }
+}

--- a/PlaceNotesTests/QuickCaptureViewModelTests.swift
+++ b/PlaceNotesTests/QuickCaptureViewModelTests.swift
@@ -73,6 +73,71 @@ final class QuickCaptureViewModelTests: XCTestCase {
         XCTAssertEqual(vm.state, prior, "Re-entry while busy should be a no-op")
     }
 
+    func testCoarseFixFallsBackToManualPickWithApproximateCoordinate() async throws {
+        let stub = StubOneShot()
+        // Indoors-on-WiFi: a fix exists but is too coarse to attribute automatically.
+        stub.result = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 37.78, longitude: -122.41),
+            altitude: 0,
+            horizontalAccuracy: 200,
+            verticalAccuracy: -1,
+            timestamp: Date()
+        )
+        let vm = QuickCaptureViewModel(oneShot: stub, context: try makeContext())
+        vm.beginCapture()
+
+        let tinyImage = UIImage(systemName: "photo")!
+        vm.photoCaptured(image: tinyImage, exifLocation: nil)
+
+        let deadline = Date().addingTimeInterval(5)
+        while Date() < deadline {
+            if vm.state == .manualPickNeeded { break }
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+
+        XCTAssertEqual(vm.state, .manualPickNeeded)
+        XCTAssertNotNil(vm.pendingApproximateCoordinate)
+        XCTAssertEqual(vm.pendingApproximateCoordinate?.latitude ?? 0, 37.78, accuracy: 0.0001)
+        XCTAssertNotNil(vm.pendingPhotoAssetId)
+    }
+
+    func testManualLocationSelectedLogsCaptureAtCoordinate() async throws {
+        let context = try makeContext()
+        // Pre-insert a place at the coordinate so PlaceResolver matches it within 50m and
+        // never reaches the network (CLGeocoder / MKLocalSearch) — keeps the test offline.
+        let place = Place(name: "Office", latitude: 37.78, longitude: -122.41)
+        context.insert(place)
+        try context.save()
+        let vm = QuickCaptureViewModel(oneShot: StubOneShot(), context: context)
+
+        vm.manualLocationSelected(
+            coordinate: CLLocationCoordinate2D(latitude: 37.78, longitude: -122.41),
+            photoAssetId: "asset-coarse"
+        )
+
+        let deadline = Date().addingTimeInterval(5)
+        while Date() < deadline {
+            if case .done = vm.state { break }
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+
+        guard case .done = vm.state else {
+            XCTFail("Expected .done state, got \(vm.state)")
+            return
+        }
+        let entries = try context.fetch(FetchDescriptor<JournalEntry>())
+        XCTAssertEqual(entries.count, 1)
+        XCTAssertEqual(entries.first?.photoAssetIdentifiers, ["asset-coarse"])
+        XCTAssertEqual(entries.first?.place?.id, place.id)
+    }
+
+    func testCancelClearsApproximateCoordinate() throws {
+        let vm = QuickCaptureViewModel(oneShot: StubOneShot(), context: try makeContext())
+        vm.beginCapture()
+        vm.cancelCapture()
+        XCTAssertNil(vm.pendingApproximateCoordinate)
+    }
+
     func testKnownPlaceCaptureCreatesJournalEntryLinkedToVisit() async throws {
         let context = try makeContext()
         let place = Place(name: "Cafe", latitude: 0, longitude: 0)


### PR DESCRIPTION
Indoors on WiFi, GPS accuracy exceeds the strict 50m attribution
threshold and in-app photos carry no EXIF GPS, so resolveCoordinate
returns nil and the flow drops to the manual picker. That picker was
location-blind: it listed all places alphabetically (mislabeled
"Recent places") with no way to create a place where the user actually
is, producing the "No matching places" dead end.

Keep auto-attribution strict, but on fallback hand the picker the
best-available approximate coordinate so it can:
- rank existing places by distance ("Nearby places")
- offer a user-confirmed "Save at my current location" action that
  resolves/creates a place at that coordinate via PlaceResolver

Extract ranking into a pure, unit-tested ManualPlacePickerRanking helper.