### PR TITLE
feat(capture): real Dynamic Island Live Activity + tappable capture fallback

### DIFF
--- a/PlaceCaptureWidget/CaptureLiveActivity.swift
+++ b/PlaceCaptureWidget/CaptureLiveActivity.swift
@@ -1,0 +1,72 @@
+import ActivityKit
+import SwiftUI
+import WidgetKit
+
+struct CaptureLiveActivity: Widget {
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: CaptureActivityAttributes.self) { context in
+            LockScreenView(state: context.state)
+                .widgetURL(CaptureActivityAttributes.captureURL)
+        } dynamicIsland: { context in
+            DynamicIsland {
+                DynamicIslandExpandedRegion(.leading) {
+                    Label {
+                        Text(context.state.placeName ?? "Placelore")
+                            .font(.caption.weight(.semibold))
+                            .lineLimit(1)
+                    } icon: {
+                        Image(systemName: "location.fill")
+                            .foregroundStyle(.green)
+                    }
+                }
+                DynamicIslandExpandedRegion(.trailing) {
+                    Text("Tracking")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+                DynamicIslandExpandedRegion(.bottom) {
+                    Link(destination: CaptureActivityAttributes.captureURL) {
+                        Label("Capture a moment", systemImage: "camera.fill")
+                            .font(.callout.weight(.semibold))
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 6)
+                            .background(.white.opacity(0.15), in: Capsule())
+                    }
+                }
+            } compactLeading: {
+                Image(systemName: "camera.fill")
+            } compactTrailing: {
+                Text("Capture")
+                    .font(.caption2.weight(.semibold))
+            } minimal: {
+                Image(systemName: "camera.fill")
+            }
+            .widgetURL(CaptureActivityAttributes.captureURL)
+            .keylineTint(.green)
+        }
+    }
+}
+
+private struct LockScreenView: View {
+    let state: CaptureActivityAttributes.ContentState
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "camera.fill")
+                .font(.title3)
+                .foregroundStyle(.white)
+                .frame(width: 40, height: 40)
+                .background(.green.gradient, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+            VStack(alignment: .leading, spacing: 2) {
+                Text(state.placeName ?? "Placelore")
+                    .font(.subheadline.weight(.semibold))
+                    .lineLimit(1)
+                Text("Tap to capture a moment")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+        }
+        .padding()
+    }
+}

--- a/PlaceCaptureWidget/Info.plist
+++ b/PlaceCaptureWidget/Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDisplayName</key>
+    <string>Placelore Capture</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleName</key>
+    <string>$(PRODUCT_NAME)</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundlePackageType</key>
+    <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+    <key>CFBundleShortVersionString</key>
+    <string>$(MARKETING_VERSION)</string>
+    <key>CFBundleVersion</key>
+    <string>$(CURRENT_PROJECT_VERSION)</string>
+    <key>NSExtension</key>
+    <dict>
+        <key>NSExtensionPointIdentifier</key>
+        <string>com.apple.widgetkit-extension</string>
+    </dict>
+</dict>
+</plist>

--- a/PlaceCaptureWidget/PlaceCaptureWidgetBundle.swift
+++ b/PlaceCaptureWidget/PlaceCaptureWidgetBundle.swift
@@ -1,0 +1,9 @@
+import SwiftUI
+import WidgetKit
+
+@main
+struct PlaceCaptureWidgetBundle: WidgetBundle {
+    var body: some Widget {
+        CaptureLiveActivity()
+    }
+}

--- a/PlaceNotes/Info.plist
+++ b/PlaceNotes/Info.plist
@@ -41,6 +41,19 @@
     <string>Placelore uses the camera to attach photos to your visits and journal entries for a place.</string>
     <key>ITSAppUsesNonExemptEncryption</key>
     <false/>
+    <key>NSSupportsLiveActivities</key>
+    <true/>
+    <key>CFBundleURLTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleURLName</key>
+            <string>dev.placelore.app</string>
+            <key>CFBundleURLSchemes</key>
+            <array>
+                <string>placelore</string>
+            </array>
+        </dict>
+    </array>
     <key>UIBackgroundModes</key>
     <array>
         <string>location</string>

--- a/PlaceNotes/LiveActivity/CaptureActivityAttributes.swift
+++ b/PlaceNotes/LiveActivity/CaptureActivityAttributes.swift
@@ -1,0 +1,20 @@
+import ActivityKit
+import Foundation
+
+/// Shared between the app (which starts/updates/ends the activity) and the
+/// `PlaceCaptureWidget` extension (which renders it in the Dynamic Island and on
+/// the Lock Screen). This file is intentionally compiled into both targets.
+struct CaptureActivityAttributes: ActivityAttributes {
+    struct ContentState: Codable, Hashable {
+        /// Name of the place the user is currently dwelling at, if resolved.
+        var placeName: String?
+    }
+
+    /// When the current tracking session began — used for a subtle "since" label.
+    var startedAt: Date
+}
+
+extension CaptureActivityAttributes {
+    /// Deep link opened when the Live Activity (or any of its regions) is tapped.
+    static let captureURL = URL(string: "placelore://capture")!
+}

