### PR TITLE
Fix debug-only feedback rollout

### DIFF
--- a/PlaceNotes/Models/PredictionFeedback.swift
+++ b/PlaceNotes/Models/PredictionFeedback.swift
@@ -1,3 +1,4 @@
+#if DEBUG
 import Foundation
 import SwiftData
 
@@ -88,3 +89,4 @@ final class PredictionFeedback {
         self.correctionSource = correctionSource
     }
 }
+#endif

--- a/PlaceNotes/Models/SchemaVersions.swift
+++ b/PlaceNotes/Models/SchemaVersions.swift
@@ -5,14 +5,17 @@ enum PlaceNotesSchemaV1: VersionedSchema {
     static var versionIdentifier = Schema.Version(1, 0, 0)
 
     static var models: [any PersistentModel.Type] {
-        [
+        var models: [any PersistentModel.Type] = [
             Place.self,
             Visit.self,
             CustomCategory.self,
             JournalEntry.self,
-            RawLocationSample.self,
-            PredictionFeedback.self
+            RawLocationSample.self
         ]
+        #if DEBUG
+        models.append(PredictionFeedback.self)
+        #endif
+        return models
     }
 }
 

--- a/PlaceNotes/Models/Visit.swift
+++ b/PlaceNotes/Models/Visit.swift
@@ -37,10 +37,6 @@ final class Visit {
     /// Used to dim the "Not the right place?" affordance after a deliberate choice.
     var placeConfirmed: Bool = false
 
-    /// The user's latest prediction-accuracy verdict for this visit, if any.
-    /// Mirrors the canonical `PredictionFeedback` record so the row can show state.
-    var feedbackVerdictRaw: String?
-
     /// Journal entries explicitly tied to this visit. Quick-capture creates one;
     /// dwell-recorded visits start empty. Cascade-deletes when the visit is removed.
     @Relationship(deleteRule: .cascade, inverse: \JournalEntry.visit)
@@ -49,11 +45,6 @@ final class Visit {
     var confidence: PlaceConfidence {
         get { PlaceConfidence(rawValue: confidenceRaw ?? "") ?? .medium }
         set { confidenceRaw = newValue.rawValue }
-    }
-
-    var feedbackVerdict: PredictionVerdict? {
-        get { feedbackVerdictRaw.flatMap(PredictionVerdict.init(rawValue:)) }
-        set { feedbackVerdictRaw = newValue?.rawValue }
     }
 
     var alternativePlaces: [PlaceCandidate] {

--- a/PlaceNotes/Services/DebugSeed.swift
+++ b/PlaceNotes/Services/DebugSeed.swift
@@ -86,6 +86,7 @@ enum DebugSeed {
 
     @MainActor
     static func clearAllData(in context: ModelContext) {
+        deleteAll(of: PredictionFeedback.self, in: context)
         deleteAll(of: RawLocationSample.self, in: context)
         deleteAll(of: JournalEntry.self, in: context)
         deleteAll(of: Visit.self, in: context)

--- a/PlaceNotes/Services/PredictionFeedbackExporter.swift
+++ b/PlaceNotes/Services/PredictionFeedbackExporter.swift
@@ -1,3 +1,4 @@
+#if DEBUG
 import Foundation
 
 /// Builds a CSV dataset from `PredictionFeedback` records for offline analysis
@@ -50,3 +51,4 @@ enum PredictionFeedbackExporter {
         return "\"\(value.replacingOccurrences(of: "\"", with: "\"\""))\""
     }
 }
+#endif

--- a/PlaceNotes/Services/PredictionFeedbackRecorder.swift
+++ b/PlaceNotes/Services/PredictionFeedbackRecorder.swift
@@ -1,3 +1,4 @@
+#if DEBUG
 import Foundation
 import SwiftData
 import os
@@ -46,12 +47,9 @@ enum PredictionFeedbackRecorder {
         )
         context.insert(feedback)
 
-        visit.feedbackVerdict = verdict
-        // A deliberate verdict resolves the "wrong place?" affordance, except an
-        // unresolved "wrong" — the place is still incorrect there.
-        if verdict != .wrong {
-            visit.placeConfirmed = true
-        }
+        // An unresolved "wrong" means the place is still unconfirmed; accurate
+        // and corrected verdicts are deliberate confirmations.
+        visit.placeConfirmed = verdict != .wrong
 
         do {
             try context.save()
@@ -60,3 +58,4 @@ enum PredictionFeedbackRecorder {
         }
     }
 }
+#endif

--- a/PlaceNotes/Views/LogbookView.swift
+++ b/PlaceNotes/Views/LogbookView.swift
@@ -9,7 +9,10 @@ struct LogbookView: View {
 
     @StateObject private var viewModel = LogbookViewModel()
 
+    #if DEBUG
+    @Query private var feedbackRecords: [PredictionFeedback]
     @State private var visitForFeedback: Visit?
+    #endif
     @State private var visitToDelete: Visit?
     @State private var showDeleteConfirmation = false
     @State private var refreshID = UUID()
@@ -54,12 +57,14 @@ struct LogbookView: View {
             .navigationDestination(item: $trajectoryDay) { day in
                 DayTrajectoryView(day: day)
             }
+            #if DEBUG
             .sheet(item: $visitForFeedback) { visit in
                 PlaceFeedbackSheet(visit: visit) {
                     viewModel.refresh(places: places, settings: settings)
                     refreshID = UUID()
                 }
             }
+            #endif
             .alert("Delete Visit?", isPresented: $showDeleteConfirmation) {
                 Button("Delete", role: .destructive) {
                     if let visit = visitToDelete {
@@ -133,10 +138,12 @@ struct LogbookView: View {
             NavigationLink {
                 PlaceDetailView(place: place)
             } label: {
+                #if DEBUG
                 LogbookVisitRow(
                     visit: visit,
                     place: place,
                     nextSameDayArrival: nextSameDay,
+                    feedbackVerdict: feedbackRecords.first { $0.visitID == visit.id }?.verdict,
                     onMarkAccurate: {
                         PredictionFeedbackRecorder.record(.accurate, for: visit, in: modelContext)
                         viewModel.refresh(places: places, settings: settings)
@@ -146,6 +153,13 @@ struct LogbookView: View {
                         visitForFeedback = visit
                     }
                 )
+                #else
+                LogbookVisitRow(
+                    visit: visit,
+                    place: place,
+                    nextSameDayArrival: nextSameDay
+                )
+                #endif
             }
             .buttonStyle(.plain)
             .swipeActions(edge: .leading, allowsFullSwipe: false) {
@@ -179,6 +193,7 @@ struct LogbookView: View {
     }
 }
 
+#if DEBUG
 // MARK: - Place Feedback Sheet
 
 private struct PlaceFeedbackSheet: View {
@@ -377,4 +392,4 @@ private struct PlaceFeedbackSheet: View {
         dismiss()
     }
 }
-
+#endif

--- a/PlaceNotes/Views/LogbookVisitRow.swift
+++ b/PlaceNotes/Views/LogbookVisitRow.swift
@@ -4,8 +4,11 @@ struct LogbookVisitRow: View {
     let visit: Visit
     let place: Place
     let nextSameDayArrival: Date?
+    #if DEBUG
+    var feedbackVerdict: PredictionVerdict? = nil
     var onMarkAccurate: (() -> Void)?
     var onOpenFeedback: (() -> Void)?
+    #endif
 
     private var dateString: String {
         let formatter = DateFormatter()
@@ -77,17 +80,20 @@ struct LogbookVisitRow: View {
                 }
             }
 
+            #if DEBUG
             feedbackBar
                 .padding(.leading, 40)
+            #endif
         }
         .padding(.vertical, 2)
     }
 
+    #if DEBUG
     @ViewBuilder
     private var feedbackBar: some View {
         if onOpenFeedback == nil {
             EmptyView()
-        } else if let verdict = visit.feedbackVerdict {
+        } else if let verdict = feedbackVerdict {
             Button {
                 onOpenFeedback?()
             } label: {
@@ -116,7 +122,9 @@ struct LogbookVisitRow: View {
             }
         }
     }
+    #endif
 
+    #if DEBUG
     @ViewBuilder
     private func verdictLabel(_ verdict: PredictionVerdict) -> some View {
         switch verdict {
@@ -134,6 +142,7 @@ struct LogbookVisitRow: View {
                 .foregroundStyle(.orange)
         }
     }
+    #endif
 }
 
 #if DEBUG

--- a/PlaceNotes/Views/SettingsView.swift
+++ b/PlaceNotes/Views/SettingsView.swift
@@ -64,10 +64,12 @@ struct SettingsView: View {
     @State private var retentionInputText = ""
     @State private var exportData: Data = Data()
     @State private var showExporter = false
+    #if DEBUG
     @State private var feedbackCount: Int = 0
     @State private var feedbackAccurateCount: Int = 0
     @State private var feedbackExportData: Data = Data()
     @State private var showFeedbackExporter = false
+    #endif
 
     private var appVersion: String {
         Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "—"
@@ -188,6 +190,7 @@ struct SettingsView: View {
                 }
                 .onAppear { refreshRawSampleCount() }
 
+                #if DEBUG
                 Section {
                     LabeledContent("Feedback Collected", value: "\(feedbackCount)")
                     LabeledContent("Predicted Correctly", value: feedbackPrecisionText)
@@ -201,6 +204,7 @@ struct SettingsView: View {
                     Text("Your “correct / wrong” verdicts on recorded places are logged here. Export the labeled CSV to analyze prediction quality offline or train a model.")
                 }
                 .onAppear { refreshFeedbackStats() }
+                #endif
 
                 Section {
                     Button(role: .destructive) {
@@ -212,7 +216,11 @@ struct SettingsView: View {
                             Spacer()
                         }
                     }
+                    #if DEBUG
+                    .disabled(places.isEmpty && visits.isEmpty && feedbackCount == 0)
+                    #else
                     .disabled(places.isEmpty && visits.isEmpty)
+                    #endif
                 }
 
                 Section("About") {
@@ -234,6 +242,7 @@ struct SettingsView: View {
                     Button(role: .destructive) {
                         DebugSeed.clearAllData(in: modelContext)
                         refreshRawSampleCount()
+                        refreshFeedbackStats()
                         refreshStorageSize()
                     } label: {
                         Text("Clear All Data (Debug)")
@@ -282,15 +291,18 @@ struct SettingsView: View {
                 contentType: .commaSeparatedText,
                 defaultFilename: "location_samples_\(formattedDate())"
             ) { _ in }
+            #if DEBUG
             .fileExporter(
                 isPresented: $showFeedbackExporter,
                 document: CSVFile(data: feedbackExportData),
                 contentType: .commaSeparatedText,
                 defaultFilename: "prediction_feedback_\(formattedDate())"
             ) { _ in }
+            #endif
         }
     }
 
+    #if DEBUG
     private func refreshFeedbackStats() {
         feedbackCount = (try? modelContext.fetchCount(FetchDescriptor<PredictionFeedback>())) ?? 0
         let accurateRaw = PredictionVerdict.accurate.rawValue
@@ -312,6 +324,7 @@ struct SettingsView: View {
         feedbackExportData = PredictionFeedbackExporter.exportCSV(from: records)
         showFeedbackExporter = true
     }
+    #endif
 
     private func refreshRawSampleCount() {
         rawSampleCount = (try? modelContext.fetchCount(FetchDescriptor<RawLocationSample>())) ?? 0
@@ -353,8 +366,17 @@ struct SettingsView: View {
         for category in customCategories {
             modelContext.delete(category)
         }
+        #if DEBUG
+        let feedback = (try? modelContext.fetch(FetchDescriptor<PredictionFeedback>())) ?? []
+        for record in feedback {
+            modelContext.delete(record)
+        }
+        #endif
         try? modelContext.save()
         PhotoStorage.deleteAll()
+        #if DEBUG
+        refreshFeedbackStats()
+        #endif
     }
 
     private func refreshStorageSize() {

--- a/PlaceNotesTests/DebugSeedTests.swift
+++ b/PlaceNotesTests/DebugSeedTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+import SwiftData
+@testable import PlaceNotes
+
+@MainActor
+final class DebugSeedTests: XCTestCase {
+    private func makeContext() throws -> ModelContext {
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        let container = try ModelContainer(
+            for: Place.self, Visit.self, JournalEntry.self, CustomCategory.self,
+            RawLocationSample.self, PredictionFeedback.self,
+            configurations: config
+        )
+        return ModelContext(container)
+    }
+
+    func testClearAllDataDeletesPredictionFeedback() throws {
+        let ctx = try makeContext()
+        let place = Place(name: "Blue Bottle", latitude: 37.78, longitude: -122.41)
+        let visit = Visit(arrivalDate: Date(), place: place)
+        let feedback = PredictionFeedback(
+            visitID: visit.id,
+            arrivalDate: visit.arrivalDate,
+            predictedPlaceName: place.name,
+            predictedCategory: place.category,
+            confidenceRaw: visit.confidence.rawValue,
+            medianAccuracyMeters: nil,
+            alternativeCount: 0,
+            latitude: place.latitude,
+            longitude: place.longitude,
+            verdict: .accurate
+        )
+
+        ctx.insert(place)
+        ctx.insert(visit)
+        ctx.insert(feedback)
+        try ctx.save()
+
+        DebugSeed.clearAllData(in: ctx)
+
+        XCTAssertEqual(try ctx.fetchCount(FetchDescriptor<PredictionFeedback>()), 0)
+        XCTAssertEqual(try ctx.fetchCount(FetchDescriptor<Visit>()), 0)
+        XCTAssertEqual(try ctx.fetchCount(FetchDescriptor<Place>()), 0)
+    }
+}

--- a/PlaceNotesTests/PredictionFeedbackRecorderTests.swift
+++ b/PlaceNotesTests/PredictionFeedbackRecorderTests.swift
@@ -45,7 +45,6 @@ final class PredictionFeedbackRecorderTests: XCTestCase {
         XCTAssertEqual(records.first?.verdict, .accurate)
         XCTAssertEqual(records.first?.predictedPlaceName, "Blue Bottle")
         XCTAssertEqual(records.first?.alternativeCount, 1)
-        XCTAssertEqual(visit.feedbackVerdict, .accurate)
         XCTAssertTrue(visit.placeConfirmed)
     }
 
@@ -59,7 +58,7 @@ final class PredictionFeedbackRecorderTests: XCTestCase {
         let records = allFeedback(ctx)
         XCTAssertEqual(records.count, 1)
         XCTAssertEqual(records.first?.verdict, .wrong)
-        XCTAssertEqual(visit.feedbackVerdict, .wrong)
+        XCTAssertFalse(visit.placeConfirmed)
     }
 
     func testWrongDoesNotConfirmPlace() throws {
@@ -69,7 +68,7 @@ final class PredictionFeedbackRecorderTests: XCTestCase {
         PredictionFeedbackRecorder.record(.wrong, for: visit, in: ctx)
 
         XCTAssertFalse(visit.placeConfirmed)
-        XCTAssertEqual(visit.feedbackVerdict, .wrong)
+        XCTAssertEqual(allFeedback(ctx).first?.verdict, .wrong)
     }
 
     func testCorrectedCapturesPredictionSnapshotAndCorrection() throws {


### PR DESCRIPTION
## Summary
- Gate the feedback analysis model, recorder/exporter, settings, and logbook UI to Debug builds
- Remove feedback state from the shared Visit model so Release schema stays unchanged
- Ensure wrong resubmission clears placeConfirmed and delete-all paths remove feedback records
- Add a regression test for DebugSeed.clearAllData deleting PredictionFeedback

## Verification
- xcodebuild test -project PlaceNotes.xcodeproj -scheme PlaceNotes-Debug -destination "platform=iOS Simulator,name=iPhone 17 Pro Max,OS=26.2" CODE_SIGNING_ALLOWED=NO
- xcodebuild build -project PlaceNotes.xcodeproj -scheme PlaceNotes-Release -destination "generic/platform=iOS Simulator" CODE_SIGNING_ALLOWED=NO