### PR TITLE
chore(feedback): gate prediction-feedback feature behind a runtime flag (off)

### DIFF
--- a/PlaceNotes/Models/AppSettings.swift
+++ b/PlaceNotes/Models/AppSettings.swift
@@ -37,6 +37,13 @@ final class AppSettings: ObservableObject {
         didSet { UserDefaults.standard.set(appearanceMode.rawValue, forKey: "appearanceMode") }
     }
 
+    /// Master switch for the place-prediction feedback feature (in-app verdict
+    /// UI, local recording, and batched Azure uploads). Disabled for now; flip
+    /// the default below — or the DEBUG toggle in Settings — to re-enable.
+    @Published var predictionFeedbackEnabled: Bool {
+        didSet { UserDefaults.standard.set(predictionFeedbackEnabled, forKey: "predictionFeedbackEnabled") }
+    }
+
     @Published var milestoneVisitCounts: [Int] {
         didSet { UserDefaults.standard.set(milestoneVisitCounts, forKey: "milestoneVisitCounts") }
     }
@@ -111,6 +118,12 @@ final class AppSettings: ObservableObject {
             self.appearanceMode = mode
         } else {
             self.appearanceMode = .system
+        }
+
+        if UserDefaults.standard.object(forKey: "predictionFeedbackEnabled") != nil {
+            self.predictionFeedbackEnabled = UserDefaults.standard.bool(forKey: "predictionFeedbackEnabled")
+        } else {
+            self.predictionFeedbackEnabled = false
         }
 
         if let data = UserDefaults.standard.data(forKey: "trackingState"),