--- a/PlaceNotes/PlaceNotesApp.swift
+++ b/PlaceNotes/PlaceNotesApp.swift
@@ -10,6 +10,7 @@ struct PlaceNotesApp: App {
     let locationManager: LocationManager
     let trackingManager: TrackingManager
     let modelContainer: ModelContainer
+    let liveActivityManager: LiveActivityManager
 
     init() {
         // Use separate stores so debug mock data never leaks into release
@@ -64,17 +65,25 @@ struct PlaceNotesApp: App {
         // resume tracking.
         let locationManager = LocationManager(settings: settings)
         locationManager.configure(modelContext: container.mainContext)
-        locationManager.onVisitRecorded = { visit in
-            if let place = visit.place {
-                NotificationManager.shared.checkMilestone(for: place)
-            }
-        }
         self.locationManager = locationManager
 
         // TrackingManager.init -> checkPauseExpiry auto-resumes monitoring when
         // the persisted state is .active, which is what makes background
         // relaunches actually start collecting again.
-        self.trackingManager = TrackingManager(locationManager: locationManager, settings: settings)
+        let trackingManager = TrackingManager(locationManager: locationManager, settings: settings)
+        self.trackingManager = trackingManager
+
+        // Mirror tracking state into the Dynamic Island capture Live Activity.
+        let liveActivityManager = LiveActivityManager()
+        liveActivityManager.observe(trackingManager)
+        self.liveActivityManager = liveActivityManager
+
+        locationManager.onVisitRecorded = { visit in
+            if let place = visit.place {
+                NotificationManager.shared.checkMilestone(for: place)
+                liveActivityManager.updatePlace(place.displayName)
+            }
+        }
     }
 
     var body: some Scene {

--- a/PlaceNotes/Services/LiveActivityManager.swift
+++ b/PlaceNotes/Services/LiveActivityManager.swift
@@ -1,0 +1,80 @@
+import Foundation
+import Combine
+import ActivityKit
+import os
+
+private let logger = Logger(subsystem: "dev.placelore.app", category: "LiveActivityManager")
+
+/// Drives the capture Live Activity that lives in the Dynamic Island / Lock
+/// Screen. It mirrors tracking state: a single activity is kept alive while
+/// tracking is `.active` and ended otherwise.
+///
+/// Note: iOS only ever surfaces one app's Live Activity in the Dynamic Island at
+/// a time, so while another app (e.g. an airline boarding pass) is occupying the
+/// island ours yields to it and is shown on the Lock Screen instead. The in-app
+/// pull/tap-to-capture affordance in `HomeView` remains the always-available
+/// fallback.
+///
+/// All tracking-state callbacks are delivered on the main run loop via the
+/// Combine subscription below, so ActivityKit mutations stay on the main thread.
+final class LiveActivityManager {
+
+    private var cancellable: AnyCancellable?
+
+    func observe(_ trackingManager: TrackingManager) {
+        cancellable = trackingManager.$state
+            .map(\.status)
+            .removeDuplicates()
+            .receive(on: RunLoop.main)
+            .sink { [weak self] status in
+                self?.sync(status: status)
+            }
+        sync(status: trackingManager.state.status)
+    }
+
+    /// Update the dwell place shown in the island without restarting the activity.
+    func updatePlace(_ placeName: String?) {
+        guard let activity = Activity<CaptureActivityAttributes>.activities.first else { return }
+        Task {
+            let state = CaptureActivityAttributes.ContentState(placeName: placeName)
+            await activity.update(ActivityContent(state: state, staleDate: nil))
+        }
+    }
+
+    private func sync(status: TrackingStatus) {
+        guard ActivityAuthorizationInfo().areActivitiesEnabled else { return }
+        switch status {
+        case .active:
+            startIfNeeded()
+        case .paused, .disabled:
+            endAll()
+        }
+    }
+
+    private func startIfNeeded() {
+        guard Activity<CaptureActivityAttributes>.activities.isEmpty else { return }
+        let attributes = CaptureActivityAttributes(startedAt: Date())
+        let state = CaptureActivityAttributes.ContentState(placeName: nil)
+        do {
+            _ = try Activity.request(
+                attributes: attributes,
+                content: ActivityContent(state: state, staleDate: nil),
+                pushType: nil
+            )
+            logger.info("Capture Live Activity started")
+        } catch {
+            logger.error("Failed to start Live Activity: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    private func endAll() {
+        let active = Activity<CaptureActivityAttributes>.activities
+        guard !active.isEmpty else { return }
+        Task {
+            for activity in active {
+                await activity.end(nil, dismissalPolicy: .immediate)
+            }
+            logger.info("Capture Live Activity ended")
+        }
+    }
+}

--- a/PlaceNotes/Views/ContentView.swift
+++ b/PlaceNotes/Views/ContentView.swift
@@ -6,6 +6,8 @@ struct ContentView: View {
     @EnvironmentObject var settings: AppSettings
     @EnvironmentObject var quickCapture: QuickCaptureViewModel
 
+    @State private var showCameraPermissionAlert = false
+
     var body: some View {
         TabView {
             HomeView()
@@ -93,6 +95,26 @@ struct ContentView: View {
         }
         .animation(.easeInOut(duration: 0.2), value: quickCapture.isWorkingInBackground)
         .animation(.easeInOut(duration: 0.2), value: quickCapture.state)
+        .onOpenURL { url in handleDeepLink(url) }
+        .alert("Camera access needed", isPresented: $showCameraPermissionAlert) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text("Enable Camera access in Settings → Placelore to capture photos.")
+        }
+    }
+
+    private func handleDeepLink(_ url: URL) {
+        guard url.scheme == "placelore", url.host == "capture" else { return }
+        Task {
+            let granted = await CameraPickerView.requestCameraPermission()
+            await MainActor.run {
+                if granted {
+                    quickCapture.beginCapture()
+                } else {
+                    showCameraPermissionAlert = true
+                }
+            }
+        }
     }
 }
 

--- a/PlaceNotes/Views/HomeView.swift
+++ b/PlaceNotes/Views/HomeView.swift
@@ -44,6 +44,8 @@ struct HomeView: View {
                 }
                 PullToCapturePill(progress: progress, isCommitting: isCommitting)
                     .padding(.top, 6)
+                    .contentShape(Rectangle())
+                    .onTapGesture { commit() }
                     .animation(.spring(response: 0.35, dampingFraction: 0.85), value: isCommitting)
                     .animation(.easeOut(duration: 0.1), value: progress)
             }

--- a/project.yml
+++ b/project.yml
@@ -82,8 +82,35 @@ targets:
           STRIP_INSTALLED_PRODUCT: YES
           DEAD_CODE_STRIPPING: YES
           VALIDATE_PRODUCT: YES
+    dependencies:
+      - target: PlaceCaptureWidget
     entitlements:
       path: PlaceNotes/PlaceNotes.entitlements
+
+  PlaceCaptureWidget:
+    type: app-extension
+    platform: iOS
+    sources:
+      - PlaceCaptureWidget
+      - path: PlaceNotes/LiveActivity/CaptureActivityAttributes.swift
+    settings:
+      base:
+        INFOPLIST_FILE: PlaceCaptureWidget/Info.plist
+        PRODUCT_BUNDLE_IDENTIFIER: dev.placelore.app.PlaceCaptureWidget
+        MARKETING_VERSION: "1.3.0"
+        CURRENT_PROJECT_VERSION: 1
+        SKIP_INSTALL: YES
+        TARGETED_DEVICE_FAMILY: "1"
+        SUPPORTED_PLATFORMS: "iphoneos iphonesimulator"
+        SUPPORTS_MACCATALYST: NO
+        SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD: NO
+        SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD: NO
+      configs:
+        Release:
+          COPY_PHASE_STRIP: YES
+          STRIP_INSTALLED_PRODUCT: YES
+          DEAD_CODE_STRIPPING: YES
+          VALIDATE_PRODUCT: YES
 
   PlaceNotesTests:
     type: bundle.unit-test


### PR DESCRIPTION
The pull-to-capture "prompt" was an in-app pill positioned just below the
safe-area top, only mimicking the Dynamic Island. When another app ran a
Live Activity, the system island expanded over the pill and intercepted
touches, and capture (which was triggerable only via the top-edge pull
gesture) became unreachable.

- Add a real ActivityKit Live Activity (PlaceCaptureWidget extension) that
  lives in the Dynamic Island / Lock Screen while tracking is active and
  deep-links to placelore://capture to start the camera.
- LiveActivityManager mirrors tracking state (start on active, end otherwise)
  and updates the shown place name as visits are recorded.
- Handle the placelore://capture deep link in ContentView (with a camera
  permission fallback alert).
- Make the in-app PullToCapturePill tappable so capture is always reachable
  even when the island is occupied by another app — iOS only ever shows one
  app's Live Activity in the island at a time.
- Register NSSupportsLiveActivities and the placelore URL scheme; wire the
  new app-extension target in project.yml.