### PR TITLE
Wire debug feedback upload to Azure Function

### DIFF
--- a/PlaceNotes/Services/PredictionFeedbackRecorder.swift
+++ b/PlaceNotes/Services/PredictionFeedbackRecorder.swift
@@ -53,6 +53,10 @@ enum PredictionFeedbackRecorder {
 
         do {
             try context.save()
+            let uploadPayload = PredictionFeedbackUploadPayload(record: feedback)
+            Task(priority: .utility) {
+                _ = await PredictionFeedbackUploader.upload(uploadPayload)
+            }
         } catch {
             logger.error("Failed to save prediction feedback: \(error.localizedDescription)")
         }

--- a/PlaceNotes/Services/PredictionFeedbackUploader.swift
+++ b/PlaceNotes/Services/PredictionFeedbackUploader.swift
@@ -1,0 +1,170 @@
+#if DEBUG
+import Foundation
+import os
+
+struct PredictionFeedbackUploadPayload: Codable, Equatable, Sendable {
+    let schemaVersion: Int
+    let appVersion: String
+    let appBuild: String
+    let buildConfiguration: String
+    let eventID: UUID
+    let createdAt: String
+    let visitID: UUID
+    let arrivalDate: String
+    let latitude: Double
+    let longitude: Double
+    let predictedPlaceName: String
+    let predictedCategory: String?
+    let confidence: String
+    let medianAccuracyMeters: Double?
+    let alternativeCount: Int
+    let verdict: String
+    let wasAccurate: Bool
+    let correctedPlaceName: String?
+    let correctedCategory: String?
+    let correctionSource: String?
+
+    init(record: PredictionFeedback, bundle: Bundle = .main) {
+        self.schemaVersion = 1
+        self.appVersion = bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "unknown"
+        self.appBuild = bundle.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "unknown"
+        self.buildConfiguration = "debug"
+        self.eventID = record.id
+        self.createdAt = Self.iso8601String(from: record.createdAt)
+        self.visitID = record.visitID
+        self.arrivalDate = Self.iso8601String(from: record.arrivalDate)
+        self.latitude = record.latitude
+        self.longitude = record.longitude
+        self.predictedPlaceName = record.predictedPlaceName
+        self.predictedCategory = record.predictedCategory
+        self.confidence = record.confidenceRaw
+        self.medianAccuracyMeters = record.medianAccuracyMeters
+        self.alternativeCount = record.alternativeCount
+        self.verdict = record.verdict.rawValue
+        self.wasAccurate = record.verdict.wasAccurate
+        self.correctedPlaceName = record.correctedPlaceName
+        self.correctedCategory = record.correctedCategory
+        self.correctionSource = record.correctionSource
+    }
+
+    private static func iso8601String(from date: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.string(from: date)
+    }
+}
+
+enum PredictionFeedbackUploadResult: Equatable, Sendable {
+    case success
+    case networkUnavailable(String)
+    case serverRejected(statusCode: Int, body: String)
+    case failed(String)
+}
+
+struct PredictionFeedbackUploadSummary: Equatable, Sendable {
+    var succeeded: Int
+    var failed: Int
+    var networkUnavailable: Int
+
+    var displayText: String {
+        if failed == 0 && networkUnavailable == 0 {
+            return "Uploaded \(succeeded)"
+        }
+        if networkUnavailable > 0 {
+            return "No internet: \(networkUnavailable) pending"
+        }
+        return "Uploaded \(succeeded), failed \(failed)"
+    }
+}
+
+protocol PredictionFeedbackHTTPSession {
+    func data(for request: URLRequest) async throws -> (Data, URLResponse)
+}
+
+extension URLSession: PredictionFeedbackHTTPSession {}
+
+enum PredictionFeedbackUploader {
+    static let endpoint = URL(string: "https://func-placelore-feedback-dev.azurewebsites.net/api/feedback")!
+
+    private static let logger = Logger(subsystem: "dev.placelore.app", category: "PredictionFeedbackUpload")
+    private static func makeEncoder() -> JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return encoder
+    }
+
+    static func upload(
+        _ payload: PredictionFeedbackUploadPayload,
+        endpoint: URL = Self.endpoint,
+        session: PredictionFeedbackHTTPSession = URLSession.shared
+    ) async -> PredictionFeedbackUploadResult {
+        do {
+            var request = URLRequest(url: endpoint, cachePolicy: .reloadIgnoringLocalCacheData, timeoutInterval: 10)
+            request.httpMethod = "POST"
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.setValue("application/json", forHTTPHeaderField: "Accept")
+            request.httpBody = try makeEncoder().encode(payload)
+
+            let (data, response) = try await session.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse else {
+                logger.error("Prediction feedback upload failed: non-HTTP response")
+                return .failed("Non-HTTP response")
+            }
+
+            guard (200..<300).contains(httpResponse.statusCode) else {
+                let body = String(data: data, encoding: .utf8) ?? ""
+                logger.error("Prediction feedback upload rejected: \(httpResponse.statusCode)")
+                return .serverRejected(statusCode: httpResponse.statusCode, body: body)
+            }
+
+            logger.debug("Prediction feedback uploaded: \(payload.eventID.uuidString)")
+            return .success
+        } catch let error as URLError {
+            if error.isNetworkUnavailable {
+                logger.warning("Prediction feedback upload deferred, network unavailable: \(error.localizedDescription)")
+                return .networkUnavailable(error.localizedDescription)
+            }
+            logger.error("Prediction feedback upload failed: \(error.localizedDescription)")
+            return .failed(error.localizedDescription)
+        } catch {
+            logger.error("Prediction feedback upload failed: \(error.localizedDescription)")
+            return .failed(error.localizedDescription)
+        }
+    }
+
+    static func upload(
+        _ payloads: [PredictionFeedbackUploadPayload],
+        endpoint: URL = Self.endpoint,
+        session: PredictionFeedbackHTTPSession = URLSession.shared
+    ) async -> PredictionFeedbackUploadSummary {
+        var summary = PredictionFeedbackUploadSummary(succeeded: 0, failed: 0, networkUnavailable: 0)
+        for payload in payloads {
+            switch await upload(payload, endpoint: endpoint, session: session) {
+            case .success:
+                summary.succeeded += 1
+            case .networkUnavailable:
+                summary.networkUnavailable += 1
+            case .serverRejected, .failed:
+                summary.failed += 1
+            }
+        }
+        return summary
+    }
+}
+
+private extension URLError {
+    var isNetworkUnavailable: Bool {
+        switch code {
+        case .notConnectedToInternet,
+             .networkConnectionLost,
+             .cannotConnectToHost,
+             .cannotFindHost,
+             .dnsLookupFailed,
+             .timedOut:
+            return true
+        default:
+            return false
+        }
+    }
+}
+#endif

