### PR TITLE
fix(capture): always-available Home FAB + clearer DI capture button

### DIFF
--- a/PlaceCaptureWidget/CaptureLiveActivity.swift
+++ b/PlaceCaptureWidget/CaptureLiveActivity.swift
@@ -40,8 +40,13 @@ struct CaptureLiveActivity: Widget {
             } compactLeading: {
                 Text("📸")
             } compactTrailing: {
-                Text("Capture")
-                    .font(.caption2.weight(.semibold))
+                Label("Capture", systemImage: "camera.fill")
+                    .labelStyle(.iconOnly)
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(.green)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 3)
+                    .background(.green.opacity(0.2), in: Capsule())
             } minimal: {
                 Text("📸")
             }

--- a/PlaceNotes/Views/HomeView.swift
+++ b/PlaceNotes/Views/HomeView.swift
@@ -121,6 +121,34 @@ struct HomeView: View {
                 pullOffset = max(0, newOffset)
             }
         }
+        .overlay(alignment: .bottomTrailing) { captureButton }
+    }
+
+    /// Always-visible fallback so a photo can be captured even when the Dynamic
+    /// Island / Live Activity capture affordance isn't present (tracking paused,
+    /// island collapsed, etc.). Mirrors the pull-to-capture gesture's behavior.
+    @ViewBuilder
+    private var captureButton: some View {
+        Button(action: requestCapture) {
+            Image(systemName: "camera.fill")
+                .font(.title2.weight(.semibold))
+                .foregroundStyle(.white)
+                .frame(width: 56, height: 56)
+                .background(.green.gradient, in: Circle())
+                .shadow(radius: 4, y: 2)
+        }
+        .buttonStyle(.plain)
+        .padding(.trailing, 20)
+        .padding(.bottom, 16)
+        .accessibilityLabel("Capture photo")
+    }
+
+    private func requestCapture() {
+        if isTrackingActive {
+            attemptCapture()
+        } else {
+            showTrackingOffAlert = true
+        }
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Problem
The Dynamic Island capture affordance is easy to miss. Compact and minimal DI presentations showed only plain text/emoji, so users didn't realize the island taps through to capture; the expanded capture button needs a long-press to reach. Result: no obvious, always-available way to take a photo.

## Changes
**DI capture button (`PlaceCaptureWidget/CaptureLiveActivity.swift`)**
- `compactTrailing` now renders a tinted `camera.fill` pill so the whole-island tap reads as a capture button. Deep link (`placelore://capture` → `beginCapture()`) unchanged. Expanded `.bottom` `Link` unchanged.

**Home fallback FAB (`PlaceNotes/Views/HomeView.swift`)**
- Always-visible green `camera.fill` floating button, bottom-trailing, above the tab bar — the guaranteed "user can always take a photo" path, independent of the Dynamic Island / tracking state.
- New `requestCapture()`: tracking active → `attemptCapture()` (camera-permission → `beginCapture()`); tracking off → existing "Tracking is off" alert. Reuses existing state/alerts. Pull-to-capture gesture untouched.

## Testing
- `xcodebuild` builds app + widget extension cleanly.
- Simulator: FAB renders correctly (green circle, white camera glyph, clears tab bar) — see screenshot evidence in PR discussion.
- ⚠️ Interactive tap and Dynamic Island compact/minimal rendering were **not** driven at runtime: the sim has no camera and this environment blocks synthetic input. The FAB tap handler is trivial wiring to already-shipping paths. Recommend a quick device/tap-capable check before release.

## Notes
- New accessibility string `"Capture photo"` is used as a literal; not added to `Localizable.xcstrings` in this PR (pre-existing catalog churn kept out). zh-Hans entry can follow in the usual i18n pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)