### PR TITLE
Optimize data queries and async operations for performance

### DIFF
--- a/PlaceNotes/PlaceNotesApp.swift
+++ b/PlaceNotes/PlaceNotesApp.swift
@@ -12,6 +12,8 @@ struct PlaceNotesApp: App {
     let modelContainer: ModelContainer
     let liveActivityManager: LiveActivityManager
     let feedbackUploadScheduler: PredictionFeedbackUploadScheduler
+    let trackingViewModel: TrackingViewModel
+    let quickCaptureViewModel: QuickCaptureViewModel
 
     init() {
         // Use separate stores so debug mock data never leaks into release
@@ -74,6 +76,16 @@ struct PlaceNotesApp: App {
         let trackingManager = TrackingManager(locationManager: locationManager, settings: settings)
         self.trackingManager = trackingManager
 
+        // Built once here — building them in `body` would hand out fresh
+        // instances (and reset in-flight capture state) every time a settings
+        // change re-evaluates the scene.
+        self.trackingViewModel = TrackingViewModel(trackingManager: trackingManager)
+        self.quickCaptureViewModel = QuickCaptureViewModel(
+            oneShot: LocationOneShot(),
+            context: container.mainContext,
+            locationManager: locationManager
+        )
+
         // Mirror tracking state into the Dynamic Island capture Live Activity.
         let liveActivityManager = LiveActivityManager()
         liveActivityManager.observe(trackingManager)
@@ -99,8 +111,8 @@ struct PlaceNotesApp: App {
             ContentView()
                 .environmentObject(settings)
                 .environmentObject(locationManager)
-                .environmentObject(makeTrackingViewModel())
-                .environmentObject(makeQuickCaptureViewModel())
+                .environmentObject(trackingViewModel)
+                .environmentObject(quickCaptureViewModel)
                 .preferredColorScheme(settings.appearanceMode.colorScheme)
                 .onAppear {
                     NotificationManager.shared.requestAuthorization()
@@ -148,19 +160,5 @@ struct PlaceNotesApp: App {
         }
 
         UserDefaults.standard.set(true, forKey: migrationKey)
-    }
-
-    @MainActor
-    private func makeQuickCaptureViewModel() -> QuickCaptureViewModel {
-        QuickCaptureViewModel(
-            oneShot: LocationOneShot(),
-            context: modelContainer.mainContext,
-            locationManager: locationManager
-        )
-    }
-
-    @MainActor
-    private func makeTrackingViewModel() -> TrackingViewModel {
-        TrackingViewModel(trackingManager: trackingManager)
     }
 }

--- a/PlaceNotes/Services/LocationExporter.swift
+++ b/PlaceNotes/Services/LocationExporter.swift
@@ -1,1 +1,52 @@
-// CSV export logic lives in SettingsView.swift alongside CSVFile.
+import Foundation
+import SwiftData
+
+/// Builds the raw-location CSV export for offline ST-DBSCAN analysis.
+/// Columns match the dimension table in the project docs.
+enum LocationExporter {
+    static let csvHeader = "id,latitude,longitude,timestamp,horizontalAccuracy,speed,altitude,verticalAccuracy,course,filterStatus,motionActivity"
+
+    private static let iso8601: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+
+    static func csvRow(for sample: RawLocationSample) -> String {
+        let row: [String] = [
+            sample.id.uuidString,
+            "\(sample.latitude)",
+            "\(sample.longitude)",
+            iso8601.string(from: sample.timestamp),
+            "\(sample.horizontalAccuracy)",
+            "\(sample.speed)",
+            sample.altitude.map { "\($0)" } ?? "",
+            sample.verticalAccuracy.map { "\($0)" } ?? "",
+            sample.course.map { "\($0)" } ?? "",
+            sample.filterStatus,
+            sample.motionActivity ?? ""
+        ]
+        return row.joined(separator: ",")
+    }
+
+    /// Fetches samples in batches so a month of high-frequency fixes is never
+    /// materialized in one array, yielding between batches to keep the main
+    /// actor responsive while the export builds.
+    @MainActor
+    static func exportCSV(from context: ModelContext, batchSize: Int = 5000) async -> Data {
+        var lines = [csvHeader]
+        var offset = 0
+        while true {
+            var descriptor = FetchDescriptor<RawLocationSample>(sortBy: [SortDescriptor(\.timestamp)])
+            descriptor.fetchLimit = batchSize
+            descriptor.fetchOffset = offset
+            let batch = (try? context.fetch(descriptor)) ?? []
+            guard !batch.isEmpty else { break }
+            lines.append(contentsOf: batch.map(csvRow(for:)))
+            offset += batch.count
+            if batch.count < batchSize { break }
+            await Task.yield()
+        }
+        return Data(lines.joined(separator: "\n").utf8)
+    }
+}

--- a/PlaceNotes/Services/LocationManager.swift
+++ b/PlaceNotes/Services/LocationManager.swift
@@ -93,6 +93,12 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
     /// Distance (meters) the user must move before we consider them "left".
     private let dwellRadiusMeters: Double = 80
 
+    /// Minimum interval between orphan-open-visit sweeps. With a 5 m distance
+    /// filter, running the SwiftData fetch on every fix would query several
+    /// times a minute while moving for no benefit.
+    private let staleVisitCheckInterval: TimeInterval = 60
+    private var lastStaleVisitCheck: Date = .distantPast
+
     /// Distance (meters) from a place at which an open visit is force-closed
     /// even if the dwell-finalize path missed the departure. Wider than the
     /// dwell radius so transient GPS jumps don't prematurely end a stay.
@@ -333,7 +339,10 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
         userLocation = location.coordinate
         lastFix = location
 
-        closeStaleOpenVisits(currentLocation: location, context: modelContext)
+        if Date().timeIntervalSince(lastStaleVisitCheck) >= staleVisitCheckInterval {
+            lastStaleVisitCheck = Date()
+            closeStaleOpenVisits(currentLocation: location, context: modelContext)
+        }
 
         // Step 1: Filter noisy / stale samples
         let isAccurate = location.horizontalAccuracy >= 0 && location.horizontalAccuracy <= maxAcceptableAccuracy
@@ -480,16 +489,18 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
         ) ?? Date()
 
         Task { @MainActor in
-            let descriptor = FetchDescriptor<RawLocationSample>(
-                predicate: #Predicate { $0.timestamp < cutoff }
-            )
-            let stale = (try? context.fetch(descriptor)) ?? []
-            for sample in stale {
-                context.delete(sample)
-            }
-            if !stale.isEmpty {
-                try? context.save()
-                logger.info("Deleted \(stale.count) raw samples older than \(self.settings.rawLocationRetentionDays) days")
+            let predicate = #Predicate<RawLocationSample> { $0.timestamp < cutoff }
+            let staleCount = (try? context.fetchCount(FetchDescriptor(predicate: predicate))) ?? 0
+            guard staleCount > 0 else { return }
+            do {
+                // Batch delete — materializing potentially hundreds of
+                // thousands of stale rows just to delete them one by one
+                // would stall the main actor at launch.
+                try context.delete(model: RawLocationSample.self, where: predicate)
+                try context.save()
+                logger.info("Deleted \(staleCount) raw samples older than \(self.settings.rawLocationRetentionDays) days")
+            } catch {
+                logger.error("Failed to delete stale raw samples: \(error.localizedDescription)")
             }
         }
     }

--- a/PlaceNotes/Services/PlaceCategorizer.swift
+++ b/PlaceNotes/Services/PlaceCategorizer.swift
@@ -35,56 +35,40 @@ final class PlaceCategorizer {
 
     /// Looks up the nearest POI category for a coordinate.
     /// Returns a human-readable category string, or nil if no POI is found nearby.
+    ///
+    /// One `.includingAll` request, matched locally against `categoryMap` —
+    /// MKLocalSearch is OS-rate-limited, so issuing one request per known
+    /// category (25 sequential network calls) is not an option here.
     static func categorize(latitude: Double, longitude: Double) async -> (label: String, icon: String)? {
         let coordinate = CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
-        let region = MKCoordinateRegion(
-            center: coordinate,
-            latitudinalMeters: 100,
-            longitudinalMeters: 100
-        )
+        let targetLocation = CLLocation(latitude: latitude, longitude: longitude)
+        let radius: CLLocationDistance = 100
 
-        for entry in categoryMap {
-            let request = MKLocalPointsOfInterestRequest(center: coordinate, radius: 100)
-            request.pointOfInterestFilter = MKPointOfInterestFilter(including: [entry.category])
-
-            let search = MKLocalSearch(request: request)
-            do {
-                let response = try await search.start()
-                if let item = response.mapItems.first {
-                    let itemLocation = item.placemark.location ?? CLLocation(latitude: latitude, longitude: longitude)
-                    let targetLocation = CLLocation(latitude: latitude, longitude: longitude)
-                    if itemLocation.distance(from: targetLocation) < 100 {
-                        return (entry.label, entry.icon)
-                    }
-                }
-            } catch {
-                continue
-            }
-        }
-
-        // Fallback: try a general search to get the POI category from the map item
-        let request = MKLocalSearch.Request()
-        request.naturalLanguageQuery = ""
-        request.region = region
-
+        let request = MKLocalPointsOfInterestRequest(center: coordinate, radius: radius)
+        request.pointOfInterestFilter = .includingAll
         let search = MKLocalSearch(request: request)
-        do {
-            let response = try await search.start()
-            if let item = response.mapItems.first,
-               let poiCategory = item.pointOfInterestCategory {
-                if let match = categoryMap.first(where: { $0.category == poiCategory }) {
-                    return (match.label, match.icon)
-                }
-                // Return the raw category name cleaned up
-                let raw = poiCategory.rawValue
-                    .replacingOccurrences(of: "MKPOICategory", with: "")
-                return (raw, "mappin")
-            }
-        } catch {
-            // ignore
-        }
 
-        return nil
+        guard let response = try? await search.start() else { return nil }
+
+        let nearest = response.mapItems
+            .compactMap { item -> (category: MKPointOfInterestCategory, distance: CLLocationDistance)? in
+                guard let category = item.pointOfInterestCategory,
+                      let location = item.placemark.location else { return nil }
+                let distance = location.distance(from: targetLocation)
+                guard distance < radius else { return nil }
+                return (category, distance)
+            }
+            .min { $0.distance < $1.distance }
+
+        guard let nearest else { return nil }
+
+        if let match = categoryMap.first(where: { $0.category == nearest.category }) {
+            return (match.label, match.icon)
+        }
+        // Return the raw category name cleaned up
+        let raw = nearest.category.rawValue
+            .replacingOccurrences(of: "MKPOICategory", with: "")
+        return (raw, "mappin")
     }
 
     /// Returns the SF Symbol for a category label.

--- a/PlaceNotes/Services/PlaceResolver.swift
+++ b/PlaceNotes/Services/PlaceResolver.swift
@@ -23,8 +23,8 @@ private struct GeoDetails {
 
 enum PlaceResolver {
 
-    /// ~50 meters in degrees latitude/longitude. Used for nearest-existing-place matching.
-    private static let nearbyThresholdDegrees: Double = 0.0005
+    /// Radius for nearest-existing-place matching.
+    private static let nearbyThresholdMeters: Double = 50
 
     /// Network calls to CLGeocoder / MKLocalSearch are rate-limited by Apple and have no
     /// client-side timeout. On flaky networks they can stall for minutes — bound them.
@@ -48,17 +48,28 @@ enum PlaceResolver {
     /// Returns the nearest Place within ~50m of the given coordinate, if any exists.
     @MainActor
     static func nearestExisting(latitude: Double, longitude: Double, in context: ModelContext) -> Place? {
-        let minLat = latitude - nearbyThresholdDegrees
-        let maxLat = latitude + nearbyThresholdDegrees
-        let minLon = longitude - nearbyThresholdDegrees
-        let maxLon = longitude + nearbyThresholdDegrees
+        // Bounding box pre-filter for the fetch; the longitude span must widen
+        // with latitude or the effective radius shrinks toward the poles.
+        let latDelta = nearbyThresholdMeters / 111_320.0
+        let lonDelta = latDelta / max(cos(latitude * .pi / 180), 0.01)
+        let minLat = latitude - latDelta
+        let maxLat = latitude + latDelta
+        let minLon = longitude - lonDelta
+        let maxLon = longitude + lonDelta
         let descriptor = FetchDescriptor<Place>(
             predicate: #Predicate<Place> {
                 $0.latitude >= minLat && $0.latitude <= maxLat &&
                 $0.longitude >= minLon && $0.longitude <= maxLon
             }
         )
-        return (try? context.fetch(descriptor))?.first
+        guard let candidates = try? context.fetch(descriptor), !candidates.isEmpty else { return nil }
+
+        let target = CLLocation(latitude: latitude, longitude: longitude)
+        return candidates
+            .map { (place: $0, distance: CLLocation(latitude: $0.latitude, longitude: $0.longitude).distance(from: target)) }
+            .filter { $0.distance <= nearbyThresholdMeters }
+            .min { $0.distance < $1.distance }?
+            .place
     }
 
     /// Full resolve: nearest-existing → geocode + POI search → create + insert new Place.
@@ -73,7 +84,7 @@ enum PlaceResolver {
             logger.debug("Found existing place: \(existing.name)")
             return (existing, [])
         }
-        logger.info("No existing place within \(nearbyThresholdDegrees) degrees — resolving (addressOnly: \(addressOnly))")
+        logger.info("No existing place within \(Int(nearbyThresholdMeters))m — resolving (addressOnly: \(addressOnly))")
         let resolved = await resolve(latitude: latitude, longitude: longitude, addressOnly: addressOnly)
         let place = Place(
             name: resolved.name,

--- a/PlaceNotes/Services/ReportGenerator.swift
+++ b/PlaceNotes/Services/ReportGenerator.swift
@@ -2,10 +2,14 @@ import Foundation
 import SwiftData
 
 struct PlaceRanking: Identifiable {
-    let id = UUID()
     let place: Place
     let qualifiedStays: Int
     let totalMinutes: Int
+
+    /// Keyed to the place so SwiftUI identity survives ranking recomputation —
+    /// a fresh UUID per ranking would tear down and rebuild every map
+    /// annotation each time the list is regenerated.
+    var id: UUID { place.id }
 
     /// All recorded visits, regardless of duration or recency — the count the
     /// place detail card, header, and charts display.

--- a/PlaceNotes/Services/TripDetector.swift
+++ b/PlaceNotes/Services/TripDetector.swift
@@ -146,8 +146,7 @@ enum TripDetector {
         })?.place
         let title: String = topPlace?.city ?? topPlace?.name ?? "Trip"
 
-        let idSeed = "\(first.arrivalDate.timeIntervalSince1970)-\(endDate.timeIntervalSince1970)"
-        let id = UUID(uuidString: stableUUID(from: idSeed)) ?? UUID()
+        let id = stableUUID(start: first.arrivalDate, end: endDate)
 
         return Trip(
             id: id,
@@ -164,16 +163,22 @@ enum TripDetector {
         )
     }
 
-    private static func stableUUID(from seed: String) -> String {
-        let hash = abs(seed.hashValue)
-        let bytes = withUnsafeBytes(of: hash) { Data($0) } + Data(repeating: 0, count: 16)
-        let prefix = bytes.prefix(16)
-        let hex = prefix.map { String(format: "%02x", $0) }.joined()
-        let g1 = hex.prefix(8)
-        let g2 = hex.dropFirst(8).prefix(4)
-        let g3 = hex.dropFirst(12).prefix(4)
-        let g4 = hex.dropFirst(16).prefix(4)
-        let g5 = hex.dropFirst(20).prefix(12)
-        return "\(g1)-\(g2)-\(g3)-\(g4)-\(g5)"
+    /// Builds the trip ID from the start/end timestamps' bit patterns.
+    /// `String.hashValue` is seeded per-process, so it must not be used here —
+    /// the same trip would get a different ID on every launch.
+    private static func stableUUID(start: Date, end: Date) -> UUID {
+        var bytes = [UInt8]()
+        bytes.reserveCapacity(16)
+        for value in [start.timeIntervalSince1970.bitPattern, end.timeIntervalSince1970.bitPattern] {
+            for shift in stride(from: 56, through: 0, by: -8) {
+                bytes.append(UInt8(truncatingIfNeeded: value >> UInt64(shift)))
+            }
+        }
+        return UUID(uuid: (
+            bytes[0], bytes[1], bytes[2], bytes[3],
+            bytes[4], bytes[5], bytes[6], bytes[7],
+            bytes[8], bytes[9], bytes[10], bytes[11],
+            bytes[12], bytes[13], bytes[14], bytes[15]
+        ))
     }
 }

--- a/PlaceNotes/ViewModels/TrackingViewModel.swift
+++ b/PlaceNotes/ViewModels/TrackingViewModel.swift
@@ -21,7 +21,11 @@ final class TrackingViewModel: ObservableObject {
             }
             .store(in: &cancellables)
 
-        startDisplayTimer()
+        updateStatusText(trackingManager.state)
+    }
+
+    deinit {
+        displayTimer?.invalidate()
     }
 
     func enable() {
@@ -42,31 +46,45 @@ final class TrackingViewModel: ObservableObject {
 
     // MARK: - Private
 
-    private func startDisplayTimer() {
-        displayTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { [weak self] _ in
-            Task { @MainActor in
-                self?.updateStatusText(self?.trackingManager.state ?? .default)
+    /// The 1 Hz countdown only needs to run while paused; running it
+    /// permanently would publish view invalidations every second for the
+    /// app's whole lifetime.
+    private func setDisplayTimerRunning(_ running: Bool) {
+        if running {
+            guard displayTimer == nil else { return }
+            displayTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { [weak self] _ in
+                Task { @MainActor in
+                    self?.updateStatusText(self?.trackingManager.state ?? .default)
+                }
             }
+        } else {
+            displayTimer?.invalidate()
+            displayTimer = nil
         }
     }
 
     private func updateStatusText(_ state: TrackingState) {
+        let newStatus: String
+        let newRemaining: String?
         switch state.status {
         case .active:
-            statusText = String(localized: "Tracking Active")
-            pauseTimeRemainingText = nil
+            newStatus = String(localized: "Tracking Active")
+            newRemaining = nil
         case .disabled:
-            statusText = String(localized: "Tracking Disabled")
-            pauseTimeRemainingText = nil
+            newStatus = String(localized: "Tracking Disabled")
+            newRemaining = nil
         case .paused:
             if let remaining = state.pauseTimeRemaining, remaining > 0 {
-                statusText = String(localized: "Tracking Paused")
-                pauseTimeRemainingText = formatTimeRemaining(remaining)
+                newStatus = String(localized: "Tracking Paused")
+                newRemaining = formatTimeRemaining(remaining)
             } else {
-                statusText = String(localized: "Tracking Active")
-                pauseTimeRemainingText = nil
+                newStatus = String(localized: "Tracking Active")
+                newRemaining = nil
             }
         }
+        if statusText != newStatus { statusText = newStatus }
+        if pauseTimeRemainingText != newRemaining { pauseTimeRemainingText = newRemaining }
+        setDisplayTimerRunning(newRemaining != nil)
     }
 
     private func formatTimeRemaining(_ interval: TimeInterval) -> String {

--- a/PlaceNotes/Views/AlternativePlacePicker.swift
+++ b/PlaceNotes/Views/AlternativePlacePicker.swift
@@ -12,6 +12,9 @@ struct AlternativePlacePicker: View {
     @State private var showConfirmation = false
 
     var body: some View {
+        // Decoded once per render — `visit.alternativePlaces` JSON-decodes on
+        // every access.
+        let alternatives = visit.alternativePlaces
         NavigationStack {
             List {
                 if let place = visit.place {
@@ -42,9 +45,9 @@ struct AlternativePlacePicker: View {
                     }
                 }
 
-                if !visit.alternativePlaces.isEmpty {
+                if !alternatives.isEmpty {
                     Section("Did you mean?") {
-                        ForEach(visit.alternativePlaces) { candidate in
+                        ForEach(alternatives) { candidate in
                             Button {
                                 pendingCandidate = candidate
                                 showConfirmation = true
@@ -80,7 +83,7 @@ struct AlternativePlacePicker: View {
                         markWrong()
                     } label: {
                         Label(
-                            visit.alternativePlaces.isEmpty ? "This is wrong" : "None of these — still wrong",
+                            alternatives.isEmpty ? "This is wrong" : "None of these — still wrong",
                             systemImage: "hand.thumbsdown"
                         )
                     }
@@ -138,8 +141,18 @@ struct AlternativePlacePicker: View {
         )
 
         let threshold = 0.0001
-        let descriptor = FetchDescriptor<Place>()
-        let allPlaces = (try? modelContext.fetch(descriptor)) ?? []
+        let candidateName = candidate.name
+        let minLat = candidate.latitude - threshold
+        let maxLat = candidate.latitude + threshold
+        let minLon = candidate.longitude - threshold
+        let maxLon = candidate.longitude + threshold
+        let descriptor = FetchDescriptor<Place>(
+            predicate: #Predicate<Place> {
+                $0.name == candidateName &&
+                $0.latitude >= minLat && $0.latitude <= maxLat &&
+                $0.longitude >= minLon && $0.longitude <= maxLon
+            }
+        )
 
         let previousPlace = visit.place
 
@@ -149,11 +162,7 @@ struct AlternativePlacePicker: View {
         }
 
         let newPlace: Place
-        if let existing = allPlaces.first(where: {
-            $0.name == candidate.name &&
-            abs($0.latitude - candidate.latitude) < threshold &&
-            abs($0.longitude - candidate.longitude) < threshold
-        }) {
+        if let existing = (try? modelContext.fetch(descriptor))?.first {
             newPlace = existing
         } else {
             newPlace = Place(

--- a/PlaceNotes/Views/DayTrajectoryView.swift
+++ b/PlaceNotes/Views/DayTrajectoryView.swift
@@ -37,7 +37,10 @@ struct DayTrajectoryView: View {
                 TrajectoryPolyline(segments: segments, colorMode: .time)
 
                 if showAllSamples {
-                    ForEach(segments.flatMap(\.points), id: \.timestamp) { point in
+                    // Indexed identity — timestamps can collide (CoreLocation
+                    // delivers duplicate-timestamp fixes), which would give
+                    // ForEach duplicate IDs.
+                    ForEach(Array(segments.flatMap(\.points).enumerated()), id: \.offset) { _, point in
                         Annotation(
                             "",
                             coordinate: point.coordinate

--- a/PlaceNotes/Views/HomePhotoViewer.swift
+++ b/PlaceNotes/Views/HomePhotoViewer.swift
@@ -46,8 +46,8 @@ struct HomePhotoViewer: View {
                 .padding(.bottom, 32)
             }
         }
-        .onAppear {
-            image = PhotoStorage.loadImage(filename: item.filename)
+        .task(id: item.filename) {
+            image = await PhotoStorage.loadImageDetached(filename: item.filename)
         }
     }
 }

--- a/PlaceNotes/Views/HomeView.swift
+++ b/PlaceNotes/Views/HomeView.swift
@@ -10,10 +10,17 @@ struct HomeView: View {
     @Query(sort: \JournalEntry.date, order: .reverse)
     private var allEntries: [JournalEntry]
 
-    @State private var pullOffset: CGFloat = 0
-    @State private var isCommitting = false
-    @State private var hapticArmed = true
-    @State private var peakProgress: Double = 0
+    /// Pull-to-capture gesture tracking. Nothing here is rendered, so it lives
+    /// in a reference holder — keeping the per-frame scroll offset in
+    /// value-type @State would re-evaluate the entire body (and rebuild the
+    /// photo feed) on every scroll frame.
+    private final class PullTracker {
+        var offset: CGFloat = 0
+        var peakProgress: Double = 0
+        var hapticArmed = true
+        var isCommitting = false
+    }
+    @State private var pull = PullTracker()
 
     @State private var selectedPhotoItem: HomePhotoItem?
     @State private var pendingPlaceID: PersistentIdentifier?
@@ -26,9 +33,6 @@ struct HomeView: View {
     private static let scrollSpaceName = "home-scroll"
 
     private var items: [HomePhotoItem] { HomePhotoFeed.flatten(allEntries) }
-    private var progress: Double {
-        PullProgress.progress(distance: pullOffset, threshold: Self.pullThreshold)
-    }
     private var isTrackingActive: Bool {
         trackingViewModel.trackingManager.state.status == .active
     }
@@ -37,9 +41,6 @@ struct HomeView: View {
         NavigationStack {
             content
             .navigationBarHidden(true)
-            .onChange(of: progress) { oldValue, newValue in
-                handleProgressChange(old: oldValue, new: newValue)
-            }
             .sheet(isPresented: $showTrackingSheet) { trackingSheet }
             .alert("Camera access needed", isPresented: $showCameraPermissionAlert) {
                 Button("OK", role: .cancel) {}
@@ -118,7 +119,7 @@ struct HomeView: View {
             }
             .coordinateSpace(name: Self.scrollSpaceName)
             .onPreferenceChange(HomeScrollOffsetKey.self) { newOffset in
-                pullOffset = max(0, newOffset)
+                handleScrollOffset(max(0, newOffset))
             }
         }
     }
@@ -158,35 +159,43 @@ struct HomeView: View {
         }
     }
 
+    private func handleScrollOffset(_ offset: CGFloat) {
+        let old = PullProgress.progress(distance: pull.offset, threshold: Self.pullThreshold)
+        let new = PullProgress.progress(distance: offset, threshold: Self.pullThreshold)
+        pull.offset = offset
+        guard new != old else { return }
+        handleProgressChange(old: old, new: new)
+    }
+
     private func handleProgressChange(old: Double, new: Double) {
-        if PullProgress.didCrossThreshold(old: old, new: new), hapticArmed {
+        if PullProgress.didCrossThreshold(old: old, new: new), pull.hapticArmed {
             UIImpactFeedbackGenerator(style: .medium).impactOccurred()
-            hapticArmed = false
+            pull.hapticArmed = false
         } else if new < 1.0 {
-            hapticArmed = true
+            pull.hapticArmed = true
         }
 
-        peakProgress = max(peakProgress, new)
+        pull.peakProgress = max(pull.peakProgress, new)
 
-        if !isCommitting,
-           peakProgress >= 1.0,
+        if !pull.isCommitting,
+           pull.peakProgress >= 1.0,
            new < old,
            new < 1.0 {
-            let peakAtRelease = peakProgress
-            peakProgress = 0
+            let peakAtRelease = pull.peakProgress
+            pull.peakProgress = 0
             if peakAtRelease >= 1.0 {
                 commit()
             }
         }
 
         if new == 0 {
-            peakProgress = 0
+            pull.peakProgress = 0
         }
     }
 
     private func commit() {
-        guard !isCommitting else { return }
-        isCommitting = true
+        guard !pull.isCommitting else { return }
+        pull.isCommitting = true
         if isTrackingActive {
             Task {
                 let granted = await CameraPickerView.requestCameraPermission()
@@ -196,11 +205,11 @@ struct HomeView: View {
                     } else {
                         showCameraPermissionAlert = true
                     }
-                    isCommitting = false
+                    pull.isCommitting = false
                 }
             }
         } else {
-            isCommitting = false
+            pull.isCommitting = false
             showTrackingOffAlert = true
         }
     }

--- a/PlaceNotes/Views/LogbookView.swift
+++ b/PlaceNotes/Views/LogbookView.swift
@@ -15,7 +15,18 @@ struct LogbookView: View {
     @State private var refreshID = UUID()
     @State private var trajectoryDay: Date?
 
+    /// Re-runs the refresh when a visit is added anywhere — keying on
+    /// `places.count` alone misses new visits at already-known places.
+    private var visitRefreshKey: Int {
+        places.reduce(0) { $0 + $1.visits.count }
+    }
+
+    private var feedbackVerdictsByVisit: [UUID: PredictionVerdict] {
+        Dictionary(feedbackRecords.map { ($0.visitID, $0.verdict) }, uniquingKeysWith: { first, _ in first })
+    }
+
     var body: some View {
+        let verdicts = feedbackVerdictsByVisit
         NavigationStack {
             Group {
                 if viewModel.sections.isEmpty {
@@ -27,7 +38,7 @@ struct LogbookView: View {
                 } else {
                     List {
                         ForEach(viewModel.sections) { section in
-                            sectionView(section)
+                            sectionView(section, verdicts: verdicts)
                         }
                     }
                     .listStyle(.insetGrouped)
@@ -39,7 +50,7 @@ struct LogbookView: View {
                 }
             }
             .navigationTitle("Logbook")
-            .task(id: places.count) {
+            .task(id: visitRefreshKey) {
                 viewModel.refresh(places: places, settings: settings)
             }
             .onChange(of: settings.tripMinDistanceKm) { _, _ in
@@ -84,7 +95,7 @@ struct LogbookView: View {
     }
 
     @ViewBuilder
-    private func sectionView(_ section: LogbookSection) -> some View {
+    private func sectionView(_ section: LogbookSection, verdicts: [UUID: PredictionVerdict]) -> some View {
         switch section {
         case .trip(let trip):
             Section {
@@ -99,7 +110,7 @@ struct LogbookView: View {
         case .thisWeek(let visits):
             Section {
                 ForEach(Array(visits.enumerated()), id: \.element.id) { idx, visit in
-                    visitRow(visit: visit, all: visits, index: idx)
+                    visitRow(visit: visit, all: visits, index: idx, verdicts: verdicts)
                 }
             } header: {
                 Label("This week", systemImage: "calendar")
@@ -110,7 +121,7 @@ struct LogbookView: View {
         case .earlier(let year, let month, let visits):
             Section {
                 ForEach(Array(visits.enumerated()), id: \.element.id) { idx, visit in
-                    visitRow(visit: visit, all: visits, index: idx)
+                    visitRow(visit: visit, all: visits, index: idx, verdicts: verdicts)
                 }
             } header: {
                 Text(earlierHeader(year: year, month: month))
@@ -122,7 +133,7 @@ struct LogbookView: View {
     }
 
     @ViewBuilder
-    private func visitRow(visit: Visit, all: [Visit], index: Int) -> some View {
+    private func visitRow(visit: Visit, all: [Visit], index: Int, verdicts: [UUID: PredictionVerdict]) -> some View {
         if let place = visit.place {
             let nextSameDay: Date? = {
                 let nextIdx = index - 1
@@ -137,7 +148,7 @@ struct LogbookView: View {
                     visit: visit,
                     place: place,
                     nextSameDayArrival: nextSameDay,
-                    feedbackVerdict: feedbackRecords.first { $0.visitID == visit.id }?.verdict,
+                    feedbackVerdict: verdicts[visit.id],
                     onMarkAccurate: {
                         PredictionFeedbackRecorder.record(.accurate, for: visit, in: modelContext)
                         viewModel.refresh(places: places, settings: settings)

--- a/PlaceNotes/Views/PhotoGridView.swift
+++ b/PlaceNotes/Views/PhotoGridView.swift
@@ -107,8 +107,8 @@ private struct FullScreenPhotoView: View {
             }
             .padding()
         }
-        .onAppear {
-            image = PhotoStorage.loadImage(filename: filename)
+        .task(id: filename) {
+            image = await PhotoStorage.loadImageDetached(filename: filename)
         }
     }
 }
@@ -134,8 +134,11 @@ struct PhotoThumbnailView: View {
                 }
             }
             .clipped()
-            .onAppear {
-                image = PhotoStorage.loadImage(filename: filename)
+            .task(id: filename) {
+                // Downsampled + cached decode off the main actor — a full-res
+                // synchronous `loadImage` per grid cell stalls scrolling and
+                // holds entire JPEGs in memory for thumbnail-sized views.
+                image = await PhotoStorage.loadThumbnailDetached(filename: filename, maxDimension: 600)
             }
     }
 }
@@ -172,6 +175,13 @@ enum PhotoStorage {
         let url = photosDirectory.appendingPathComponent(filename)
         guard let data = try? Data(contentsOf: url) else { return nil }
         return UIImage(data: data)
+    }
+
+    /// Async wrapper that runs the full-size decode off the main actor.
+    static func loadImageDetached(filename: String) async -> UIImage? {
+        await Task.detached(priority: .userInitiated) {
+            loadImage(filename: filename)
+        }.value
     }
 
     /// Decodes a downsampled UIImage from the saved JPEG without holding the

--- a/PlaceNotes/Views/SearchPlacesView.swift
+++ b/PlaceNotes/Views/SearchPlacesView.swift
@@ -26,9 +26,18 @@ struct SearchPlacesView: View {
 
     private var filteredPlaces: [Place] {
         let minStay = settings.minStayMinutes
+        // Qualified stats are computed once per place up front — calling
+        // qualifiedStayCount/totalQualifiedMinutes inside the sort comparator
+        // re-filters the whole visit array on every comparison.
         return places
-            .filter { $0.qualifiedStayCount(minMinutes: minStay) > 0 }
-            .filter { place in
+            .compactMap { place -> (place: Place, stays: Int, minutes: Int)? in
+                let qualified = place.qualifiedStays(minMinutes: minStay)
+                guard !qualified.isEmpty else { return nil }
+                let minutes = qualified.reduce(0) { $0 + $1.durationMinutes }
+                return (place, qualified.count, minutes)
+            }
+            .filter { entry in
+                let place = entry.place
                 if searchText.isEmpty { return true }
                 let query = searchText.lowercased()
                 return place.displayName.lowercased().contains(query)
@@ -38,19 +47,20 @@ struct SearchPlacesView: View {
                     || (place.city?.lowercased().contains(query) ?? false)
                     || (place.state?.lowercased().contains(query) ?? false)
             }
-            .filter { place in
-                if let cat = selectedCategory { return place.category == cat }
+            .filter { entry in
+                if let cat = selectedCategory { return entry.place.category == cat }
                 return true
             }
-            .filter { place in
-                if let city = selectedCity { return place.city == city }
+            .filter { entry in
+                if let city = selectedCity { return entry.place.city == city }
                 return true
             }
-            .filter { place in
-                if let state = selectedState { return place.state == state }
+            .filter { entry in
+                if let state = selectedState { return entry.place.state == state }
                 return true
             }
-            .sorted { ($0.qualifiedStayCount(minMinutes: minStay), $0.totalQualifiedMinutes(minMinutes: minStay)) > ($1.qualifiedStayCount(minMinutes: minStay), $1.totalQualifiedMinutes(minMinutes: minStay)) }
+            .sorted { ($0.stays, $0.minutes) > ($1.stays, $1.minutes) }
+            .map(\.place)
     }
 
     private var hasActiveFilters: Bool {

--- a/PlaceNotes/Views/SettingsView.swift
+++ b/PlaceNotes/Views/SettingsView.swift
@@ -18,39 +18,9 @@ struct CSVFile: FileDocument {
     }
 }
 
-private enum LocationExporter {
-    private static let iso8601: ISO8601DateFormatter = {
-        let f = ISO8601DateFormatter()
-        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        return f
-    }()
-
-    static func exportCSV(from samples: [RawLocationSample]) -> Data {
-        var lines = ["id,latitude,longitude,timestamp,horizontalAccuracy,speed,altitude,verticalAccuracy,course,filterStatus,motionActivity"]
-        for s in samples {
-            let row: [String] = [
-                s.id.uuidString,
-                "\(s.latitude)",
-                "\(s.longitude)",
-                iso8601.string(from: s.timestamp),
-                "\(s.horizontalAccuracy)",
-                "\(s.speed)",
-                s.altitude.map { "\($0)" } ?? "",
-                s.verticalAccuracy.map { "\($0)" } ?? "",
-                s.course.map { "\($0)" } ?? "",
-                s.filterStatus,
-                s.motionActivity ?? ""
-            ]
-            lines.append(row.joined(separator: ","))
-        }
-        return lines.joined(separator: "\n").data(using: .utf8) ?? Data()
-    }
-}
-
 struct SettingsView: View {
     @Environment(\.modelContext) private var modelContext
     @Query private var places: [Place]
-    @Query private var visits: [Visit]
     @Query private var customCategories: [CustomCategory]
     @Query private var feedbackRecords: [PredictionFeedback]
     @EnvironmentObject var settings: AppSettings
@@ -61,6 +31,9 @@ struct SettingsView: View {
     @State private var showClearDataConfirmation = false
     @State private var storageSizeText = "Calculating…"
     @State private var rawSampleCount: Int = 0
+    /// Counted via `fetchCount` instead of an `@Query` — Settings only needs
+    /// the number, not every Visit row materialized in memory.
+    @State private var visitCount: Int = 0
     @State private var showRetentionInput = false
     @State private var retentionInputText = ""
     @State private var exportData: Data = Data()
@@ -148,12 +121,11 @@ struct SettingsView: View {
 
                 Section {
                     LabeledContent("Places", value: "\(places.count)")
-                    LabeledContent("Visits", value: "\(visits.count)")
+                    LabeledContent("Visits", value: "\(visitCount)")
                     LabeledContent("Total Tracked Time", value: totalTrackedTimeText)
                     LabeledContent("Storage Used", value: storageSizeText)
-                        .onAppear { refreshStorageSize() }
-                        .onChange(of: places.count) { refreshStorageSize() }
-                        .onChange(of: visits.count) { refreshStorageSize() }
+                        .onAppear { refreshDataCounts() }
+                        .onChange(of: places.count) { refreshDataCounts() }
                 } header: {
                     Text("Data Storage")
                 } footer: {
@@ -215,7 +187,7 @@ struct SettingsView: View {
                             Spacer()
                         }
                     }
-                    .disabled(places.isEmpty && visits.isEmpty && feedbackRecords.isEmpty)
+                    .disabled(places.isEmpty && visitCount == 0 && feedbackRecords.isEmpty && rawSampleCount == 0)
                 }
 
                 Section("About") {
@@ -227,17 +199,17 @@ struct SettingsView: View {
                     Button("Seed Sample Trajectory") {
                         DebugSeed.seedSampleTrajectories(in: modelContext)
                         refreshRawSampleCount()
-                        refreshStorageSize()
+                        refreshDataCounts()
                     }
                     Button("Seed Open Visit") {
                         DebugSeed.seedOpenVisitNow(in: modelContext)
                         refreshRawSampleCount()
-                        refreshStorageSize()
+                        refreshDataCounts()
                     }
                     Button(role: .destructive) {
                         DebugSeed.clearAllData(in: modelContext)
                         refreshRawSampleCount()
-                        refreshStorageSize()
+                        refreshDataCounts()
                     } label: {
                         Text("Clear All Data (Debug)")
                     }
@@ -255,7 +227,7 @@ struct SettingsView: View {
                 }
                 Button("Cancel", role: .cancel) {}
             } message: {
-                Text("This will permanently delete all \(places.count) places and \(visits.count) visits. This cannot be undone.")
+                Text("This will permanently delete all \(places.count) places, \(visitCount) visits, and every raw location sample. This cannot be undone.")
             }
             .alert("Set Minimum Stay", isPresented: $showMinStayInput) {
                 TextField("Minutes", text: $minStayInputText)
@@ -320,11 +292,16 @@ struct SettingsView: View {
         rawSampleCount = (try? modelContext.fetchCount(FetchDescriptor<RawLocationSample>())) ?? 0
     }
 
+    private func refreshDataCounts() {
+        visitCount = (try? modelContext.fetchCount(FetchDescriptor<Visit>())) ?? 0
+        refreshStorageSize()
+    }
+
     private func exportRawSamples() {
-        let descriptor = FetchDescriptor<RawLocationSample>(sortBy: [SortDescriptor(\.timestamp)])
-        let samples = (try? modelContext.fetch(descriptor)) ?? []
-        exportData = LocationExporter.exportCSV(from: samples)
-        showExporter = true
+        Task {
+            exportData = await LocationExporter.exportCSV(from: modelContext)
+            showExporter = true
+        }
     }
 
     private func applyRetentionDays() {
@@ -347,7 +324,8 @@ struct SettingsView: View {
     }
 
     private func clearAllData() {
-        for visit in visits {
+        let allVisits = (try? modelContext.fetch(FetchDescriptor<Visit>())) ?? []
+        for visit in allVisits {
             modelContext.delete(visit)
         }
         for place in places {
@@ -359,8 +337,13 @@ struct SettingsView: View {
         for record in feedbackRecords {
             modelContext.delete(record)
         }
+        // Raw GPS samples are the most privacy-sensitive data in the store;
+        // "Delete All Data" must not leave the movement trace behind.
+        try? modelContext.delete(model: RawLocationSample.self)
         try? modelContext.save()
         PhotoStorage.deleteAll()
+        refreshRawSampleCount()
+        refreshDataCounts()
     }
 
     private func refreshStorageSize() {
@@ -381,10 +364,8 @@ struct SettingsView: View {
             return total + bytes
         }
 
-        let visitBytes = visits.reduce(0) { total, _ in
-            // UUID + arrivalDate + departureDate + foreign key
-            total + 16 + 8 + 8 + 16
-        }
+        // UUID + arrivalDate + departureDate + foreign key per Visit row
+        let visitBytes = visitCount * (16 + 8 + 8 + 16)
 
         let rawBytes = placeBytes + visitBytes
         // Account for SQLite overhead (indexes, page headers, alignment)


### PR DESCRIPTION
## Summary

This PR refactors several data access patterns and async operations to reduce memory overhead, improve responsiveness, and fix correctness issues. Key improvements include batched CSV export, efficient visit counting, optimized place lookups, and better state management in ViewModels.

## Key Changes

### Data Access & Memory Efficiency
- **LocationExporter**: Moved from inline SettingsView code to dedicated `Services/LocationExporter.swift`. Now fetches raw samples in batches (5000 at a time) with `Task.yield()` between batches to keep the main actor responsive during large exports, preventing memory spikes from materializing entire months of high-frequency GPS fixes at once.
- **Visit counting**: Replaced `@Query private var visits` with `@State private var visitCount` fetched via `fetchCount()`. Settings only needs the count, not every Visit row materialized in memory.
- **Stale sample deletion**: Changed from fetching all stale samples into an array then deleting one-by-one to batch delete via `context.delete(model:where:)`, preventing main-actor stalls at launch when cleaning up months of old data.
- **Place lookups**: Added proper distance filtering in `PlaceResolver.nearestExisting()` using CLLocation distance calculations instead of naive degree-based bounding boxes. Accounts for latitude-dependent longitude scaling to maintain consistent ~50m radius across all coordinates.

### POI Categorization
- **PlaceCategorizer**: Simplified from 25+ sequential network calls (one per known category) to a single `.includingAll` request. Results are matched locally against `categoryMap`, respecting the OS rate-limit on MKLocalSearch.

### View State Management
- **HomeView pull-to-capture**: Moved scroll offset tracking into a reference-type `PullTracker` class. Keeping per-frame scroll offsets in value-type `@State` was re-evaluating the entire body and rebuilding the photo feed on every scroll frame.
- **TrackingViewModel**: Display timer now only runs while paused (countdown visible), not permanently for the app's lifetime. Prevents unnecessary view invalidations every second. Added proper cleanup in `deinit`.
- **PlaceNotesApp**: Built `TrackingViewModel` and `QuickCaptureViewModel` once in `init()` instead of in `body`. Settings changes were handing out fresh instances and resetting in-flight capture state.

### Query Optimization
- **SearchPlacesView**: Pre-compute qualified stay counts and minutes once per place instead of calling `qualifiedStayCount()` and `totalQualifiedMinutes()` inside sort comparators, which re-filtered the entire visit array on every comparison.
- **LogbookView**: Cache `feedbackVerdictsByVisit` dictionary and `visitRefreshKey` (sum of all place visit counts) to avoid repeated lookups and ensure refresh triggers on new visits at existing places.
- **AlternativePlacePicker**: Decode `visit.alternativePlaces` JSON once per render instead of on every access.

### Trip ID Generation
- **TripDetector**: Fixed `stableUUID()` to use bit patterns of timestamps instead of `String.hashValue`, which is seeded per-process. Same trip now gets consistent ID across launches.

### Photo Loading
- **PhotoGridView**: Async image loading now runs off the main actor. Thumbnails use downsampled decode (`loadThumbnailDetached`) to avoid stalling scroll with full-res JPEGs in memory.

### Data Integrity
- **SettingsView**: "Clear All Data" now also deletes `RawLocationSample` records (the most privacy-sensitive data), preventing the movement trace from being left behind.
- **LocationManager**: Added 60-second minimum interval between orphan-open-visit sweeps. With a 5m distance filter, running the SwiftData fetch on every fix queries several times per minute while moving for no benefit.

## Implementation Details

- All async operations use `async/await` with proper `@MainActor` annotations.
- Batch operations use `Task.yield()` to keep the main actor responsive during long-running exports.
- Distance calculations now use `CLLocation.distance(from:)` for geographic accuracy.
- State management prefers reference types (`final class`) for mutable tracking state to avoid per

https://claude.ai/code/session_01Md1WthMQJkGrELY4BMkDdq