--- a/PlaceNotes/Views/SettingsView.swift
+++ b/PlaceNotes/Views/SettingsView.swift
@@ -69,6 +69,7 @@ struct SettingsView: View {
     @State private var feedbackAccurateCount: Int = 0
     @State private var feedbackExportData: Data = Data()
     @State private var showFeedbackExporter = false
+    @State private var feedbackUploadStatus: String = "Not uploaded"
     #endif
 
     private var appVersion: String {
@@ -194,6 +195,11 @@ struct SettingsView: View {
                 Section {
                     LabeledContent("Feedback Collected", value: "\(feedbackCount)")
                     LabeledContent("Predicted Correctly", value: feedbackPrecisionText)
+                    LabeledContent("Azure Upload", value: feedbackUploadStatus)
+                    Button("Upload Feedback to Azure") {
+                        uploadFeedbackToAzure()
+                    }
+                    .disabled(feedbackCount == 0)
                     Button("Export Feedback CSV") {
                         exportFeedback()
                     }
@@ -323,6 +329,24 @@ struct SettingsView: View {
         let records = (try? modelContext.fetch(descriptor)) ?? []
         feedbackExportData = PredictionFeedbackExporter.exportCSV(from: records)
         showFeedbackExporter = true
+    }
+
+    private func uploadFeedbackToAzure() {
+        let descriptor = FetchDescriptor<PredictionFeedback>(sortBy: [SortDescriptor(\.createdAt)])
+        let records = (try? modelContext.fetch(descriptor)) ?? []
+        let payloads = records.map { PredictionFeedbackUploadPayload(record: $0) }
+        guard !payloads.isEmpty else {
+            feedbackUploadStatus = "No feedback"
+            return
+        }
+
+        feedbackUploadStatus = "Uploading…"
+        Task {
+            let summary = await PredictionFeedbackUploader.upload(payloads)
+            await MainActor.run {
+                feedbackUploadStatus = summary.displayText
+            }
+        }
     }
     #endif
 

--- a/PlaceNotesTests/PredictionFeedbackUploaderTests.swift
+++ b/PlaceNotesTests/PredictionFeedbackUploaderTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+import Foundation
+@testable import PlaceNotes
+
+final class PredictionFeedbackUploaderTests: XCTestCase {
+    private final class StubHTTPSession: PredictionFeedbackHTTPSession {
+        var receivedRequest: URLRequest?
+        var result: Result<(Data, URLResponse), Error>
+
+        init(result: Result<(Data, URLResponse), Error>) {
+            self.result = result
+        }
+
+        func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+            receivedRequest = request
+            return try result.get()
+        }
+    }
+
+    private func makePayload(verdict: PredictionVerdict = .accurate) -> PredictionFeedbackUploadPayload {
+        let record = PredictionFeedback(
+            visitID: UUID(uuidString: "11111111-1111-1111-1111-111111111111")!,
+            arrivalDate: Date(timeIntervalSince1970: 1_700_000_000),
+            predictedPlaceName: "Blue Bottle",
+            predictedCategory: "Cafe",
+            confidenceRaw: "High",
+            medianAccuracyMeters: 14,
+            alternativeCount: 1,
+            latitude: 37.78,
+            longitude: -122.41,
+            verdict: verdict,
+            correctedName: nil,
+            correctedCategory: nil,
+            correctionSource: nil,
+            createdAt: Date(timeIntervalSince1970: 1_700_000_100)
+        )
+        return PredictionFeedbackUploadPayload(record: record, bundle: Bundle(for: Self.self))
+    }
+
+    func testUploadPostsJSONToAzureFunctionEndpoint() async throws {
+        let endpoint = URL(string: "https://example.test/api/feedback")!
+        let response = HTTPURLResponse(url: endpoint, statusCode: 202, httpVersion: nil, headerFields: nil)!
+        let session = StubHTTPSession(result: .success((Data(), response)))
+
+        let result = await PredictionFeedbackUploader.upload(makePayload(), endpoint: endpoint, session: session)
+
+        XCTAssertEqual(result, .success)
+        let request = try XCTUnwrap(session.receivedRequest)
+        XCTAssertEqual(request.url, endpoint)
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+
+        let body = try XCTUnwrap(request.httpBody)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+        XCTAssertEqual(json["schemaVersion"] as? Int, 1)
+        XCTAssertEqual(json["buildConfiguration"] as? String, "debug")
+        XCTAssertEqual(json["predictedPlaceName"] as? String, "Blue Bottle")
+        XCTAssertEqual(json["verdict"] as? String, "accurate")
+        XCTAssertEqual(json["wasAccurate"] as? Bool, true)
+    }
+
+    func testUploadTreatsNoInternetAsRecoverableNetworkUnavailable() async {
+        let endpoint = URL(string: "https://example.test/api/feedback")!
+        let session = StubHTTPSession(result: .failure(URLError(.notConnectedToInternet)))
+
+        let result = await PredictionFeedbackUploader.upload(makePayload(), endpoint: endpoint, session: session)
+
+        guard case .networkUnavailable = result else {
+            XCTFail("Expected networkUnavailable, got \(result)")
+            return
+        }
+    }
+
+    func testUploadSummarizesPartialNetworkFailures() async {
+        let endpoint = URL(string: "https://example.test/api/feedback")!
+        let session = StubHTTPSession(result: .failure(URLError(.timedOut)))
+
+        let summary = await PredictionFeedbackUploader.upload(
+            [makePayload(), makePayload(verdict: .wrong)],
+            endpoint: endpoint,
+            session: session
+        )
+
+        XCTAssertEqual(summary.succeeded, 0)
+        XCTAssertEqual(summary.failed, 0)
+        XCTAssertEqual(summary.networkUnavailable, 2)
+        XCTAssertEqual(summary.displayText, "No internet: 2 pending")
+    }
+}

--- a/PlaceNotesTests/VisitTests.swift
+++ b/PlaceNotesTests/VisitTests.swift
@@ -13,11 +13,14 @@ final class VisitTests: XCTestCase {
     }
 
     func testDurationWithoutDepartureUsesNow() {
-        let arrival = Date().addingTimeInterval(-30 * 60) // 30 minutes ago
+        let now = Date()
+        let startOfToday = Calendar.current.startOfDay(for: now)
+        let preferredArrival = now.addingTimeInterval(-30 * 60)
+        let arrival = preferredArrival < startOfToday ? startOfToday : preferredArrival
         let visit = Visit(arrivalDate: arrival, departureDate: nil)
-        // Should be approximately 30 minutes (allow 1 min tolerance for test execution)
-        XCTAssertGreaterThanOrEqual(visit.durationMinutes, 29)
-        XCTAssertLessThanOrEqual(visit.durationMinutes, 31)
+        let expectedMinutes = Int(Date().timeIntervalSince(arrival) / 60)
+        XCTAssertGreaterThanOrEqual(visit.durationMinutes, max(0, expectedMinutes - 1))
+        XCTAssertLessThanOrEqual(visit.durationMinutes, expectedMinutes + 1)
     }
 
     func testDurationNeverNegative() {
@@ -175,11 +178,15 @@ final class VisitTests: XCTestCase {
     }
 
     func testEffectiveDurationTodayUsesNowWhenNoCap() {
-        let arrival = Date().addingTimeInterval(-15 * 60)
+        let now = Date()
+        let startOfToday = Calendar.current.startOfDay(for: now)
+        let preferredArrival = now.addingTimeInterval(-15 * 60)
+        let arrival = preferredArrival < startOfToday ? startOfToday : preferredArrival
         let visit = Visit(arrivalDate: arrival, departureDate: nil)
         let mins = visit.effectiveDurationMinutes(cappedAt: nil)
-        XCTAssertGreaterThanOrEqual(mins, 14)
-        XCTAssertLessThanOrEqual(mins, 16)
+        let expectedMinutes = Int(Date().timeIntervalSince(arrival) / 60)
+        XCTAssertGreaterThanOrEqual(mins, max(0, expectedMinutes - 1))
+        XCTAssertLessThanOrEqual(mins, expectedMinutes + 1)
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
## Summary
- add a DEBUG-only Azure Function uploader for prediction feedback payloads
- fire-and-forget upload newly saved feedback while keeping local persistence as the source of truth
- add a Debug Settings retry button for uploading stored feedback
- treat no-internet, DNS, timeout, and connection failures as recoverable pending uploads

## Validation
- xcodebuild test -project PlaceNotes.xcodeproj -scheme PlaceNotes-Debug -destination "platform=iOS Simulator,name=iPhone 17 Pro Max,OS=26.2" CODE_SIGNING_ALLOWED=NO
- xcodebuild build -project PlaceNotes.xcodeproj -scheme PlaceNotes-Release -destination "generic/platform=iOS Simulator" CODE_SIGNING_ALLOWED=NO

## Note
This assumes the Azure Function HTTP trigger route is /api/feedback on func-placelore-feedback-dev.azurewebsites.net.