### PR TITLE
Show recently-visited short-stay places on the map

### DIFF
--- a/PlaceNotes/Views/FrequentPlacesMapView.swift
+++ b/PlaceNotes/Views/FrequentPlacesMapView.swift
@@ -121,15 +121,21 @@ struct FrequentPlacesMapView: View {
     }
 
     /// Builds a combined ranking list: frequent places from the viewModel plus
-    /// any place with a journal entry that didn't clear the frequency threshold
-    /// (e.g. photo quick-captures, which create a 60-second synthetic visit).
-    /// Without this, photo-logged places never appear on the map and the user
-    /// can't open their detail sheet to set a nickname.
+    /// any recently-visited place that didn't clear the frequency threshold —
+    /// short stays below `minStayMinutes` (e.g. the 24-minute "Unknown Place")
+    /// and photo quick-captures with a journal entry. These are still real
+    /// persisted places shown in the day trajectory, so without this they go
+    /// missing from the map and the user can't open their detail sheet.
     private func mapRankings() -> [PlaceRanking] {
         var rankings = Array(viewModel.monthlyPlaces.prefix(50))
         let included = Set(rankings.map { $0.place.id })
+        let cutoff = Calendar.current.date(byAdding: .day, value: -30, to: Date()) ?? .distantPast
         let extras = places
-            .filter { !$0.journalEntries.isEmpty && !included.contains($0.id) }
+            .filter { place in
+                guard !included.contains(place.id) else { return false }
+                return !place.journalEntries.isEmpty
+                    || place.visits.contains { $0.arrivalDate >= cutoff }
+            }
             .map { PlaceRanking(place: $0, qualifiedStays: 0, totalMinutes: 0) }
         rankings.append(contentsOf: extras)
         return rankings


### PR DESCRIPTION
## Problem

A logged place (e.g. "Unknown Place") appeared in the **day trajectory** view but was missing from the main **Map** page.

The two views filtered `Place` data differently:

| View | What it shows |
|------|---------------|
| **Map** (`FrequentPlacesMapView.mapRankings()`) | Places with a visit ≥ `minStayMinutes` (default **30 min**) in the last 30 days, **plus** journal-entry places |
| **Day trajectory** (`DayTrajectoryView`) | **Every** place with any visit that day — no duration threshold |

The "Unknown Place" was a `24m` stay with no journal entry — below the 30-minute threshold — so it was logged as a real `Place` and shown in the trajectory, but filtered off the map.

## Fix

Broaden `mapRankings()` so the "extras" list also includes any place with a visit in the **last 30 days**, not just journal-entry places. Short stays now appear on the map too, matching what the trajectory shows.

Scoped to the last 30 days to match the map's existing recency window, so the map won't fill with every short stop ever recorded — only recent ones.

https://claude.ai/code/session_011EH1JnkokNPhoHXjwUosF9

---
_Generated by [Claude Code](https://claude.ai/code/session_011EH1JnkokNPhoHXjwUosF9)_