### PR TITLE
feat(capture): enrich Dynamic Island Live Activity with active-place card info

### DIFF
--- a/PlaceCaptureWidget/CaptureLiveActivity.swift
+++ b/PlaceCaptureWidget/CaptureLiveActivity.swift
@@ -11,7 +11,7 @@ struct CaptureLiveActivity: Widget {
             DynamicIsland {
                 DynamicIslandExpandedRegion(.leading) {
                     Label {
-                        Text(context.state.placeName ?? "Placelore")
+                        Text(context.state.title)
                             .font(.caption.weight(.semibold))
                             .lineLimit(1)
                     } icon: {
@@ -25,12 +25,16 @@ struct CaptureLiveActivity: Widget {
                         .foregroundStyle(.secondary)
                 }
                 DynamicIslandExpandedRegion(.bottom) {
-                    Link(destination: CaptureActivityAttributes.captureURL) {
-                        Label("Capture a moment", systemImage: "camera.fill")
-                            .font(.callout.weight(.semibold))
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical, 6)
-                            .background(.white.opacity(0.15), in: Capsule())
+                    VStack(alignment: .leading, spacing: 8) {
+                        DwellSubtitle(state: context.state)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        Link(destination: CaptureActivityAttributes.captureURL) {
+                            Label("Capture a moment", systemImage: "camera.fill")
+                                .font(.callout.weight(.semibold))
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, 6)
+                                .background(.white.opacity(0.15), in: Capsule())
+                        }
                     }
                 }
             } compactLeading: {
@@ -47,6 +51,26 @@ struct CaptureLiveActivity: Widget {
     }
 }
 
+/// Live "time here · prior visits" line that mirrors the home card's meta row.
+/// Uses a relative-style date so the elapsed label updates on its own without
+/// the app having to push activity updates.
+private struct DwellSubtitle: View {
+    let state: CaptureActivityAttributes.ContentState
+
+    var body: some View {
+        if let arrivalDate = state.arrivalDate {
+            Label {
+                Text("\(arrivalDate, style: .relative) · \(state.priorVisitsText)")
+                    .lineLimit(1)
+            } icon: {
+                Image(systemName: "clock")
+            }
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+    }
+}
+
 private struct LockScreenView: View {
     let state: CaptureActivityAttributes.ContentState
 
@@ -58,12 +82,16 @@ private struct LockScreenView: View {
                 .frame(width: 40, height: 40)
                 .background(.green.gradient, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
             VStack(alignment: .leading, spacing: 2) {
-                Text(state.placeName ?? "Placelore")
+                Text(state.title)
                     .font(.subheadline.weight(.semibold))
                     .lineLimit(1)
-                Text("Tap to capture a moment")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                if state.arrivalDate != nil {
+                    DwellSubtitle(state: state)
+                } else {
+                    Text("Tap to capture a moment")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
             }
             Spacer()
         }

--- a/PlaceNotes/LiveActivity/CaptureActivityAttributes.swift
+++ b/PlaceNotes/LiveActivity/CaptureActivityAttributes.swift
@@ -8,6 +8,12 @@ struct CaptureActivityAttributes: ActivityAttributes {
     struct ContentState: Codable, Hashable {
         /// Name of the place the user is currently dwelling at, if resolved.
         var placeName: String?
+        /// Emoji for the resolved place (custom or category default).
+        var placeEmoji: String? = nil
+        /// When the current visit began — drives a live "time here" label.
+        var arrivalDate: Date? = nil
+        /// Visits to this place before the current one (mirrors the home card).
+        var priorVisitCount: Int = 0
     }
 
     /// When the current tracking session began — used for a subtle "since" label.
@@ -17,4 +23,23 @@ struct CaptureActivityAttributes: ActivityAttributes {
 extension CaptureActivityAttributes {
     /// Deep link opened when the Live Activity (or any of its regions) is tapped.
     static let captureURL = URL(string: "placelore://capture")!
+}
+
+extension CaptureActivityAttributes.ContentState {
+    /// Emoji + place name, falling back to the app name before a place resolves.
+    /// Mirrors the home "You're at" card's heading.
+    var title: String {
+        guard let placeName, !placeName.isEmpty else { return "Placelore" }
+        guard let placeEmoji, !placeEmoji.isEmpty else { return placeName }
+        return "\(placeEmoji) \(placeName)"
+    }
+
+    /// Prior-visit subtitle matching the home card's wording.
+    var priorVisitsText: String {
+        switch max(0, priorVisitCount) {
+        case 0: return "First visit here"
+        case 1: return "1 prior visit"
+        case let count: return "\(count) prior visits"
+        }
+    }
 }

--- a/PlaceNotes/PlaceNotesApp.swift
+++ b/PlaceNotes/PlaceNotesApp.swift
@@ -81,7 +81,12 @@ struct PlaceNotesApp: App {
         locationManager.onVisitRecorded = { visit in
             if let place = visit.place {
                 NotificationManager.shared.checkMilestone(for: place)
-                liveActivityManager.updatePlace(place.displayName)
+                liveActivityManager.updatePlace(
+                    name: place.displayName,
+                    emoji: place.emoji,
+                    arrivalDate: visit.arrivalDate,
+                    priorVisitCount: place.priorVisitCount
+                )
             }
         }
     }

--- a/PlaceNotes/Services/LiveActivityManager.swift
+++ b/PlaceNotes/Services/LiveActivityManager.swift
@@ -33,10 +33,17 @@ final class LiveActivityManager {
     }
 
     /// Update the dwell place shown in the island without restarting the activity.
-    func updatePlace(_ placeName: String?) {
+    /// Mirrors the home "You're at" card: place name + emoji, arrival time, and
+    /// prior-visit count.
+    func updatePlace(name: String?, emoji: String? = nil, arrivalDate: Date? = nil, priorVisitCount: Int = 0) {
         guard let activity = Activity<CaptureActivityAttributes>.activities.first else { return }
         Task {
-            let state = CaptureActivityAttributes.ContentState(placeName: placeName)
+            let state = CaptureActivityAttributes.ContentState(
+                placeName: name,
+                placeEmoji: emoji,
+                arrivalDate: arrivalDate,
+                priorVisitCount: priorVisitCount
+            )
             await activity.update(ActivityContent(state: state, staleDate: nil))
         }
     }

--- a/PlaceNotesTests/CurrentlyAtCardFormattersTests.swift
+++ b/PlaceNotesTests/CurrentlyAtCardFormattersTests.swift
@@ -141,4 +141,31 @@ final class CurrentlyAtCardFormattersTests: XCTestCase {
     func testPriorVisitsNegativeClampsToFirst() {
         XCTAssertEqual(CurrentlyAtFormatter.priorVisits(-1), String(localized: "First visit here"))
     }
+
+    // MARK: - Live Activity (Dynamic Island) content state
+
+    func testActivityTitleFallsBackToAppNameWhenNoPlace() {
+        let state = CaptureActivityAttributes.ContentState(placeName: nil)
+        XCTAssertEqual(state.title, "Placelore")
+    }
+
+    func testActivityTitleUsesNameWhenEmojiMissing() {
+        let state = CaptureActivityAttributes.ContentState(placeName: "Blue Bottle")
+        XCTAssertEqual(state.title, "Blue Bottle")
+    }
+
+    func testActivityTitleCombinesEmojiAndName() {
+        let state = CaptureActivityAttributes.ContentState(placeName: "Blue Bottle", placeEmoji: "☕️")
+        XCTAssertEqual(state.title, "☕️ Blue Bottle")
+    }
+
+    func testActivityPriorVisitsTextMirrorsCard() {
+        XCTAssertEqual(CaptureActivityAttributes.ContentState(placeName: "X", priorVisitCount: 0).priorVisitsText, "First visit here")
+        XCTAssertEqual(CaptureActivityAttributes.ContentState(placeName: "X", priorVisitCount: 1).priorVisitsText, "1 prior visit")
+        XCTAssertEqual(CaptureActivityAttributes.ContentState(placeName: "X", priorVisitCount: 7).priorVisitsText, "7 prior visits")
+    }
+
+    func testActivityPriorVisitsTextClampsNegative() {
+        XCTAssertEqual(CaptureActivityAttributes.ContentState(placeName: "X", priorVisitCount: -3).priorVisitsText, "First visit here")
+    }
 }


### PR DESCRIPTION
Mirror the home "You're at" card in the capture Live Activity:
- show place emoji + name as the heading
- add a live "time here" label (relative-style date, auto-updating on
  the Lock Screen without app-side pushes)
- show the prior-visit count, matching the card's wording

Carry arrivalDate, emoji, and priorVisitCount through the shared
ContentState and LiveActivityManager.updatePlace, and add unit tests for
the new ContentState formatting helpers.