--- a/PlaceNotes/PlaceNotesApp.swift
+++ b/PlaceNotes/PlaceNotesApp.swift
@@ -117,13 +117,16 @@ struct PlaceNotesApp: App {
                 .onAppear {
                     NotificationManager.shared.requestAuthorization()
                     Self.removeOldSharedStore()
-                    feedbackUploadScheduler.start()
+                    if settings.predictionFeedbackEnabled {
+                        feedbackUploadScheduler.start()
+                    }
 
                     #if DEBUG
                     MockLocationProvider.seedIfNeeded(context: modelContainer.mainContext)
                     #endif
                 }
                 .onReceive(NotificationCenter.default.publisher(for: UIApplication.didEnterBackgroundNotification)) { _ in
+                    guard settings.predictionFeedbackEnabled else { return }
                     Task { @MainActor in
                         await feedbackUploadScheduler.uploadPending()
                     }

--- a/PlaceNotes/Services/PredictionFeedbackRecorder.swift
+++ b/PlaceNotes/Services/PredictionFeedbackRecorder.swift
@@ -19,6 +19,11 @@ enum PredictionFeedbackRecorder {
         correctionSource: String? = nil,
         in context: ModelContext
     ) {
+        // Single chokepoint: when the feedback feature is off, no record is
+        // written regardless of which caller invoked this (Logbook verdicts,
+        // the picker, or a place reassignment via AlternativePlacePicker).
+        guard AppSettings.shared.predictionFeedbackEnabled else { return }
+
         let visitID = visit.id
         let descriptor = FetchDescriptor<PredictionFeedback>(
             predicate: #Predicate { $0.visitID == visitID }

--- a/PlaceNotes/Views/AlternativePlacePicker.swift
+++ b/PlaceNotes/Views/AlternativePlacePicker.swift
@@ -5,6 +5,7 @@ import CoreLocation
 struct AlternativePlacePicker: View {
     @Environment(\.modelContext) private var modelContext
     @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject private var settings: AppSettings
     let visit: Visit
     var onPlaceChanged: (() -> Void)?
 
@@ -36,11 +37,13 @@ struct AlternativePlacePicker: View {
                             Spacer()
                         }
 
-                        Button {
-                            markAccurate()
-                        } label: {
-                            Label("This is correct", systemImage: "hand.thumbsup")
-                                .foregroundStyle(.green)
+                        if settings.predictionFeedbackEnabled {
+                            Button {
+                                markAccurate()
+                            } label: {
+                                Label("This is correct", systemImage: "hand.thumbsup")
+                                    .foregroundStyle(.green)
+                            }
                         }
                     }
                 }
@@ -78,20 +81,22 @@ struct AlternativePlacePicker: View {
                     }
                 }
 
-                Section {
-                    Button(role: .destructive) {
-                        markWrong()
-                    } label: {
-                        Label(
-                            alternatives.isEmpty ? "This is wrong" : "None of these — still wrong",
-                            systemImage: "hand.thumbsdown"
-                        )
+                if settings.predictionFeedbackEnabled {
+                    Section {
+                        Button(role: .destructive) {
+                            markWrong()
+                        } label: {
+                            Label(
+                                alternatives.isEmpty ? "This is wrong" : "None of these — still wrong",
+                                systemImage: "hand.thumbsdown"
+                            )
+                        }
+                    } footer: {
+                        Text("Your feedback is logged to measure how well place prediction is working.")
                     }
-                } footer: {
-                    Text("Your feedback is logged to measure how well place prediction is working.")
                 }
             }
-            .navigationTitle("How did we do?")
+            .navigationTitle(settings.predictionFeedbackEnabled ? "How did we do?" : "Change Place")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {

--- a/PlaceNotes/Views/LogbookView.swift
+++ b/PlaceNotes/Views/LogbookView.swift
@@ -149,14 +149,14 @@ struct LogbookView: View {
                     place: place,
                     nextSameDayArrival: nextSameDay,
                     feedbackVerdict: verdicts[visit.id],
-                    onMarkAccurate: {
+                    onMarkAccurate: settings.predictionFeedbackEnabled ? {
                         PredictionFeedbackRecorder.record(.accurate, for: visit, in: modelContext)
                         viewModel.refresh(places: places, settings: settings)
                         refreshID = UUID()
-                    },
-                    onOpenFeedback: {
+                    } : nil,
+                    onOpenFeedback: settings.predictionFeedbackEnabled ? {
                         visitForFeedback = visit
-                    }
+                    } : nil
                 )
             }
             .buttonStyle(.plain)

--- a/PlaceNotes/Views/SettingsView.swift
+++ b/PlaceNotes/Views/SettingsView.swift
@@ -129,7 +129,11 @@ struct SettingsView: View {
                 } header: {
                     Text("Data Storage")
                 } footer: {
-                    Text("Places and visits are stored on-device. Prediction feedback may be uploaded in batches to improve place matching.")
+                    if settings.predictionFeedbackEnabled {
+                        Text("Places and visits are stored on-device. Prediction feedback may be uploaded in batches to improve place matching.")
+                    } else {
+                        Text("Places and visits are stored on-device.")
+                    }
                 }
 
                 Section {
@@ -162,18 +166,20 @@ struct SettingsView: View {
                 .onAppear { refreshRawSampleCount() }
 
                 #if DEBUG
-                Section {
-                    LabeledContent("Feedback Collected", value: "\(feedbackRecords.count)")
-                    LabeledContent("Predicted Correctly", value: feedbackPrecisionText)
-                    LabeledContent("Pending Upload", value: "\(pendingFeedbackUploadCount)")
-                    Button("Export Feedback CSV") {
-                        exportFeedback()
+                if settings.predictionFeedbackEnabled {
+                    Section {
+                        LabeledContent("Feedback Collected", value: "\(feedbackRecords.count)")
+                        LabeledContent("Predicted Correctly", value: feedbackPrecisionText)
+                        LabeledContent("Pending Upload", value: "\(pendingFeedbackUploadCount)")
+                        Button("Export Feedback CSV") {
+                            exportFeedback()
+                        }
+                        .disabled(feedbackRecords.isEmpty)
+                    } header: {
+                        Text("Prediction Feedback")
+                    } footer: {
+                        Text("Your “correct / wrong” verdicts on recorded places are logged here. Uploads happen automatically in batches; CSV export is for local debugging.")
                     }
-                    .disabled(feedbackRecords.isEmpty)
-                } header: {
-                    Text("Prediction Feedback")
-                } footer: {
-                    Text("Your “correct / wrong” verdicts on recorded places are logged here. Uploads happen automatically in batches; CSV export is for local debugging.")
                 }
                 #endif
 
@@ -195,6 +201,12 @@ struct SettingsView: View {
                 }
 
                 #if DEBUG
+                Section {
+                    Toggle("Prediction Feedback Enabled", isOn: $settings.predictionFeedbackEnabled)
+                } footer: {
+                    Text("Master switch for the place-prediction feedback feature (verdict UI, local recording, and Azure uploads). Off by default while the pipeline is paused.")
+                }
+
                 Section {
                     Button("Seed Sample Trajectory") {
                         DebugSeed.seedSampleTrajectories(in: modelContext)

--- a/PlaceNotesTests/PredictionFeedbackRecorderTests.swift
+++ b/PlaceNotesTests/PredictionFeedbackRecorderTests.swift
@@ -5,6 +5,18 @@ import SwiftData
 @MainActor
 final class PredictionFeedbackRecorderTests: XCTestCase {
 
+    override func setUp() {
+        super.setUp()
+        // The recorder no-ops when the feedback feature is disabled (the
+        // shipped default); these tests exercise the enabled behavior.
+        AppSettings.shared.predictionFeedbackEnabled = true
+    }
+
+    override func tearDown() {
+        AppSettings.shared.predictionFeedbackEnabled = false
+        super.tearDown()
+    }
+
     private func makeContext() throws -> ModelContext {
         let config = ModelConfiguration(isStoredInMemoryOnly: true)
         let container = try ModelContainer(


### PR DESCRIPTION
## Why
Pause the place-prediction feedback pipeline (in-app verdict capture, local recording, and batched Azure uploads) for now, with a clean path to re-enable.

## How
New `AppSettings.predictionFeedbackEnabled` — persisted, **default `false`** — gates the whole feature:

- **Uploads** (`PlaceNotesApp`): `scheduler.start()` / background `uploadPending()` only run when enabled. No network egress to Azure while off.
- **Recording** (`PredictionFeedbackRecorder.record`): early-returns when disabled. Single chokepoint → no `PredictionFeedback` rows written from any of the 4 call sites. Place **reassignment** (`AlternativePlacePicker` / `TripDetailView`) still works — only the feedback-row write is skipped.
- **UI hidden when off:**
  - `LogbookView` — the correct/wrong verdict bar.
  - `AlternativePlacePicker` — the "How did we do?" verdict controls; the alternative-place reassignment list is **kept** (shared with `TripDetailView`); title becomes "Change Place".
  - `SettingsView` — the (DEBUG) Prediction Feedback stats/export section; Data Storage footer drops the upload claim.

## Re-enabling
- DEBUG: a Settings toggle ("Prediction Feedback Enabled") flips the flag at runtime.
- Release: change the `predictionFeedbackEnabled` default to `true`.

## Testing
- `xcodebuild` build: **succeeds** (app + widget).
- Full suite: **287 tests, 0 failures**. `PredictionFeedbackRecorderTests` enables the flag in `setUp` (it exercises the enabled behavior).
- Note: had to run `xcodegen generate` locally — the checked-in project was stale and didn't include `PredictionFeedback.swift` (pre-existing; CI regenerates).

## Not included
`Localizable.xcstrings` churn kept out of this PR. New UI strings ("Change Place", toggle label, footer) use literals; zh-Hans entries can follow in the usual i18n pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)